### PR TITLE
Fixed Rust Version

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -106,7 +106,7 @@ jobs:
           bun-version: 1.3.1
 
       - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@1.89.0
+        uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ runner.os == 'macOS' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 


### PR DESCRIPTION
This pull request makes a minor update to the CI workflow configuration. The Rust toolchain installation step now uses the `stable` channel instead of a specific version, which will ensure the workflow always uses the latest stable Rust release.