### PR TITLE
fix: remove unused SearchResults export from library components

### DIFF
--- a/packages/ui/components/library/index.ts
+++ b/packages/ui/components/library/index.ts
@@ -5,7 +5,6 @@ export {
 	JoinInlineExpanded,
 	LibrarySkeleton,
 	PinnedHero,
-	SearchResults,
 	Section,
 	SortableFavoriteCard,
 } from "./library-sub-components";


### PR DESCRIPTION
This pull request makes a minor update to the `library/index.ts` file by removing the `SearchResults` export from the list of sub-components. This helps keep the exports list accurate and avoids exposing unused or deprecated components.

- Removed the `SearchResults` export from `library-sub-components` in `library/index.ts` to clean up unused or unnecessary exports.