### PR TITLE
Refactor MessageComponent to improve usage stats handling and readabi…

### DIFF
--- a/packages/ui/components/interfaces/chat-default/message.tsx
+++ b/packages/ui/components/interfaces/chat-default/message.tsx
@@ -665,7 +665,8 @@ export const MessageComponent = memo(function MessageComponent({
 		);
 	}, [message.ratingSettings]);
 
-	const hasUsageStats = !isUser && Boolean(message.usage_stats?.length);
+	const usageStats = !isUser ? (message.usage_stats ?? []) : [];
+	const hasUsageStats = usageStats.length > 0;
 	const hasFooterContent = hasUsageStats || processedAttachments.length > 0;
 
 	return (
@@ -747,8 +748,8 @@ export const MessageComponent = memo(function MessageComponent({
 						onFullscreen={setFullscreenFile}
 					/>
 					{hasUsageStats && (
-							<UsageStats stats={message.usage_stats} className="mt-1" />
-						)}
+						<UsageStats stats={usageStats} className="mt-1" />
+					)}
 					{!loading && (
 						<MessageActions
 							isUser={isUser}


### PR DESCRIPTION
This pull request makes a small update to the `MessageComponent` in the chat UI to improve how usage statistics are handled and displayed for messages. The main change is to ensure that usage statistics are only passed to the `UsageStats` component when appropriate, which also simplifies the logic for determining when these stats should be shown.

Improvements to usage statistics handling:

* Refactored the logic to compute `usageStats` so that it is always an array (empty for user messages), and updated `hasUsageStats` to check its length, ensuring consistent and correct rendering of usage statistics. (`packages/ui/components/interfaces/chat-default/message.tsx`, [packages/ui/components/interfaces/chat-default/message.tsxL668-R669](diffhunk://#diff-2f6547449085283590564defd622541f9410e895181bee5696abe75d2d6ca0afL668-R669))
* Updated the `UsageStats` component to use the new `usageStats` variable instead of accessing `message.usage_stats` directly, further improving clarity and reliability. (`packages/ui/components/interfaces/chat-default/message.tsx`, [packages/ui/components/interfaces/chat-default/message.tsxL750-R751](diffhunk://#diff-2f6547449085283590564defd622541f9410e895181bee5696abe75d2d6ca0afL750-R751))