### PR TITLE
Bug/117 bug template selection

### DIFF
--- a/packages/api/src/middleware/jwt.rs
+++ b/packages/api/src/middleware/jwt.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use crate::{
     entity::{membership, pat, prelude::*, role, sea_orm_active_enums, technical_user, user},
     error::{ApiError, AuthorizationError},
-    permission::{global_permission::GlobalPermission, role_permission::RolePermissions},
+    permission::{global_permission::GlobalPermission, role_permission::{has_role_permission, RolePermissions}},
 };
 use axum::{
     body::Body,
@@ -61,9 +61,7 @@ pub struct AppPermissionResponse {
 
 impl AppPermissionResponse {
     pub fn has_permission(&self, permission: RolePermissions) -> bool {
-        self.permissions.contains(permission)
-            || self.permissions.contains(RolePermissions::Admin)
-            || self.permissions.contains(RolePermissions::Owner)
+        has_role_permission(&self.permissions, permission)
     }
 
     pub fn sub(&self) -> Result<String> {

--- a/packages/api/src/permission/role_permission.rs
+++ b/packages/api/src/permission/role_permission.rs
@@ -28,4 +28,11 @@ bitflags! {
         const ReadCourses       =   0b00100000_00000000_00000000;
         const WriteCourses      =   0b01000000_00000000_00000000;
     }
+
+}
+
+pub fn has_role_permission(permissions: &RolePermissions, permission: RolePermissions) -> bool {
+    permissions.contains(permission)
+        || permissions.contains(RolePermissions::Admin)
+        || permissions.contains(RolePermissions::Owner)
 }

--- a/packages/api/src/routes/app/internal/get_apps.rs
+++ b/packages/api/src/routes/app/internal/get_apps.rs
@@ -21,7 +21,7 @@ pub async fn get_apps(
 ) -> Result<Json<Vec<(App, Option<Metadata>)>>, ApiError> {
     let language = query.language.clone().unwrap_or_else(|| "en".to_string());
 
-    let limit = query.limit.unwrap_or(100).max(100);
+    let limit = query.limit.unwrap_or(100).min(100);
 
     let sub = user.sub()?;
 
@@ -35,7 +35,7 @@ pub async fn get_apps(
                 .or(meta::Column::Lang.eq("en")),
         )
         .filter(membership::Column::UserId.eq(sub))
-        .limit(Some(limit.max(100)))
+        .limit(Some(limit.min(100)))
         .offset(query.offset)
         .all(&state.db)
         .await?;

--- a/packages/api/src/routes/user/templates.rs
+++ b/packages/api/src/routes/user/templates.rs
@@ -2,7 +2,7 @@ use crate::{
     entity::{membership, meta, role, template},
     error::ApiError,
     middleware::jwt::AppUser,
-    permission::role_permission::RolePermissions,
+    permission::role_permission::{has_role_permission, RolePermissions},
     routes::LanguageParams,
     state::AppState,
 };
@@ -10,6 +10,7 @@ use axum::{
     Extension, Json,
     extract::{Query, State},
 };
+use bitflags::Flags;
 use flow_like::bit::Metadata;
 use sea_orm::{
     ColumnTrait, DatabaseTransaction, EntityTrait, JoinType, QueryFilter, QueryOrder, QuerySelect,
@@ -28,36 +29,32 @@ pub async fn get_templates(
     let txn = state.db.begin().await?;
     let app_ids = get_user_app_ids_with_template_access(&txn, user_id, &query).await?;
     let templates = get_templates_with_metadata(&txn, &app_ids, language).await?;
+    txn.commit().await?;
 
     Ok(Json(templates))
 }
-
 async fn get_user_app_ids_with_template_access(
     txn: &DatabaseTransaction,
     user_id: String,
     query: &LanguageParams,
 ) -> Result<Vec<String>, ApiError> {
-    let limit = query.limit.unwrap_or(100).max(100);
+    let limit = query.limit.unwrap_or(100).min(100);
 
-    let roles = role::Entity::find()
-        .order_by_desc(membership::Column::UpdatedAt)
-        .join(JoinType::InnerJoin, role::Relation::Membership.def())
+    let app_ids = membership::Entity::find()
+        .select_only()
+        .columns([role::Column::AppId, role::Column::Permissions])
+        .join(JoinType::InnerJoin, membership::Relation::Role.def())
         .filter(membership::Column::UserId.eq(user_id))
-        .filter(role::Column::AppId.is_not_null())
+        .order_by_desc(membership::Column::UpdatedAt)
         .limit(Some(limit))
         .offset(query.offset)
+        .into_tuple::<(String, i64)>()
         .all(txn)
-        .await?;
-
-    let app_ids = roles
+        .await?
         .into_iter()
-        .filter_map(|role| {
-            let permission = RolePermissions::from_bits(role.permissions)?;
-            if permission.contains(RolePermissions::ReadTemplates) {
-                role.app_id
-            } else {
-                None
-            }
+        .filter_map(|(app_id, permissions)| {
+            let permission = RolePermissions::from_bits(permissions)?;
+            has_role_permission(&permission, RolePermissions::ReadTemplates).then_some(app_id)
         })
         .collect();
 
@@ -104,4 +101,5 @@ fn find_best_metadata<'a>(
         .iter()
         .find(|meta| meta.lang == language)
         .or_else(|| metadata.iter().find(|meta| meta.lang == "en"))
+        .or_else(|| metadata.first())
 }


### PR DESCRIPTION
This pull request introduces several improvements to the `TemplateState` logic in the desktop app and refactors permission handling in the API to enhance maintainability and functionality. Key changes include removing unused code in the `TemplateState` class, centralizing permission checks with a new utility function, and optimizing database queries for template access.

### Desktop App Changes:
* **Code Simplification in `TemplateState`:**
  - Removed unused `injectDataFunction` logic and associated background task handling, simplifying the `getTemplates` method (`apps/desktop/components/tauri-provider/template-state.ts`: [[1]](diffhunk://#diff-7507990a410efef31332060ff307df04dddfab23afc011794cfe5083b3594af9L88-L89) [[2]](diffhunk://#diff-7507990a410efef31332060ff307df04dddfab23afc011794cfe5083b3594af9L129-L138).
  - Adjusted the `fetcher` call to clean up redundant null assertion (`apps/desktop/components/tauri-provider/template-state.ts`: [apps/desktop/components/tauri-provider/template-state.tsL102-R100](diffhunk://#diff-7507990a410efef31332060ff307df04dddfab23afc011794cfe5083b3594af9L102-R100)).

### API Changes:
* **Permission Handling Refactor:**
  - Introduced a new utility function `has_role_permission` to centralize permission checks, replacing inline logic across the codebase (`packages/api/src/permission/role_permission.rs`: [[1]](diffhunk://#diff-6411070d85c5167e560f12a456e822f0b69df77d34dc470d78d38e150876e3eaR31-R37) `packages/api/src/middleware/jwt.rs`: [[2]](diffhunk://#diff-8fddfafc57e26e542835d9527cdcb8434c433937d79e389ffd5c764aa5b163e9L64-R64).
  - Updated imports to include `has_role_permission`, ensuring consistent usage (`packages/api/src/middleware/jwt.rs`: [[1]](diffhunk://#diff-8fddfafc57e26e542835d9527cdcb8434c433937d79e389ffd5c764aa5b163e9L6-R6) `packages/api/src/routes/user/templates.rs`: [[2]](diffhunk://#diff-0c4cd3b00b5abbd2b480aa4dd5d3685204e7eadcac9a8cb536c6b09b69e9bb64L5-R13).

* **Database Query Optimization:**
  - Improved the query for retrieving user app IDs with template access by reducing redundant filtering and leveraging tuple extraction for efficiency (`packages/api/src/routes/user/templates.rs`: [packages/api/src/routes/user/templates.rsR32-R57](diffhunk://#diff-0c4cd3b00b5abbd2b480aa4dd5d3685204e7eadcac9a8cb536c6b09b69e9bb64R32-R57)).
  - Adjusted the `limit` parameter handling to use `min` instead of `max` for clarity and correctness (`packages/api/src/routes/user/templates.rs`: [packages/api/src/routes/user/templates.rsR32-R57](diffhunk://#diff-0c4cd3b00b5abbd2b480aa4dd5d3685204e7eadcac9a8cb536c6b09b69e9bb64R32-R57)).

* **Metadata Fallback Logic:**
  - Added an additional fallback to use the first metadata entry if no language match is found (`packages/api/src/routes/user/templates.rs`: [packages/api/src/routes/user/templates.rsR104](diffhunk://#diff-0c4cd3b00b5abbd2b480aa4dd5d3685204e7eadcac9a8cb536c6b09b69e9bb64R104)).… logic