### PR TITLE
feat: Add Apple Sign In entitlement to Entitlements.plist

### DIFF
--- a/apps/desktop/src-tauri/Entitlements.plist
+++ b/apps/desktop/src-tauri/Entitlements.plist
@@ -5,6 +5,12 @@
   <!-- App Sandbox -->
   <!-- <key>com.apple.security.app-sandbox</key><true/> -->
 
+  <!-- Apple Login -->
+  <key>com.apple.developer.applesignin</key>
+  <array>
+    <string>Default</string>
+  </array>
+
   <!-- Network: client + server (open/listen on ports) -->
   <key>com.apple.security.network.client</key><true/>
   <key>com.apple.security.network.server</key><true/>


### PR DESCRIPTION
This pull request adds support for Apple Login to the app's entitlements configuration. The main change is the inclusion of the necessary entitlement key for Apple Sign In.

Entitlements configuration update:

* Added the `com.apple.developer.applesignin` key with the value `Default` to enable Apple Login support in `Entitlements.plist`.