### PR TITLE
Sea Orm CLI Fix

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -87,7 +87,7 @@ jobs:
         run: "npm install -g bun"
 
       - name: install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.89.0
         with:
           targets: ${{ (matrix.platform == 'macos-latest' || matrix.platform == 'macos-13') && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ ahash = "0.8.12"
 base64 = "0.22.1"
 ndarray = "0.16.1"
 dirs-next = "2.0.0"
+regex = "1.11.2"
 
 [profile.dev]
 split-debuginfo = "unpacked"

--- a/apps/website/src/content/blog/2025-09-06-alpha-0-0-4.mdx
+++ b/apps/website/src/content/blog/2025-09-06-alpha-0-0-4.mdx
@@ -7,10 +7,11 @@ cover: "/images/alpha-0-0-4.jpg"
 draft: true
 ------------
 
-* you can now create profiles
-* auto updates
+* you can now create and manage profiles including which apps you want to see + different themes per profile
+* auto updates for the Desktop app
 * improved performance for huge workflows
 * improved stability for long running workflows
 * new flows are now created in "info" state, you can still enable debugging
 * fixed apple login
 * ML nodes [#257](https://github.com/TM9657/flow-like/pull/257)
+* Excel nodes [#262](https://github.com/TM9657/flow-like/issues/262)

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -4,7 +4,7 @@
 	"version": "0.0.2",
 	"type": "module",
 	"scripts": {
-		"postinstall": "cargo install sea-orm-cli@1.1.11",
+		"postinstall": "cargo install sea-orm-cli@1.1.15",
 		"db:push:sync": "bun run db:push && bun run db:sync",
 		"db:sync": "sea-orm-cli generate entity -o src/entity --max-connections 10 --with-serde both",
 		"db:push": "bunx prisma db push --schema prisma/schema",

--- a/packages/api/src/state.rs
+++ b/packages/api/src/state.rs
@@ -64,7 +64,7 @@ impl State {
         let client: Client<HttpConnector, Body> =
             hyper_util::client::legacy::Client::<(), ()>::builder(TokioExecutor::new())
                 .build(HttpConnector::new());
-        opt.max_connections(100)
+        opt.max_connections(10)
             .min_connections(1)
             .connect_timeout(Duration::from_secs(8))
             .sqlx_logging(platform_config.environment == Environment::Development);

--- a/packages/catalog/Cargo.toml
+++ b/packages/catalog/Cargo.toml
@@ -12,7 +12,7 @@ ahash.workspace = true
 base64.workspace=true
 fasteval = "0.2.4"
 strsim = "0.11.1"
-regex = "1.11.2"
+regex.workspace = true
 chrono.workspace = true
 calamine = { version = "0.30", default-features = false, features = ["dates"] }
 umya-spreadsheet = "2.3.2"

--- a/packages/types/Cargo.toml
+++ b/packages/types/Cargo.toml
@@ -29,7 +29,7 @@ rxing = { version = "0.7.1", features = ["serde", "image"] }
 ab_glyph = "0.2.29"
 tokio-util = "0.7.15"
 jsonschema = "0.33.0"
-regex = "1.11.1"
+regex.workspace = true
 
 [build-dependencies]
 prost-build = "0.13.5"


### PR DESCRIPTION
This pull request includes dependency updates, workflow adjustments, and some configuration tweaks to improve consistency and stability across the codebase. The most notable changes are updates to Rust and npm dependencies, changes to connection pool settings, and improvements to documentation and blog content.

**Dependency and Tooling Updates:**

* Updated the `sea-orm-cli` version used in the `postinstall` script of `packages/api/package.json` from `1.1.11` to `1.1.15` for improved features and bug fixes.
* Switched the Rust toolchain in the GitHub Actions workflow (`.github/workflows/alpha-release.yml`) from `stable` to a fixed version `1.89.0` to ensure build consistency.
* Updated the `regex` dependency to use workspace versioning in `packages/catalog/Cargo.toml` and `packages/types/Cargo.toml`, and added it as a direct dependency in the root `Cargo.toml` for unified version management. [[1]](diffhunk://#diff-536903dcd3f03ad4ff9e830d56912d68a33f39605ee1fdf16e359c215e7a6d7bL15-R15) [[2]](diffhunk://#diff-953c112c753ee46c9f100cbf7f95c9bef5d8f06423dd4e9b64a41f131e8e8eb3L32-R32) [[3]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R69)

**Configuration and Performance:**

* Reduced the maximum number of database connections from 100 to 10 in `packages/api/src/state.rs` to better manage resource usage and prevent potential overloads.

**Documentation and Blog:**

* Enhanced the blog post `2025-09-06-alpha-0-0-4.mdx` to clarify profile management features and specify that auto updates are for the Desktop app; also added Excel node support to the changelog.