### PR TITLE
fix: Add RUSTFLAGS for Windows platform to prevent stack overflow issues

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -127,7 +127,7 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           PUBLIC_SENTRY_ENDPOINT: ${{ secrets.PUBLIC_SENTRY_ENDPOINT }}
           APPLE_SIGNING_IDENTITY: ${{ env.CERT_ID }}
-          RUSTFLAGS: ${{ matrix.platform == 'windows-latest' && '-C link-args=/STACK:8388608 -C link-args=-Wl,--stack,8388608' || '' }}
+          RUSTFLAGS: ${{ matrix.platform == 'windows-latest' && '-C link-arg=/STACK:8388608' || '' }}
         with:
           tagName: alpha-v__VERSION__ # the action automatically replaces \_\_VERSION\_\_ with the app version.
           releaseName: "Flow Like - Alpha v__VERSION__"


### PR DESCRIPTION
This pull request introduces a platform-specific build configuration for Windows in the alpha release workflow. The main change is the addition of custom `RUSTFLAGS` to increase the stack size when building on Windows, which can help prevent stack overflow issues during compilation.

Build configuration update:

* [`.github/workflows/alpha-release.yml`](diffhunk://#diff-f7bb11da4daed6ccaceec672bf18a5ddd48a7afde778745ee203d8968598a73cR130): Added a conditional `RUSTFLAGS` environment variable to set increased stack size for Windows builds.