### PR TITLE
feature / add more nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3969,6 +3969,7 @@ dependencies = [
  "futures",
  "image",
  "mime_guess",
+ "minijinja",
  "prost",
  "prost-build",
  "prost-types",
@@ -6804,6 +6805,15 @@ checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
 dependencies = [
  "mime",
  "unicase",
+]
+
+[[package]]
+name = "minijinja"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98642a6dfca91122779a307b77cd07a4aa951fbe32232aaf5bad9febc66be754"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/packages/catalog/src/control.rs
+++ b/packages/catalog/src/control.rs
@@ -5,6 +5,7 @@ pub mod gather;
 pub mod par_execution;
 pub mod reroute;
 pub mod sequence;
+pub mod while_loop;
 
 use flow_like::flow::node::NodeLogic;
 use std::sync::Arc;
@@ -18,5 +19,6 @@ pub async fn register_functions() -> Vec<Arc<dyn NodeLogic>> {
         Arc::new(delay::DelayNode::default()),
         Arc::new(gather::GatherExecutionNode::default()),
         Arc::new(reroute::RerouteNode::default()),
+        Arc::new(while_loop::WhileLoopNode::default()),
     ]
 }

--- a/packages/catalog/src/control/while_loop.rs
+++ b/packages/catalog/src/control/while_loop.rs
@@ -1,0 +1,115 @@
+
+use flow_like::{
+    flow::{
+        execution::{LogLevel, context::ExecutionContext, internal_node::InternalNode},
+        node::{Node, NodeLogic},
+        variable::VariableType,
+    },
+    state::FlowLikeState,
+};
+use flow_like_types::{async_trait, json::json};
+
+#[derive(Default)]
+pub struct WhileLoopNode {}
+
+impl WhileLoopNode {
+    pub fn new() -> Self {
+        WhileLoopNode {}
+    }
+}
+
+#[async_trait]
+impl NodeLogic for WhileLoopNode {
+    async fn get_node(&self, _app_state: &FlowLikeState) -> Node {
+        let mut node = Node::new(
+            "while_loop",
+            "While Loop",
+            "Loop downstream execution in while loop",
+            "Control",
+        );
+        node.add_icon("/flow/icons/for-each.svg");
+
+        // inputs
+        node.add_input_pin("exec_in", "Input", "Trigger Pin", VariableType::Execution);
+        
+        node.add_input_pin(
+            "condition",
+            "Condition",
+            "Loop while this is true",
+            VariableType::Boolean,
+        )
+        .set_default_value(Some(flow_like_types::json::json!(false)));
+
+        node.add_input_pin(
+            "max_iter",
+            "Max",
+            "Maximum number of iterations",
+            VariableType::Integer,
+        )
+        .set_default_value(Some(json!(15)));
+
+        // outputs
+        node.add_output_pin(
+            "exec_out",
+            "Downstream Execution",
+            "Downstream execution propagation",
+            VariableType::Execution,
+        );
+
+        node.add_output_pin(
+            "iter",
+            "Iter",
+            "Current iteration index",
+            VariableType::Integer,
+        );
+
+        node.add_output_pin(
+            "done",
+            "Done",
+            "Executes once loop terminates",
+            VariableType::Execution,
+        );
+
+        node
+    }
+
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+
+        let exec_item = context.get_pin_by_name("exec_out").await?;
+        let iter = context.get_pin_by_name("iter").await?;
+        let done = context.get_pin_by_name("done").await?;
+        let max_iter: u64 = context.evaluate_pin("max_iter").await?;
+
+        context.activate_exec_pin_ref(&exec_item).await?;
+        for i in 0..max_iter {
+            let condition = context.evaluate_pin::<bool>("condition").await?;
+            if !condition {
+                break;
+            }
+            iter
+                .lock()
+                .await
+                .set_value(flow_like_types::json::json!(i))
+                .await;
+            let flow = exec_item.lock().await.get_connected_nodes().await;
+            for node in flow {
+                let mut sub_context = context.create_sub_context(&node).await;
+                let run = InternalNode::trigger(&mut sub_context, &mut None, true).await;
+                sub_context.end_trace();
+                context.push_sub_context(sub_context);
+
+                if run.is_err() {
+                    let error = run.err().unwrap();
+                    context.log_message(
+                        &format!("Error: {:?} in iteration {}", error, i),
+                        LogLevel::Error,
+                    );
+                }
+            }
+        }
+
+        context.deactivate_exec_pin_ref(&exec_item).await?;
+        context.activate_exec_pin_ref(&done).await?;
+        Ok(())
+    }
+}

--- a/packages/catalog/src/storage.rs
+++ b/packages/catalog/src/storage.rs
@@ -21,6 +21,7 @@ pub async fn register_functions() -> Vec<Arc<dyn NodeLogic>> {
         Arc::new(db::vector::filter::FilterLocalDatabaseNode::default()),
         Arc::new(db::vector::delete::DeleteLocalDatabaseNode::default()),
         Arc::new(db::vector::count::CountLocalDatabaseNode::default()),
+        Arc::new(db::vector::schema::GetSchemaLocalDatabaseNode::default()),
     ];
 
     nodes.extend(path::register_functions().await);

--- a/packages/catalog/src/storage/db/vector.rs
+++ b/packages/catalog/src/storage/db/vector.rs
@@ -26,6 +26,7 @@ pub mod optimize;
 pub mod purge;
 pub mod upsert;
 pub mod vector_search;
+pub mod schema;
 
 #[derive(Default, Serialize, Deserialize, JsonSchema, Clone)]
 pub struct NodeDBConnection {

--- a/packages/catalog/src/storage/db/vector/schema.rs
+++ b/packages/catalog/src/storage/db/vector/schema.rs
@@ -1,0 +1,95 @@
+
+use flow_like::{
+    flow::{
+        execution::context::ExecutionContext,
+        node::{Node, NodeLogic},
+        pin::PinOptions,
+        variable::VariableType,
+    },
+    state::FlowLikeState,
+};
+use flow_like_storage::databases::vector::VectorStore;
+use flow_like_types::{async_trait, json::json};
+
+use super::NodeDBConnection;
+
+/// # Get Database Schema
+/// Retrieves schema from local database as struct
+#[derive(Default)]
+pub struct GetSchemaLocalDatabaseNode {}
+
+impl GetSchemaLocalDatabaseNode {
+    pub fn new() -> Self {
+        GetSchemaLocalDatabaseNode {}
+    }
+}
+
+#[async_trait]
+impl NodeLogic for GetSchemaLocalDatabaseNode {
+    async fn get_node(&self, _app_state: &FlowLikeState) -> Node {
+        let mut node = Node::new(
+            "schema_local_db",
+            "Get Schema",
+            "Get Local Database Schema",
+            "Database/Local/Meta",
+        );
+        node.add_icon("/flow/icons/database.svg");
+
+        // inputs
+        node.add_input_pin(
+            "exec_in", 
+            "Input", 
+            "", 
+            VariableType::Execution
+        );
+        
+        node.add_input_pin(
+            "database",
+            "Database",
+            "Database Connection Reference",
+            VariableType::Struct,
+        )
+        .set_schema::<NodeDBConnection>()
+        .set_options(
+            PinOptions::new()
+            .set_enforce_schema(true)
+            .build()
+        );
+
+        // outputs
+        node.add_output_pin(
+            "exec_out",
+            "Done",
+            "Done Fetching Local Database Schema",
+            VariableType::Execution,
+        );
+
+        node.add_output_pin(
+            "schema", 
+            "Schema", 
+            "Local Database Schema", 
+            VariableType::Struct
+        );
+        node
+    }
+
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        // get inputs
+        context.deactivate_exec_pin("exec_out").await?;
+        let database: NodeDBConnection = context.evaluate_pin("database").await?;
+        let database = database
+            .load(context, &database.cache_key)
+            .await?
+            .db
+            .clone();
+        let database = database.read().await;
+        
+        // get schema
+        let schema = database.schema().await?;
+        
+        // set outputs
+        context.set_pin_value("schema", json!(schema)).await?;
+        context.activate_exec_pin("exec_out").await?;
+        Ok(())
+    }
+}

--- a/packages/catalog/src/utils/string.rs
+++ b/packages/catalog/src/utils/string.rs
@@ -16,6 +16,7 @@ pub mod to_uppercase;
 pub mod trim;
 pub mod unequal;
 pub mod utf_8_lossy;
+pub mod template;
 
 pub async fn register_functions() -> Vec<Arc<dyn NodeLogic>> {
     let mut items: Vec<Arc<dyn NodeLogic>> = vec![
@@ -33,6 +34,7 @@ pub async fn register_functions() -> Vec<Arc<dyn NodeLogic>> {
         Arc::new(ends_with::StringEndsWithNode::default()),
         Arc::new(utf_8_lossy::ParseUtf8LossyNode::default()),
         Arc::new(contains::StringContainsNode::default()),
+        Arc::new(template::TemplateStringNode::default()),
     ];
 
     items.append(&mut similarity::register_functions().await);

--- a/packages/catalog/src/utils/string/template.rs
+++ b/packages/catalog/src/utils/string/template.rs
@@ -1,0 +1,139 @@
+
+/// # Render Jinja Templates
+
+use flow_like::{
+    flow::{
+        board::Board,
+        execution::{LogLevel, context::ExecutionContext},
+        node::{Node, NodeLogic},
+        pin::PinType,
+        variable::VariableType,
+    },
+    state::FlowLikeState,
+};
+use flow_like_types::{Value, async_trait, json::json, minijinja};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
+
+
+#[derive(Default)]
+pub struct TemplateStringNode {}
+
+impl TemplateStringNode {
+    pub fn new() -> Self {
+        TemplateStringNode {}
+    }
+}
+
+
+#[async_trait]
+impl NodeLogic for TemplateStringNode {
+    async fn get_node(&self, _app_state: &FlowLikeState) -> Node {
+        let mut node = Node::new(
+            "render_template",
+            "Render Template",
+            "Template Engine based on Jinja Templates",
+            "Utils/String",
+        );
+        node.add_icon("/flow/icons/string.svg");
+
+        // inputs
+        node.add_input_pin(
+            "template",
+            "Template",
+            "Jinja Template String",
+            VariableType::String,
+        );
+
+        // outputs
+        node.add_output_pin(
+            "rendered",
+            "Rendered",
+            "Rendered String",
+            VariableType::String,
+        );
+
+        return node;
+    }
+
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+
+        // load inputs & templates
+        let template_string: String = context.evaluate_pin("template").await?;
+        let mut jinja_env = minijinja::Environment::new();
+        
+        // collect placeholders & values
+        jinja_env.add_template("template", &template_string).unwrap();
+        let template = jinja_env.get_template("template").unwrap();
+        let placeholders = template.undeclared_variables(false);
+        context.log_message(&format!("extracted placholders: {:?}", placeholders), LogLevel::Debug);
+        
+        let mut template_context = HashMap::new();
+        for placeholder in placeholders {
+            let value: flow_like_types::Value = context.evaluate_pin(&placeholder).await?;
+            template_context.insert(placeholder, value);
+        }
+
+        // render template
+        let rendered = template.render(template_context).unwrap();
+
+        // set outputs
+        context
+            .set_pin_value("rendered", json!(rendered))
+            .await?;
+        Ok(())
+    }
+
+    async fn on_update(&self, node: &mut Node, board: Arc<Board>) {
+        let pins: Vec<_> = node
+            .pins
+            .values()
+            .filter(|p| p.name != "template" && p.pin_type == PinType::Input)
+            .collect();
+
+        let template_string: String = node
+            .get_pin_by_name("template")
+            .and_then(|pin| pin.default_value.clone())
+            .and_then(|bytes| flow_like_types::json::from_slice::<Value>(&bytes).ok())
+            .and_then(|json| json.as_str().map(ToOwned::to_owned))
+            .unwrap_or_default();
+
+        let mut current_placeholders = pins
+            .iter()
+            .map(|p| (p.name.clone(), *p))
+            .collect::<HashMap<_, _>>();
+
+        let mut jinja_env = minijinja::Environment::new();
+        jinja_env.add_template("template", &template_string).unwrap();
+        let template = jinja_env.get_template("template").unwrap();
+        let template_placeholders = template.undeclared_variables(false);
+        let mut all_placeholders = HashSet::new();
+        let mut missing_placeholders = HashSet::new();
+
+        for placeholder in template_placeholders {
+            all_placeholders.insert(placeholder.clone());
+            if current_placeholders.remove(&placeholder).is_none() {
+                missing_placeholders.insert(placeholder.clone());
+            }
+        }
+
+        let ids_to_remove = current_placeholders
+            .values()
+            .map(|p| p.id.clone())
+            .collect::<Vec<_>>();
+        ids_to_remove.iter().for_each(|id| {
+            node.pins.remove(id);
+        });
+
+        for placeholder in missing_placeholders {
+            node.add_input_pin(&placeholder, &placeholder, "", VariableType::Generic);
+        }
+
+        all_placeholders.iter().for_each(|placeholder| {
+            let _ = node.match_type(placeholder, board.clone(), None, None);
+        })
+
+    }
+}

--- a/packages/catalog/src/utils/string/template.rs
+++ b/packages/catalog/src/utils/string/template.rs
@@ -1,6 +1,4 @@
 
-/// # Render Jinja Templates
-
 use flow_like::{
     flow::{
         board::Board,
@@ -19,6 +17,7 @@ use std::{
 
 
 #[derive(Default)]
+#[doc = "Render jinja templates based on a template string and dynamic placeholder inputs."]
 pub struct TemplateStringNode {}
 
 impl TemplateStringNode {

--- a/packages/storage/src/databases/vector.rs
+++ b/packages/storage/src/databases/vector.rs
@@ -146,4 +146,7 @@ pub trait VectorStore: Send + Sync {
     /// * `Ok(usize)` - The total count of items in the vector store.
     /// * `Err(anyhow::Error)` - If the count operation fails.
     async fn count(&self, filter: Option<String>) -> Result<usize>;
+
+    async fn schema(&self) -> Result<(arrow_schema::Schema)>;
+
 }

--- a/packages/storage/src/databases/vector.rs
+++ b/packages/storage/src/databases/vector.rs
@@ -147,6 +147,6 @@ pub trait VectorStore: Send + Sync {
     /// * `Err(anyhow::Error)` - If the count operation fails.
     async fn count(&self, filter: Option<String>) -> Result<usize>;
 
-    async fn schema(&self) -> Result<(arrow_schema::Schema)>;
+    async fn schema(&self) -> Result<arrow_schema::Schema>;
 
 }

--- a/packages/storage/src/databases/vector/lancedb.rs
+++ b/packages/storage/src/databases/vector/lancedb.rs
@@ -1,5 +1,3 @@
-use arrow::ipc::convert::try_schema_from_flatbuffer_bytes;
-use arrow::json::reader::infer_json_schema;
 use arrow_array::RecordBatch;
 use flow_like_types::Cacheable;
 use flow_like_types::async_trait;
@@ -14,7 +12,6 @@ use lancedb::{
     query::{ExecutableQuery, QueryBase},
     table::{CompactionOptions, Duration, OptimizeOptions},
 };
-use serde_arrow::schema;
 use std::{any::Any, path::PathBuf, sync::Arc};
 
 use crate::arrow_utils::record_batch_to_value;

--- a/packages/types/Cargo.toml
+++ b/packages/types/Cargo.toml
@@ -22,6 +22,7 @@ image = "0.25.6"
 base64 = "0.22.1"
 mime_guess = "2.0.5"
 reqwest-eventsource = "0.6.0"
+minijinja = "2.9.0"
 
 [build-dependencies]
 prost-build = "0.13.5"

--- a/packages/types/src/lib.rs
+++ b/packages/types/src/lib.rs
@@ -59,3 +59,4 @@ pub use rand;
 pub mod intercom;
 pub mod utils;
 pub use image;
+pub use minijinja;


### PR DESCRIPTION
## Render Template Node 
add node to render jinja templates -> useful for prompt templates
- [x] based on [minijinja](https://github.com/mitsuhiko/minijinja) -> no addtional crates needed
- [x] dynamic input pins based on template vars
- [x] works with `Structs` and `Arrays` and nested types

Future improvements:
- handle larger set of expressions / conditions
- consider error handling (e.g. for LLMs generating templates, template generation at runtime)

## (While) Loop Node
implemented as for loop with max range and break condition
- [x] can be used as while loop with condition
- [x] can be used as for loop with range

## Get Schema Node
retrieve lance table schema as struct for local dbs
adaptions made to LocalVectorDB implementations -> review reference usage / borrowing / arcs / cache usage
