### PR TITLE
Remove execution pins from Path and Virtual directory nodes for simpl…

### DIFF
--- a/packages/catalog/src/data/path/dirs/cache_dir.rs
+++ b/packages/catalog/src/data/path/dirs/cache_dir.rs
@@ -30,20 +30,6 @@ impl NodeLogic for PathFromCacheDirNode {
         );
         node.add_icon("/flow/icons/path.svg");
 
-        node.add_input_pin(
-            "exec_in",
-            "Input",
-            "Initiate Execution",
-            VariableType::Execution,
-        );
-
-        node.add_output_pin(
-            "exec_out",
-            "Output",
-            "Done with the Execution",
-            VariableType::Execution,
-        );
-
         node.add_output_pin("path", "Path", "Output Path", VariableType::Struct)
             .set_schema::<FlowPath>();
 
@@ -67,15 +53,12 @@ impl NodeLogic for PathFromCacheDirNode {
     }
 
     async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
-        context.deactivate_exec_pin("exec_out").await?;
-
         let node_scope: bool = context.evaluate_pin("node_scope").await?;
         let user_scope: bool = context.evaluate_pin("user_scope").await?;
 
         let path = FlowPath::from_cache_dir(context, node_scope, user_scope).await?;
         context.set_pin_value("path", json!(path)).await?;
 
-        context.activate_exec_pin("exec_out").await?;
         Ok(())
     }
 }

--- a/packages/catalog/src/data/path/dirs/storage_dir.rs
+++ b/packages/catalog/src/data/path/dirs/storage_dir.rs
@@ -30,20 +30,6 @@ impl NodeLogic for PathFromStorageDirNode {
         );
         node.add_icon("/flow/icons/path.svg");
 
-        node.add_input_pin(
-            "exec_in",
-            "Input",
-            "Initiate Execution",
-            VariableType::Execution,
-        );
-
-        node.add_output_pin(
-            "exec_out",
-            "Output",
-            "Done with the Execution",
-            VariableType::Execution,
-        );
-
         node.add_output_pin("path", "Path", "Output Path", VariableType::Struct)
             .set_schema::<FlowPath>();
 
@@ -59,14 +45,10 @@ impl NodeLogic for PathFromStorageDirNode {
     }
 
     async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
-        context.deactivate_exec_pin("exec_out").await?;
-
         let node_scope: bool = context.evaluate_pin("node_scope").await?;
 
         let path = FlowPath::from_storage_dir(context, node_scope).await?;
         context.set_pin_value("path", json!(path)).await?;
-
-        context.activate_exec_pin("exec_out").await?;
         Ok(())
     }
 }

--- a/packages/catalog/src/data/path/dirs/user_dir.rs
+++ b/packages/catalog/src/data/path/dirs/user_dir.rs
@@ -30,20 +30,6 @@ impl NodeLogic for PathFromUserDirNode {
         );
         node.add_icon("/flow/icons/path.svg");
 
-        node.add_input_pin(
-            "exec_in",
-            "Input",
-            "Initiate Execution",
-            VariableType::Execution,
-        );
-
-        node.add_output_pin(
-            "exec_out",
-            "Output",
-            "Done with the Execution",
-            VariableType::Execution,
-        );
-
         node.add_output_pin("path", "Path", "Output Path", VariableType::Struct)
             .set_schema::<FlowPath>();
 
@@ -59,14 +45,11 @@ impl NodeLogic for PathFromUserDirNode {
     }
 
     async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
-        context.deactivate_exec_pin("exec_out").await?;
-
         let node_scope: bool = context.evaluate_pin("node_scope").await?;
 
         let path = FlowPath::from_user_dir(context, node_scope).await?;
         context.set_pin_value("path", json!(path)).await?;
 
-        context.activate_exec_pin("exec_out").await?;
         Ok(())
     }
 }

--- a/packages/catalog/src/data/path/dirs/virtual_dir.rs
+++ b/packages/catalog/src/data/path/dirs/virtual_dir.rs
@@ -34,26 +34,12 @@ impl NodeLogic for VirtualDirNode {
         node.add_icon("/flow/icons/path.svg");
 
         node.add_input_pin(
-            "exec_in",
-            "Input",
-            "Initiate Execution",
-            VariableType::Execution,
-        );
-
-        node.add_input_pin(
             "name",
             "Name",
             "Virtual directory name",
             VariableType::String,
         )
         .set_default_value(Some(json!("/virtual")));
-
-        node.add_output_pin(
-            "exec_out",
-            "Output",
-            "Done with the Execution",
-            VariableType::Execution,
-        );
 
         node.add_output_pin(
             "path",
@@ -67,8 +53,6 @@ impl NodeLogic for VirtualDirNode {
     }
 
     async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
-        context.deactivate_exec_pin("exec_out").await?;
-
         let name: String = context.evaluate_pin("name").await?;
 
         let cache_path = format!("virtual_dir_{}", name);
@@ -87,8 +71,6 @@ impl NodeLogic for VirtualDirNode {
             cache_store_ref: None,
         };
         context.set_pin_value("path", json!(virtual_path)).await?;
-
-        context.activate_exec_pin("exec_out").await?;
         Ok(())
     }
 }


### PR DESCRIPTION
This pull request refactors several node implementations in the `packages/catalog/src/data/path/dirs` directory to simplify their execution model. The main change is the removal of the execution pins (`exec_in` and `exec_out`) and their associated activation/deactivation logic, making these nodes purely data-producing without explicit execution flow control.

**Refactoring of node execution model:**

* Removed `exec_in` and `exec_out` execution pins from the node definitions in `cache_dir.rs`, `storage_dir.rs`, `user_dir.rs`, and `virtual_dir.rs`, so these nodes now only expose data pins relevant to their output. [[1]](diffhunk://#diff-0d7ac8fc52e4c43b98d017b6766eb1295cfd43fb04d93060fb73e3f4672250dbL33-L46) [[2]](diffhunk://#diff-7edad35f7fbaf421186ae7a655412599170df00d736b9a5c01a6bc8dc0c815d4L33-L46) [[3]](diffhunk://#diff-b2b19f405a5be72f520774868c257031e293cdf466de6b1641c6a3a657bee821L33-L46) [[4]](diffhunk://#diff-4d60783a50ae9d67f9e0985535862fa17b373052a20dc002d6534c341d7b0d57L36-L42) [[5]](diffhunk://#diff-4d60783a50ae9d67f9e0985535862fa17b373052a20dc002d6534c341d7b0d57L51-L57)

* Eliminated calls to `activate_exec_pin` and `deactivate_exec_pin` for `exec_out` in the `run` methods of all affected nodes, streamlining their execution to just produce and set the output path value. [[1]](diffhunk://#diff-0d7ac8fc52e4c43b98d017b6766eb1295cfd43fb04d93060fb73e3f4672250dbL70-L78) [[2]](diffhunk://#diff-7edad35f7fbaf421186ae7a655412599170df00d736b9a5c01a6bc8dc0c815d4L62-L69) [[3]](diffhunk://#diff-b2b19f405a5be72f520774868c257031e293cdf466de6b1641c6a3a657bee821L62-L69) [[4]](diffhunk://#diff-4d60783a50ae9d67f9e0985535862fa17b373052a20dc002d6534c341d7b0d57L70-L71) [[5]](diffhunk://#diff-4d60783a50ae9d67f9e0985535862fa17b373052a20dc002d6534c341d7b0d57L90-L91)