### PR TITLE
fix: Comment out update logic in the update function to prevent crash…

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -369,25 +369,26 @@ fn handle_deep_link(app: &AppHandle, event: OpenUrlEvent) {
 
 #[tauri::command(async)]
 async fn update(app_handle: AppHandle) -> tauri_plugin_updater::Result<()> {
-    if let Some(update) = app_handle.updater()?.check().await? {
-        let mut downloaded = 0;
+    // LEADS TO CRASHES (MAIN OVERFLOW) ON WINDOWS
+    // if let Some(update) = app_handle.updater()?.check().await? {
+    //     let mut downloaded = 0;
 
-        // alternatively we could also call update.download() and update.install() separately
-        update
-            .download_and_install(
-                |chunk_length, content_length| {
-                    downloaded += chunk_length;
-                    println!("downloaded {downloaded} from {content_length:?}");
-                },
-                || {
-                    println!("download finished");
-                },
-            )
-            .await?;
+    //     // alternatively we could also call update.download() and update.install() separately
+    //     update
+    //         .download_and_install(
+    //             |chunk_length, content_length| {
+    //                 downloaded += chunk_length;
+    //                 println!("downloaded {downloaded} from {content_length:?}");
+    //             },
+    //             || {
+    //                 println!("download finished");
+    //             },
+    //         )
+    //         .await?;
 
-        println!("update installed");
-        app_handle.restart();
-    }
+    //     println!("update installed");
+    //     app_handle.restart();
+    // }
 
     Ok(())
 }


### PR DESCRIPTION
This pull request makes a targeted change to the `update` command in `apps/desktop/src-tauri/src/lib.rs` to address stability issues on Windows. Specifically, it comments out the auto-update logic that was causing crashes due to main thread overflow.

Stability improvements:

* Commented out the section of code in the `update` command that checks for, downloads, and installs updates, as this was leading to crashes (main thread overflow) on Windows platforms. The update logic is now disabled to prevent these issues.…