### PR TITLE
refactor: Remove Apple Sign In entitlement from Entitlements.plist

### DIFF
--- a/apps/desktop/src-tauri/Entitlements.plist
+++ b/apps/desktop/src-tauri/Entitlements.plist
@@ -5,12 +5,6 @@
   <!-- App Sandbox -->
   <!-- <key>com.apple.security.app-sandbox</key><true/> -->
 
-  <!-- Apple Login -->
-  <key>com.apple.developer.applesignin</key>
-  <array>
-    <string>Default</string>
-  </array>
-
   <!-- Network: client + server (open/listen on ports) -->
   <key>com.apple.security.network.client</key><true/>
   <key>com.apple.security.network.server</key><true/>


### PR DESCRIPTION
This pull request makes a small change to the entitlements configuration for the desktop app. Specifically, it removes the entitlement for Apple Sign-In from the `Entitlements.plist` file. This means the app will no longer request permission for Apple Sign-In functionality.