### PR TITLE
feat: Prevent event propagation on key down in FlowContextMenu input

### DIFF
--- a/packages/ui/components/flow/flow-context-menu.tsx
+++ b/packages/ui/components/flow/flow-context-menu.tsx
@@ -392,6 +392,9 @@ export function FlowContextMenu({
 								setFilter(e.target.value);
 								search(e.target.value);
 							}}
+							onKeyDown={(e) => {
+								e.stopPropagation();
+							}}
 						/>
 					</div>
 					<div className="pr-1 flex flex-grow flex-col overflow-hidden">


### PR DESCRIPTION
This pull request introduces a minor usability improvement to the `FlowContextMenu` component. The change ensures that keyboard events on the filter input do not propagate to parent components, which can help prevent unintended side effects when interacting with the filter input.

* Added an `onKeyDown` handler to the filter input in `flow-context-menu.tsx` to stop event propagation.