### PR TITLE
feat: update thiserror dependency to version 2.0.17

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -9,6 +9,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  RUSTUP_MAX_RETRIES: 10
+
 jobs:
   alpha-release:
     permissions:
@@ -17,13 +22,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: "macos-latest" # for Arm based macs (M1 and above).
+          - platform: "macos-latest"
             args: "--config src-tauri/configs/tauri.macos.arm.conf.json --verbose"
-          - platform: "macos-13" # for Intel based macs.
+          - platform: "macos-13"
             args: "--config src-tauri/configs/tauri.macos.intel.conf.json --verbose"
-          - platform: "ubuntu-latest" # for Tauri v1 you could replace this with ubuntu-20.04.
+          - platform: "ubuntu-latest"
             args: "--config src-tauri/configs/tauri.linux.x64.conf.json --verbose"
-          - platform: "ubuntu-24.04-arm" # for Tauri v1 you could replace this with ubuntu-20.04.
+          - platform: "ubuntu-24.04-arm"
             args: "--verbose"
           - platform: "windows-latest"
             args: "--config src-tauri/configs/tauri.win.x64.conf.json --verbose"
@@ -64,19 +69,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 1
 
-      - name: install dependencies (ubuntu only)
-        if: matrix.platform == 'ubuntu-latest' || matrix.platform == 'ubuntu-24.04-arm'
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
-
-      - name: install dependencies (ubuntu arm only)
-        if: matrix.platform == 'ubuntu-24.04-arm'
-        run: |
-          sudo apt-get install -y xdg-utils
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf xdg-utils
 
       - name: Import Apple Developer Certificate
         if: runner.os == 'macOS'
@@ -92,20 +91,9 @@ jobs:
           security set-keychain-settings -t 7200 -u build.keychain
           security import certificate.p12 -k build.keychain -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" build.keychain
-          security find-identity -v -p codesigning build.keychain
-
-      - name: Verify Certificate
-        if: runner.os == 'macOS'
-        run: |
           CERT_INFO=$(security find-identity -v -p codesigning build.keychain | grep "TM9657 GmbH")
           CERT_ID=$(echo "$CERT_INFO" | awk -F'"' '{print $2}')
           echo "CERT_ID=$CERT_ID" >> $GITHUB_ENV
-          echo "Certificate imported."
-
-      - name: setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: lts/*
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
@@ -117,50 +105,37 @@ jobs:
         with:
           bun-version: 1.3.1
 
-      - name: install Rust stable
+      - name: Install Rust stable
         uses: dtolnay/rust-toolchain@1.89.0
         with:
-          targets: ${{ (matrix.platform == 'macos-latest' || matrix.platform == 'macos-13') && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+          targets: ${{ runner.os == 'macOS' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
-      - name: install frontend dependencies
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ". -> target"
+          cache-on-failure: true
+
+      - name: Install frontend dependencies
         run: bun install
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: tauri-apps/tauri-action@v0
-        if: matrix.platform == 'ubuntu-latest' || matrix.platform == 'ubuntu-24.04-arm'
+      - name: Build and Release
+        uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           PUBLIC_SENTRY_ENDPOINT: ${{ secrets.PUBLIC_SENTRY_ENDPOINT }}
-          LD_LIBRARY_PATH: "${{ github.workspace }}/apps/desktop/src-tauri/binaries/linux/x64"
-        with:
-          tagName: alpha-v__VERSION__
-          releaseName: "Flow Like - Alpha v__VERSION__"
-          releaseBody: "Alpha release for testing purposes. Please do not distribute."
-          releaseDraft: true
-          prerelease: true
-          projectPath: "./apps/desktop"
-          tauriScript: "bun tauri"
-          args: ${{ matrix.args }}
-
-      - uses: tauri-apps/tauri-action@v0
-        if: matrix.platform != 'ubuntu-latest' && matrix.platform != 'ubuntu-24.04-arm'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LD_LIBRARY_PATH: ${{ runner.os == 'Linux' && format('{0}/apps/desktop/src-tauri/binaries/linux/x64', github.workspace) || '' }}
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          PUBLIC_SENTRY_ENDPOINT: ${{ secrets.PUBLIC_SENTRY_ENDPOINT }}
           APPLE_SIGNING_IDENTITY: ${{ env.CERT_ID }}
-          RUSTFLAGS: ${{ matrix.platform == 'windows-latest' && '-C link-arg=/STACK:8388608' || '' }}
+          RUSTFLAGS: ${{ runner.os == 'Windows' && '-C link-arg=/STACK:8388608' || '' }}
         with:
-          tagName: alpha-v__VERSION__ # the action automatically replaces \_\_VERSION\_\_ with the app version.
+          tagName: alpha-v__VERSION__
           releaseName: "Flow Like - Alpha v__VERSION__"
           releaseBody: "Alpha release for testing purposes. Please do not distribute."
           releaseDraft: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5104,7 +5104,7 @@ dependencies = [
  "strsim",
  "sysinfo 0.37.2",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tracing",
  "url",
  "zeroize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ rig-core = {version="0.24.0", features = ["rmcp"]}
 async-trait = "0.1.89"
 jsonschema = "0.33.0"
 rmcp = {version="0.8.5", features = ["auth", "client", "client-side-sse","macros","transport-streamable-http-client-reqwest","transport-streamable-http-server"]}
+thiserror = "2.0.17"
 
 [profile.dev]
 split-debuginfo = "unpacked"

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -47,7 +47,7 @@ flate2 = { version = "1.1.2", default-features = false, features = ["rust_backen
 chacha20poly1305 = {version="0.10.1", features=["stream", "std"]}
 argon2 = "0.5.3"
 zeroize = "1.8.1"
-thiserror = "1.0"
+thiserror.workspace = true
 serde_json.workspace = true
 async-trait.workspace = true
 


### PR DESCRIPTION
This pull request makes several improvements to the GitHub Actions workflow for alpha releases and updates Rust dependencies. The workflow is streamlined for better maintainability and reliability, with improved dependency management, environment setup, and job definitions. Additionally, Rust dependency versions are updated for consistency.

**Workflow improvements and environment setup:**

* Added environment variables (`CARGO_INCREMENTAL`, `CARGO_NET_RETRY`, `RUSTUP_MAX_RETRIES`) to the workflow to improve Rust build reliability and reduce network-related failures.
* Simplified and unified Linux dependency installation steps, combining previous Ubuntu-specific steps and ensuring all necessary packages are installed for both x86 and ARM builds.
* Improved the Rust toolchain setup by using `runner.os` for platform detection, added a Rust dependency cache step for faster builds, and updated the frontend dependency installation step for clarity.

**Job matrix and release process enhancements:**

* Cleaned up the job matrix by removing outdated comments and ensuring consistent configuration for each platform.
* Consolidated the Tauri build and release steps, simplifying environment variable usage and making the process more maintainable across platforms.

**Dependency version updates:**

* Updated `thiserror` dependency in `Cargo.toml` to version `2.0.17` and switched to workspace versioning in `packages/core/Cargo.toml` for better consistency across the project. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R76) [[2]](diffhunk://#diff-9b3cf6d51092bad3cdc57f681782835cc2118db554c51fd2448d1645de4192f3L50-R50)