### PR TITLE
Enhance iOS overscroll support with layout adjustments and safe area …

### DIFF
--- a/apps/desktop/app/layout.tsx
+++ b/apps/desktop/app/layout.tsx
@@ -161,6 +161,7 @@ export default function RootLayout({
 			data-desktop-app="true"
 			suppressHydrationWarning
 			suppressContentEditableWarning
+			className="min-h-screen"
 		>
 			{/* <ReactScan /> */}
 			<PHProvider>

--- a/apps/desktop/components/app-sidebar.tsx
+++ b/apps/desktop/components/app-sidebar.tsx
@@ -268,11 +268,9 @@ export function AppSidebar({
 	return (
 		<SidebarProvider defaultOpen={defaultOpen}>
 			<InnerSidebar />
-			<IOSQuickMenuTrigger />
 			<main
 				className="w-full h-dvh flex flex-col overflow-hidden"
 				style={{
-					height: "var(--fl-mobile-vvh, 100dvh)",
 					paddingTop: "var(--fl-safe-top, env(safe-area-inset-top, 0px))",
 				}}
 			>
@@ -280,15 +278,11 @@ export function AppSidebar({
 					<MobileHeader />
 					<SidebarInset
 						className="relative flex flex-col flex-1 min-h-0 h-full overflow-hidden"
-						style={{
-							paddingBottom:
-								"var(--fl-safe-bottom, env(safe-area-inset-bottom, 0px))",
-						}}
 					>
 						<FlowBackground
 							intensity="subtle"
 							interactive
-							className="flex flex-col flex-1 min-h-0"
+							className="flex flex-col flex-1 min-h-0 h-full"
 						>
 							{children}
 						</FlowBackground>

--- a/packages/ui/components/interfaces/chat-default.tsx
+++ b/packages/ui/components/interfaces/chat-default.tsx
@@ -553,7 +553,7 @@ export const ChatInterfaceMemoized = memo(function ChatInterface({
 						console.log("Open chat history");
 					}}
 				>
-					<div className="flex items-center gap-2 text-sm font-medium">
+					<div className="flex items-center gap-2 text-sm font-medium" style={{paddingTop: "var(--fl-safe-top, env(safe-area-inset-top, 0px))"}}>
 						<HistoryIcon className="w-3 h-3" />
 						Chat History
 					</div>

--- a/packages/ui/components/interfaces/chat-default/chat.tsx
+++ b/packages/ui/components/interfaces/chat-default/chat.tsx
@@ -276,13 +276,13 @@ const ChatInner = forwardRef<IChatRef, IChatProps>(
 
 		return (
 			<main
-				className="flex flex-col h-full w-full items-center flex-grow bg-background max-h-full overflow-hidden"
+				className="flex flex-col flex-1 min-h-0 w-full items-center bg-background overflow-hidden"
 				style={{
 					WebkitOverflowScrolling: "touch",
 					touchAction: "manipulation",
 				}}
 			>
-				<div className="h-full flex-grow flex flex-col bg-background max-h-full w-full overflow-hidden">
+				<div className="flex-1 min-h-0 flex flex-col bg-background w-full overflow-hidden">
 					{/* Messages Container */}
 					<div
 						ref={scrollContainerRef}
@@ -342,7 +342,13 @@ const ChatInner = forwardRef<IChatRef, IChatProps>(
 					</div>
 
 					{/* ChatBox */}
-					<div className="bg-transparent px-2 pb-2 max-w-screen-lg w-full mx-auto">
+					<div
+						className="bg-background px-2 pb-2 max-w-screen-lg w-full mx-auto"
+						style={{
+							paddingBottom:
+								"calc(0.5rem + var(--fl-safe-bottom, env(safe-area-inset-bottom, 0px)))",
+						}}
+					>
 						{defaultActiveTools && (
 							<ChatBox
 								ref={chatBox}

--- a/packages/ui/components/interfaces/chat-default/history.tsx
+++ b/packages/ui/components/interfaces/chat-default/history.tsx
@@ -131,13 +131,13 @@ export function ChatHistory({
 		<div className="flex flex-col h-full flex-grow overflow-hidden max-h-full">
 			<div className="relative border-b border-border/20 bg-background/95 backdrop-blur-md">
 				<div className="p-4">
-					<div className="flex items-center justify-between mb-4">
+					<div className="flex items-center justify-between mb-4" style={{paddingTop: "var(--fl-safe-top, env(safe-area-inset-top, 0px))"}}>
 						<div className="flex items-center gap-3">
 							<div className="p-2 rounded-lg bg-primary/10 border border-primary/15">
 								<MessageCircleIcon className="w-4 h-4 text-primary" />
 							</div>
 							<div>
-								<h2 className="text-lg font-semibold text-foreground">
+								<h2 className="text-lg font-semibold text-foreground" >
 									Chat History
 								</h2>
 								<p className="text-xs text-muted-foreground">

--- a/packages/ui/global.css
+++ b/packages/ui/global.css
@@ -499,7 +499,7 @@
 	}
 
 	html {
-		@apply scroll-smooth;
+		@apply scroll-smooth bg-background;
 	}
 
 	body {
@@ -520,11 +520,13 @@
 		overflow: hidden !important;
 		position: fixed !important;
 		inset: 0 !important;
+		margin: 0 !important;
+		width: 100% !important;
+		height: 100% !important;
 	}
 
 	/* Desktop app hardening: safe area support & scroll containment. */
 	html:where([data-desktop-app]) {
-		height: var(--fl-mobile-vvh, 100dvh) !important;
 		--fl-safe-top: max(
 			env(safe-area-inset-top, 0px),
 			var(--fl-native-safe-top, 0px)
@@ -535,15 +537,21 @@
 		);
 	}
 
-	body:where([data-desktop-app]) {
-		height: var(--fl-mobile-vvh, 100dvh) !important;
-		width: 100dvw !important;
-	}
+	/* position:fixed + inset:0 already sizes body to the viewport.
+	   Do NOT add an explicit height – it would override inset:0 and
+	   cause the body to extend past the screen on iOS. */
 
 	/* Prevent sidebar-wrapper min-h-svh from causing body overflow */
 	body:where([data-desktop-app]) [data-slot="sidebar-wrapper"] {
 		min-height: 0 !important;
-		height: 100% !important;
+		height: 100dvh !important;
+		max-height: 100dvh !important;
+		overflow: hidden !important;
+	}
+
+	/* Ensure the main content area fills sidebar-wrapper without overflow */
+	body:where([data-desktop-app]) [data-slot="sidebar-inset"] {
+		min-height: 0 !important;
 		max-height: 100% !important;
 	}
 


### PR DESCRIPTION
This pull request focuses on improving layout consistency, safe area handling (especially for desktop and iOS), and overall visual polish across the chat and sidebar interfaces. The changes ensure that padding, height, and overflow behaviors are correct in various environments, and that the UI adapts smoothly to device safe areas.

**Safe area and layout improvements:**

* Added `min-h-screen` to the root layout container in `apps/desktop/app/layout.tsx` to ensure the app fills the viewport vertically.
* Updated multiple components (`ChatInterface`, `ChatHistory`) to add `paddingTop` using CSS variables for safe area insets, improving support for devices with notches or special display areas. [[1]](diffhunk://#diff-694d7d26765bace9af9da9a652386e16c1e608439d2b0b4e691444505d6fcc40L556-R556) [[2]](diffhunk://#diff-51461965dde53ea23ecf24add1e0d57f405903c22c2ee4ca418d81efc7664a8dL134-R134)
* Changed the chat input container to use `paddingBottom` that includes the safe area inset, ensuring it isn't obscured on devices with bottom safe areas.

**Sidebar and main content adjustments:**

* Removed the `IOSQuickMenuTrigger` and adjusted sidebar and main content area heights and overflow to better fit the viewport and prevent unwanted scrolling or clipping, especially on iOS.
* Improved the sidebar wrapper and inset CSS to use `100dvh` and properly constrain overflow, ensuring the sidebar and main content fill the screen without causing body overflow.

**General background and overflow fixes:**

* Applied `bg-background` to the `html` element for consistent background color across the app.
* Updated chat container class names and layout structure to use `flex-1 min-h-0` patterns, which provide more reliable flexbox sizing and overflow handling.

These changes collectively provide a more robust and visually consistent experience across different devices and environments.…handling