### PR TITLE
fix: patch esaxx-rs for Windows CRT mismatch and update lancedb depen…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6375,8 +6375,7 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 [[package]]
 name = "esaxx-rs"
 version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
+source = "git+https://github.com/thewh1teagle/esaxx-rs.git?branch=feat%2Fdynamic-msvc-link#3c8ac57d245ab328f7c71953b7c116a8d1d5498f"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,3 +132,8 @@ k8s-openapi = { version = "0.24", features = ["v1_32"] }
 percent-encoding = "2.3.2"
 # Force flate2 to use pure Rust backend (no C zlib) for iOS compatibility
 flate2 = { version = "1.1", default-features = false, features = ["rust_backend"] }
+
+# Patch esaxx-rs to fix Windows CRT mismatch (upstream hardcodes static CRT /MT,
+# conflicting with ort_sys which uses dynamic CRT /MD → LNK2038)
+[patch.crates-io]
+esaxx-rs = { git = "https://github.com/thewh1teagle/esaxx-rs.git", branch = "feat/dynamic-msvc-link" }

--- a/packages/storage/Cargo.toml
+++ b/packages/storage/Cargo.toml
@@ -7,7 +7,8 @@ edition = "2024"
 flow-like-types.workspace = true
 object_store = {version="0.12.4", features = ["gcp", "aws", "azure", "serde", "serde_json", "cloud"] }
 # Using lancedb branch with lance v3.0.0-beta.1 which includes iOS fp16kernels fix (PR #5747)
-lancedb = { git = "https://github.com/lancedb/lancedb.git", branch = "codex/update-lance-3-0-0-beta-1", features = ["polars", "remote", "aws", "azure", "gcs", "fp16kernels"]}
+# fp16kernels are not supported on Windows (lance skips compiling the C kernels for MSVC)
+lancedb = { git = "https://github.com/lancedb/lancedb.git", branch = "codex/update-lance-3-0-0-beta-1", features = ["polars", "remote", "aws", "azure", "gcs"]}
 polars = "0.39.2"
 polars-arrow = "0.39.2"
 arrow-array = "57.2"
@@ -39,6 +40,9 @@ datafusion-federation = { version = "0.4", optional = true }
 # Iceberg support from TM9657 fork (compatible with DataFusion 51)
 iceberg = { git = "https://github.com/TM9657/iceberg-rust.git", branch = "main", optional = true }
 iceberg-datafusion = { git = "https://github.com/TM9657/iceberg-rust.git", branch = "main", optional = true }
+
+[target.'cfg(not(target_os = "windows"))'.dependencies]
+lancedb = { git = "https://github.com/lancedb/lancedb.git", branch = "codex/update-lance-3-0-0-beta-1", features = ["fp16kernels"]}
 
 [features]
 tauri = []


### PR DESCRIPTION
This pull request makes targeted dependency updates and configuration changes to improve cross-platform compatibility, particularly for Windows and iOS environments. The main focus is on adjusting how certain crates are compiled and linked, to avoid platform-specific issues.

Dependency and platform compatibility updates:

* Updated the `lancedb` dependency in `packages/storage/Cargo.toml` to remove the `fp16kernels` feature for Windows, since fp16kernels are not supported and Lance skips compiling the C kernels for MSVC.
* Added a conditional dependency for `lancedb` with the `fp16kernels` feature enabled only for non-Windows targets, ensuring correct feature usage across platforms.

Build and linking fixes:

* Patched the `esaxx-rs` crate in `Cargo.toml` to use a fork that links against the dynamic MSVC CRT, resolving a conflict with `ort_sys` which uses dynamic CRT and avoiding linker errors on Windows.…dencies