### PR TITLE
fix: Update EmailAttachmentsNode to handle optional attachments and s…

### DIFF
--- a/packages/catalog/src/mail/imap/inbox/mail.rs
+++ b/packages/catalog/src/mail/imap/inbox/mail.rs
@@ -219,7 +219,8 @@ impl NodeLogic for EmailAttachmentsNode {
             "Array of attachments",
             VariableType::Struct,
         )
-        .set_schema::<Option<Vec<Attachment>>>();
+        .set_value_type(ValueType::Array)
+        .set_schema::<Attachment>();
 
         node
     }
@@ -227,7 +228,7 @@ impl NodeLogic for EmailAttachmentsNode {
     async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
         let email: Email = context.evaluate_pin("email").await?;
         context
-            .set_pin_value("attachments", json!(email.attachments))
+            .set_pin_value("attachments", json!(email.attachments.unwrap_or_default()))
             .await?;
         Ok(())
     }


### PR DESCRIPTION
This pull request updates the handling of email attachments in the `EmailAttachmentsNode` logic to improve type safety and robustness. The main changes focus on how the attachments are represented and processed, ensuring the code handles missing attachment data more gracefully.

Attachment handling improvements:

* Changed the schema registration for the `attachments` pin to use `ValueType::Array` and set the schema to `Attachment`, instead of an optional vector of attachments. This makes the expected data type more explicit and consistent.
* Updated the value assignment for the `attachments` pin to use `email.attachments.unwrap_or_default()`, ensuring that an empty array is used when there are no attachments, preventing potential errors from `None` values.