### PR TITLE
 Update next.js, react-server-dom-* and React packages to secure versions (CVE-2025-55182)

### DIFF
--- a/apps/embedded/package.json
+++ b/apps/embedded/package.json
@@ -12,9 +12,9 @@
 		"@tm9657/flow-like-ui": "workspace:*",
 		"@xyflow/react": "^12.8.2",
 		"comlink": "^4.4.2",
-		"next": "16.0.3",
-		"react": "19.2.0",
-		"react-dom": "19.2.0"
+		"next": "16.0.7",
+		"react": "19.2.1",
+		"react-dom": "19.2.1"
 	},
 	"devDependencies": {
 		"tailwindcss": "^3.4.17",


### PR DESCRIPTION
This PR automatically bumps react-server-dom-* and related react dependencies (react, react-dom) to secure versions in order to mitigate CVE-2025-55182 and related vulnerabilities.

For details on the security issue and upstream changes, see: https://react.dev/blog/2025/12/03/critical-security-vulnerability-in-react-server-components.

