### PR TITLE
feat(flow-copilot): add GetNodeDetailsTool for detailed node informat…

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -32,6 +32,35 @@ jobs:
       APPLE_ID: ${{ secrets.APPLE_ID }}
       APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
     steps:
+      - name: Free Disk Space (Ubuntu)
+        if: runner.os == 'Linux'
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
+      - name: Free Disk Space (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          sudo rm -rf /Users/runner/Library/Android/sdk || true
+          sudo rm -rf /Library/Frameworks/Mono.framework || true
+          sudo rm -rf /usr/local/share/powershell || true
+          sudo rm -rf /usr/local/.ghcup || true
+          sudo rm -rf /opt/hostedtoolcache/CodeQL || true
+          df -h
+
+      - name: Free Disk Space (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          Remove-Item -Recurse -Force "C:\Android\android-sdk" -ErrorAction SilentlyContinue
+          Remove-Item -Recurse -Force "C:\Program Files\dotnet\sdk\*" -ErrorAction SilentlyContinue
+          Remove-Item -Recurse -Force "C:\hostedtoolcache\CodeQL" -ErrorAction SilentlyContinue
+
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,35 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
     steps:
+      - name: Free Disk Space (Ubuntu)
+        if: runner.os == 'Linux'
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
+      - name: Free Disk Space (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          sudo rm -rf /Users/runner/Library/Android/sdk || true
+          sudo rm -rf /Library/Frameworks/Mono.framework || true
+          sudo rm -rf /usr/local/share/powershell || true
+          sudo rm -rf /usr/local/.ghcup || true
+          sudo rm -rf /opt/hostedtoolcache/CodeQL || true
+          df -h
+
+      - name: Free Disk Space (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          Remove-Item -Recurse -Force "C:\Android\android-sdk" -ErrorAction SilentlyContinue
+          Remove-Item -Recurse -Force "C:\Program Files\dotnet\sdk\*" -ErrorAction SilentlyContinue
+          Remove-Item -Recurse -Force "C:\hostedtoolcache\CodeQL" -ErrorAction SilentlyContinue
+
       - uses: actions/checkout@v4
 
       - name: setup node

--- a/packages/core/src/flow/copilot/context.rs
+++ b/packages/core/src/flow/copilot/context.rs
@@ -6,7 +6,7 @@ use crate::flow::pin::PinType;
 use flow_like_types::Result;
 
 /// Compact node representation for context
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NodeContext {
     pub id: String,
     #[serde(rename = "t")] // "type" abbreviated
@@ -24,7 +24,7 @@ pub struct NodeContext {
 }
 
 /// Compact pin representation
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PinContext {
     #[serde(rename = "n")] // "name" abbreviated
     pub name: String,
@@ -36,7 +36,7 @@ pub struct PinContext {
 }
 
 /// Compact edge representation
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EdgeContext {
     #[serde(rename = "f")] // "from" abbreviated
     pub from_node_id: String,
@@ -49,7 +49,7 @@ pub struct EdgeContext {
 }
 
 /// Complete graph context for the LLM
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GraphContext {
     pub nodes: Vec<NodeContext>,
     pub edges: Vec<EdgeContext>,


### PR DESCRIPTION
This pull request refactors the Copilot's "focus_node" tool into a new, more powerful "get_node_details" tool, enhancing the ability to retrieve and present detailed information about nodes in the flow graph. It also updates the workflow files to free up disk space on CI runners across all platforms, which should help prevent build failures due to insufficient space. Additionally, several Rust structs are now `Clone` to support new usage patterns.

**Copilot Tooling Refactor and Enhancements:**

* Replaced the `FocusNodeTool` with a new `GetNodeDetailsTool` that provides comprehensive node information, including pins, connections, and metadata. The tool is now available as `get_node_details` and exposes a richer API and output, both in the tool implementation and Copilot's internal tool dispatch. (`packages/core/src/flow/copilot/tools.rs` [[1]](diffhunk://#diff-8f28da9847b1572e7864f8ef728bfe9eb8272461f3808b50e85c44c74b28acc4L288-R388) [[2]](diffhunk://#diff-8f28da9847b1572e7864f8ef728bfe9eb8272461f3808b50e85c44c74b28acc4L66-L69) [[3]](diffhunk://#diff-8f28da9847b1572e7864f8ef728bfe9eb8272461f3808b50e85c44c74b28acc4L24-R25) [[4]](diffhunk://#diff-8f28da9847b1572e7864f8ef728bfe9eb8272461f3808b50e85c44c74b28acc4L794-R864); `packages/core/src/flow/copilot/mod.rs` [[5]](diffhunk://#diff-a5fba402a28377189715c20785a933e50bfbf96f7deffee01db1e0021c644eacL14-R14) [[6]](diffhunk://#diff-a5fba402a28377189715c20785a933e50bfbf96f7deffee01db1e0021c644eacL49-R49) [[7]](diffhunk://#diff-a5fba402a28377189715c20785a933e50bfbf96f7deffee01db1e0021c644eacL196-R198) [[8]](diffhunk://#diff-a5fba402a28377189715c20785a933e50bfbf96f7deffee01db1e0021c644eacR439-R443) [[9]](diffhunk://#diff-a5fba402a28377189715c20785a933e50bfbf96f7deffee01db1e0021c644eacR667) [[10]](diffhunk://#diff-a5fba402a28377189715c20785a933e50bfbf96f7deffee01db1e0021c644eacL678-R743)
* Updated the Copilot system prompt and tool descriptions to reflect the new tool and clarify usage rules for referencing and explaining nodes. (`packages/core/src/flow/copilot/mod.rs` [[1]](diffhunk://#diff-a5fba402a28377189715c20785a933e50bfbf96f7deffee01db1e0021c644eacL590-R588) [[2]](diffhunk://#diff-a5fba402a28377189715c20785a933e50bfbf96f7deffee01db1e0021c644eacL602-R614)

**Rust Struct Improvements:**

* Added `Clone` to `NodeContext`, `PinContext`, `EdgeContext`, and `GraphContext` to allow easier duplication and sharing of graph state. (`packages/core/src/flow/copilot/context.rs` [[1]](diffhunk://#diff-af9a847a2511e21d0f1c2894d4dfe1732588ea2cced37b21a7eeec224e5dfbbbL9-R9) [[2]](diffhunk://#diff-af9a847a2511e21d0f1c2894d4dfe1732588ea2cced37b21a7eeec224e5dfbbbL27-R27) [[3]](diffhunk://#diff-af9a847a2511e21d0f1c2894d4dfe1732588ea2cced37b21a7eeec224e5dfbbbL39-R39) [[4]](diffhunk://#diff-af9a847a2511e21d0f1c2894d4dfe1732588ea2cced37b21a7eeec224e5dfbbbL52-R52)

**CI Workflow Improvements:**

* Added steps in both `alpha-release.yml` and `release.yml` workflows to aggressively free disk space on Linux, macOS, and Windows runners before builds, reducing the risk of out-of-space errors. (`.github/workflows/alpha-release.yml` [[1]](diffhunk://#diff-f7bb11da4daed6ccaceec672bf18a5ddd48a7afde778745ee203d8968598a73cR35-R63); `.github/workflows/release.yml` [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R27-R55)

These changes together make the Copilot more robust and informative for users, and improve reliability of CI builds.…ion retrieval