### PR TITLE
Feature/589 optimize llamacpp command

### DIFF
--- a/apps/desktop/lib/profile-sync.ts
+++ b/apps/desktop/lib/profile-sync.ts
@@ -50,7 +50,7 @@ export const toLocalProfile = (onlineProfile: OnlineProfile) => ({
 		updated: onlineProfile.updated_at,
 	},
 	execution_settings: {
-		gpu_mode: false,
+		gpu_mode: true,
 		max_context_size: 32000,
 	},
 	updated: onlineProfile.updated_at,

--- a/apps/desktop/src-tauri/gen/apple/flow-like-desktop_iOS/Info.plist
+++ b/apps/desktop/src-tauri/gen/apple/flow-like-desktop_iOS/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.4</string>
+	<string>0.1.5</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.1.4</string>
+	<string>0.1.5</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>LSSupportsOpeningDocumentsInPlace</key>

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
 	"productName": "Flow Like",
-	"version": "0.1.4",
+	"version": "0.1.5",
 	"identifier": "com.flow-like.app",
 	"build": {
 		"beforeDevCommand": "bun run dev",

--- a/packages/api/src/routes/inbound.rs
+++ b/packages/api/src/routes/inbound.rs
@@ -1445,7 +1445,7 @@ async fn dispatch_rest_fn(
     let body_value = parse_rest_body_value(body, &content_type)?;
     let headers_single = header_map_to_json(headers);
     let query_single = parse_query_single(raw_query);
-    let mut args = body_value.as_object().cloned().unwrap_or_default();
+    let mut args = rest_args_from_body_and_query(&body_value, &query_single);
 
     let request_id = headers
         .get("traceparent")
@@ -1466,7 +1466,7 @@ async fn dispatch_rest_fn(
     let request_value = json!({
         "method": method.as_str(),
         "path": request_path,
-        "query": query_single,
+        "query": query_single.clone(),
         "headers": headers_single,
         "body": body_value.clone(),
         "body_text": String::from_utf8(body.to_vec()).ok(),
@@ -1478,7 +1478,7 @@ async fn dispatch_rest_fn(
     args.insert("request".to_string(), request_value);
     args.insert("method".to_string(), json!(method.as_str()));
     args.insert("path".to_string(), json!(request_path));
-    args.insert("query".to_string(), json!(parse_query_single(raw_query)));
+    args.insert("query".to_string(), json!(query_single));
     args.insert("headers".to_string(), json!(header_map_to_json(headers)));
     args.insert("body".to_string(), body_value.clone());
     args.insert(
@@ -1716,6 +1716,44 @@ fn parse_query_single(raw: &str) -> HashMap<String, String> {
         out.insert(key, value);
     }
     out
+}
+
+fn rest_args_from_body_and_query(
+    body: &Value,
+    query: &HashMap<String, String>,
+) -> serde_json::Map<String, Value> {
+    let mut args = serde_json::Map::new();
+
+    for (key, value) in query {
+        if !is_rest_internal_arg_key(key) {
+            args.insert(key.clone(), Value::String(value.clone()));
+        }
+    }
+
+    if let Some(body_object) = body.as_object() {
+        for (key, value) in body_object {
+            args.insert(key.clone(), value.clone());
+        }
+    }
+
+    args
+}
+
+fn is_rest_internal_arg_key(name: &str) -> bool {
+    matches!(
+        name,
+        "_client"
+            | "request"
+            | "method"
+            | "path"
+            | "query"
+            | "headers"
+            | "body"
+            | "body_text"
+            | "body_bytes"
+            | "payload"
+            | "__inbound_rest"
+    )
 }
 
 fn header_map_to_json(headers: &HeaderMap) -> HashMap<String, String> {
@@ -4206,7 +4244,8 @@ mod tests {
 
     use super::{
         canonical_auth_kind, inbound_base_path, is_asymmetric_jwt_algorithm,
-        jwk_matches_oauth_header, mcp_resource_url, with_inbound_openapi_server,
+        jwk_matches_oauth_header, mcp_resource_url, parse_query_single,
+        rest_args_from_body_and_query, with_inbound_openapi_server,
     };
 
     #[test]
@@ -4257,6 +4296,26 @@ mod tests {
 
         assert_eq!(spec["servers"][0]["url"], json!("/r/public-alias"));
         assert_eq!(spec["paths"]["/hi"], json!({"get": {}}));
+    }
+
+    #[test]
+    fn rest_query_params_fill_named_args_without_overwriting_body_or_internal_args() {
+        let query = parse_query_single(
+            "name=from-query&limit=10&payload=ignored&body=ignored&encoded=hello+world",
+        );
+        let body = json!({
+            "name": "from-body",
+            "active": true
+        });
+
+        let args = rest_args_from_body_and_query(&body, &query);
+
+        assert_eq!(args.get("name").cloned(), Some(json!("from-body")));
+        assert_eq!(args.get("limit").cloned(), Some(json!("10")));
+        assert_eq!(args.get("active").cloned(), Some(json!(true)));
+        assert_eq!(args.get("encoded").cloned(), Some(json!("hello world")));
+        assert!(!args.contains_key("payload"));
+        assert!(!args.contains_key("body"));
     }
 
     #[test]

--- a/packages/catalog/web/src/web/http_runtime.rs
+++ b/packages/catalog/web/src/web/http_runtime.rs
@@ -414,10 +414,10 @@ fn split_target(target: &str) -> (String, HashMap<String, String>) {
     let mut query = HashMap::new();
     for pair in query_string.split('&').filter(|pair| !pair.is_empty()) {
         let (key, value) = pair.split_once('=').unwrap_or((pair, ""));
-        let key = urlencoding::decode(key)
+        let key = urlencoding::decode(&key.replace('+', " "))
             .map(|value| value.into_owned())
             .unwrap_or_else(|_| key.to_string());
-        let value = urlencoding::decode(value)
+        let value = urlencoding::decode(&value.replace('+', " "))
             .map(|value| value.into_owned())
             .unwrap_or_else(|_| value.to_string());
         query.insert(key, value);
@@ -459,5 +459,27 @@ fn reason_phrase(status: u16) -> &'static str {
         500 => "Internal Server Error",
         501 => "Not Implemented",
         _ => "OK",
+    }
+}
+
+#[cfg(all(test, feature = "execute"))]
+mod tests {
+    use super::split_target;
+
+    #[test]
+    fn split_target_decodes_query_plus_like_space_and_percent_plus_literally() {
+        let (path, query) =
+            split_target("search?full+name=Felix+Lau&literal=a%2Bb&encoded=hello%20world");
+
+        assert_eq!(path, "/search");
+        assert_eq!(
+            query.get("full name").map(String::as_str),
+            Some("Felix Lau")
+        );
+        assert_eq!(query.get("literal").map(String::as_str), Some("a+b"));
+        assert_eq!(
+            query.get("encoded").map(String::as_str),
+            Some("hello world")
+        );
     }
 }

--- a/packages/catalog/web/src/web/http_runtime.rs
+++ b/packages/catalog/web/src/web/http_runtime.rs
@@ -414,15 +414,25 @@ fn split_target(target: &str) -> (String, HashMap<String, String>) {
     let mut query = HashMap::new();
     for pair in query_string.split('&').filter(|pair| !pair.is_empty()) {
         let (key, value) = pair.split_once('=').unwrap_or((pair, ""));
-        let key = urlencoding::decode(&key.replace('+', " "))
-            .map(|value| value.into_owned())
-            .unwrap_or_else(|_| key.to_string());
-        let value = urlencoding::decode(&value.replace('+', " "))
-            .map(|value| value.into_owned())
-            .unwrap_or_else(|_| value.to_string());
+        let key = decode_query_component(key);
+        let value = decode_query_component(value);
         query.insert(key, value);
     }
     (normalize_path(path), query)
+}
+
+#[cfg(feature = "execute")]
+fn decode_query_component(component: &str) -> String {
+    if component.contains('+') {
+        let replaced = component.replace('+', " ");
+        return urlencoding::decode(&replaced)
+            .map(|value| value.into_owned())
+            .unwrap_or_else(|_| component.to_string());
+    }
+
+    urlencoding::decode(component)
+        .map(|value| value.into_owned())
+        .unwrap_or_else(|_| component.to_string())
 }
 
 #[cfg(feature = "execute")]

--- a/packages/catalog/web/src/web/rest.rs
+++ b/packages/catalog/web/src/web/rest.rs
@@ -2305,7 +2305,7 @@ fn rest_arguments(
     client: &flow_like_types::Value,
     body: flow_like_types::Value,
 ) -> flow_like_types::Value {
-    let mut args = body.as_object().cloned().unwrap_or_default();
+    let mut args = rest_args_from_body_and_query(&body, &request.query);
     let payload = super::auth::payload_with_client(body.clone(), client);
     args.insert("payload".to_string(), payload);
     let request_value = rest_request_to_value_with_client(request, client, &body);
@@ -2322,6 +2322,28 @@ fn rest_arguments(
     args.insert("body_bytes".to_string(), json!(request.body));
     args.insert("_client".to_string(), client.clone());
     flow_like_types::Value::Object(args)
+}
+
+#[cfg(feature = "execute")]
+fn rest_args_from_body_and_query(
+    body: &flow_like_types::Value,
+    query: &HashMap<String, String>,
+) -> json::Map<String, flow_like_types::Value> {
+    let mut args = json::Map::new();
+
+    for (key, value) in query {
+        if !is_rest_internal_arg_pin(key) {
+            args.insert(key.clone(), flow_like_types::Value::String(value.clone()));
+        }
+    }
+
+    if let Some(body_object) = body.as_object() {
+        for (key, value) in body_object {
+            args.insert(key.clone(), value.clone());
+        }
+    }
+
+    args
 }
 
 #[cfg(feature = "execute")]
@@ -2576,6 +2598,37 @@ mod tests {
         }
     }
 
+    #[derive(Default)]
+    struct RestQueryLogic;
+
+    #[async_trait]
+    impl NodeLogic for RestQueryLogic {
+        fn get_node(&self) -> Node {
+            Node::new(
+                "rest_query_echo",
+                "REST Query Echo",
+                "REST query echo test",
+                "Tests",
+            )
+        }
+
+        async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+            let name: String = context.evaluate_pin("name").await?;
+            let payload: Value = context.evaluate_pin("payload").await?;
+            let query: Value = context.evaluate_pin("query").await?;
+            let request: Value = context.evaluate_pin("request").await?;
+            context.set_result(json!({
+                "body": {
+                    "name": name,
+                    "payload": payload,
+                    "query": query,
+                    "request_query": request.get("query").cloned().unwrap_or(Value::Null)
+                }
+            }));
+            Ok(())
+        }
+    }
+
     fn rest_handler() -> Arc<InternalNode> {
         let mut node = Node::new(
             "test_rest_handler",
@@ -2587,6 +2640,20 @@ mod tests {
         node.add_output_pin("payload", "Payload", "Payload", VariableType::Struct);
         node.add_output_pin("_client", "Client", "Client", VariableType::Struct);
         internal_node_with_logic(node, Arc::new(RestEchoLogic))
+    }
+
+    fn rest_query_handler() -> Arc<InternalNode> {
+        let mut node = Node::new(
+            "test_rest_query_handler",
+            "Test REST Query Handler",
+            "Handler query test node",
+            "Tests",
+        );
+        node.add_output_pin("name", "Name", "Name", VariableType::String);
+        node.add_output_pin("payload", "Payload", "Payload", VariableType::Struct);
+        node.add_output_pin("query", "Query", "Query", VariableType::Struct);
+        node.add_output_pin("request", "Request", "Request", VariableType::Struct);
+        internal_node_with_logic(node, Arc::new(RestQueryLogic))
     }
 
     #[tokio::test]
@@ -2704,6 +2771,66 @@ mod tests {
         assert_eq!(body["payload"]["_client"]["protocol"], json!("rest"));
         assert_eq!(body["client"]["protocol"], json!("rest"));
         assert_eq!(body["client"]["remote_addr"], json!("127.0.0.1:1234"));
+    }
+
+    #[tokio::test]
+    async fn rest_route_uses_query_params_as_named_args_with_body_precedence() {
+        let handler = rest_query_handler();
+        let parent = internal_node(RestServerNode::new().get_node());
+        let context = test_context(parent, vec![handler.clone()]).await;
+        let mut functions = FunctionContextMap::new();
+        functions.insert(
+            handler.node_id().to_string(),
+            super::super::http_runtime::create_shared_function_context(&context, &handler).await,
+        );
+        let config = RestServerConfig {
+            function_routes: vec![RestFunctionRoute {
+                path: "/search".to_string(),
+                methods: vec!["GET".to_string(), "POST".to_string()],
+                function_refs: vec![handler.node_id().to_string()],
+            }],
+            ..Default::default()
+        };
+
+        let get_request = super::super::http_runtime::HttpRequest {
+            method: "GET".to_string(),
+            path: "/search".to_string(),
+            query: HashMap::from([
+                ("name".to_string(), "from-query".to_string()),
+                ("payload".to_string(), "ignored".to_string()),
+            ]),
+            headers: HashMap::new(),
+            body: Vec::new(),
+            remote_addr: "127.0.0.1:1234".to_string(),
+        };
+        let response =
+            route_request(get_request, &config, &functions, &[], &[], None, "parent").await;
+        assert_eq!(response.status_code, 200);
+        let body: Value = flow_like_types::json::from_slice(&response.body).unwrap();
+        assert_eq!(body["name"], json!("from-query"));
+        assert_eq!(body["query"]["name"], json!("from-query"));
+        assert_eq!(body["request_query"]["name"], json!("from-query"));
+        assert_eq!(body["payload"]["_client"]["protocol"], json!("rest"));
+        assert_ne!(body["payload"], json!("ignored"));
+
+        let post_request = super::super::http_runtime::HttpRequest {
+            method: "POST".to_string(),
+            path: "/search".to_string(),
+            query: HashMap::from([("name".to_string(), "from-query".to_string())]),
+            headers: HashMap::from([("content-type".to_string(), "application/json".to_string())]),
+            body: flow_like_types::json::to_vec(&json!({
+                "name": "from-body"
+            }))
+            .unwrap(),
+            remote_addr: "127.0.0.1:1234".to_string(),
+        };
+        let response =
+            route_request(post_request, &config, &functions, &[], &[], None, "parent").await;
+        assert_eq!(response.status_code, 200);
+        let body: Value = flow_like_types::json::from_slice(&response.body).unwrap();
+        assert_eq!(body["name"], json!("from-body"));
+        assert_eq!(body["query"]["name"], json!("from-query"));
+        assert_eq!(body["request_query"]["name"], json!("from-query"));
     }
 
     #[tokio::test]

--- a/packages/core/src/models/llm.rs
+++ b/packages/core/src/models/llm.rs
@@ -24,6 +24,8 @@ pub struct ExecutionSettings {
     pub max_context_size: usize,
 }
 
+pub const DEFAULT_MAX_CONTEXT_SIZE: usize = 32_000;
+
 impl Default for ExecutionSettings {
     fn default() -> Self {
         ExecutionSettings::new()
@@ -33,8 +35,8 @@ impl Default for ExecutionSettings {
 impl ExecutionSettings {
     pub fn new() -> Self {
         Self {
-            gpu_mode: false,
-            max_context_size: 32_000,
+            gpu_mode: true,
+            max_context_size: DEFAULT_MAX_CONTEXT_SIZE,
         }
     }
 }

--- a/packages/core/src/models/llm/local.rs
+++ b/packages/core/src/models/llm/local.rs
@@ -21,7 +21,7 @@ use std::{
     time::Duration,
 };
 
-use super::ExecutionSettings;
+use super::{DEFAULT_MAX_CONTEXT_SIZE, ExecutionSettings};
 
 pub struct LocalModel {
     bit: Bit,
@@ -101,7 +101,7 @@ impl ModelLogic for LocalModel {
 
 impl LocalModel {
     pub async fn check_health(port: &str) -> Result<bool> {
-        let response = reqwest::get(format!("http://localhost:{}/health", port)).await?;
+        let response = reqwest::get(format!("http://127.0.0.1:{}/health", port)).await?;
 
         if response.status().is_success() {
             Ok(true)
@@ -132,7 +132,7 @@ impl LocalModel {
     }
 
     async fn server_supports_tool_use(port: u16) -> Result<bool> {
-        let response = reqwest::get(format!("http://localhost:{port}/props")).await?;
+        let response = reqwest::get(format!("http://127.0.0.1:{port}/props")).await?;
         if !response.status().is_success() {
             return Ok(false);
         }
@@ -141,31 +141,61 @@ impl LocalModel {
         Ok(props_support_tool_use(&props))
     }
 
-    async fn spawn_server(
-        child_handle: &Arc<Mutex<Option<Child>>>,
+    fn resolve_context_length(model_context_length: Option<u32>, max_context_size: usize) -> u32 {
+        let max_context_size = if max_context_size == 0 {
+            DEFAULT_MAX_CONTEXT_SIZE as u32
+        } else {
+            u32::try_from(max_context_size).unwrap_or(u32::MAX)
+        };
+        let model_context_length = model_context_length
+            .filter(|context_length| *context_length > 0)
+            .unwrap_or(max_context_size);
+
+        std::cmp::min(model_context_length, max_context_size)
+    }
+
+    fn server_args(
         gguf_path: &PathBuf,
         context_length: u32,
         port: u16,
-        gpu_layer: u32,
+        gpu_mode: bool,
         projection_path: Option<&str>,
         template_override: &LlamaServerTemplateOverride,
-    ) -> Result<()> {
-        let program = PathBuf::from("llama-server");
-        let mut sidecar = crate::utils::execute::sidecar(&program, None).await?;
+    ) -> Vec<String> {
         let mut args = vec![
-            "-m".to_string(),
+            "--model".to_string(),
             gguf_path.to_string_lossy().into_owned(),
-            "-c".to_string(),
+            "--ctx-size".to_string(),
             context_length.to_string(),
             "--host".to_string(),
-            "localhost".to_string(),
+            "127.0.0.1".to_string(),
             "--port".to_string(),
             port.to_string(),
+            "--parallel".to_string(),
+            "1".to_string(),
             "--no-webui".to_string(),
             "--jinja".to_string(),
-            "-ngl".to_string(),
-            gpu_layer.to_string(),
         ];
+
+        if gpu_mode {
+            args.extend([
+                "--n-gpu-layers".to_string(),
+                "auto".to_string(),
+                "--flash-attn".to_string(),
+                "auto".to_string(),
+                "--fit".to_string(),
+                "on".to_string(),
+            ]);
+        } else {
+            args.extend([
+                "--device".to_string(),
+                "none".to_string(),
+                "--n-gpu-layers".to_string(),
+                "0".to_string(),
+                "--flash-attn".to_string(),
+                "off".to_string(),
+            ]);
+        }
 
         if let Some(projection_path) = projection_path {
             args.push("--mmproj".to_string());
@@ -179,6 +209,29 @@ impl LocalModel {
             args.push("--chat-template".to_string());
             args.push(chat_template.clone());
         }
+
+        args
+    }
+
+    async fn spawn_server(
+        child_handle: &Arc<Mutex<Option<Child>>>,
+        gguf_path: &PathBuf,
+        context_length: u32,
+        port: u16,
+        gpu_mode: bool,
+        projection_path: Option<&str>,
+        template_override: &LlamaServerTemplateOverride,
+    ) -> Result<()> {
+        let program = PathBuf::from("llama-server");
+        let mut sidecar = crate::utils::execute::sidecar(&program, None).await?;
+        let args = Self::server_args(
+            gguf_path,
+            context_length,
+            port,
+            gpu_mode,
+            projection_path,
+            template_override,
+        );
 
         println!("Starting LLM Server with args: {:?}", args);
 
@@ -271,9 +324,10 @@ impl LocalModel {
         let child_handle = Arc::new(Mutex::new(None));
         let port = pick_unused_port().unwrap();
 
-        let mut context_length = bit.try_to_context_length().unwrap_or(512);
-        context_length = std::cmp::min(context_length, execution_settings.max_context_size as u32);
-        let gpu_layer = if execution_settings.gpu_mode { 45 } else { 0 };
+        let context_length = Self::resolve_context_length(
+            bit.try_to_context_length(),
+            execution_settings.max_context_size,
+        );
 
         println!("Execution settings: {:?}", execution_settings);
 
@@ -282,7 +336,7 @@ impl LocalModel {
             &gguf_path,
             context_length,
             port,
-            gpu_layer,
+            execution_settings.gpu_mode,
             projection_path.as_deref(),
             &template_override,
         )
@@ -311,7 +365,7 @@ impl LocalModel {
                 &gguf_path,
                 context_length,
                 port,
-                gpu_layer,
+                execution_settings.gpu_mode,
                 projection_path.as_deref(),
                 &fallback_template,
             )
@@ -327,6 +381,79 @@ impl LocalModel {
             llm_model: Arc::new(llm_model),
             port,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn arg_value<'a>(args: &'a [String], key: &str) -> Option<&'a str> {
+        args.windows(2)
+            .find(|window| window[0] == key)
+            .map(|window| window[1].as_str())
+    }
+
+    #[test]
+    fn server_args_use_automatic_gpu_offload() {
+        let args = LocalModel::server_args(
+            &PathBuf::from("/models/model.gguf"),
+            8192,
+            9650,
+            true,
+            None,
+            &LlamaServerTemplateOverride::default(),
+        );
+
+        assert_eq!(arg_value(&args, "--n-gpu-layers"), Some("auto"));
+        assert_eq!(arg_value(&args, "--flash-attn"), Some("auto"));
+        assert_eq!(arg_value(&args, "--fit"), Some("on"));
+        assert_eq!(arg_value(&args, "--parallel"), Some("1"));
+        assert_eq!(arg_value(&args, "--host"), Some("127.0.0.1"));
+        assert_eq!(arg_value(&args, "--ctx-size"), Some("8192"));
+        assert!(!args.iter().any(|arg| arg == "-ngl" || arg == "45"));
+    }
+
+    #[test]
+    fn context_length_is_bounded_by_desktop_default() {
+        assert_eq!(
+            LocalModel::resolve_context_length(Some(128_000), DEFAULT_MAX_CONTEXT_SIZE),
+            DEFAULT_MAX_CONTEXT_SIZE as u32
+        );
+        assert_eq!(
+            LocalModel::resolve_context_length(Some(128_000), 0),
+            DEFAULT_MAX_CONTEXT_SIZE as u32
+        );
+    }
+
+    #[test]
+    fn server_args_can_pin_context_size() {
+        let args = LocalModel::server_args(
+            &PathBuf::from("/models/model.gguf"),
+            16_384,
+            9650,
+            true,
+            None,
+            &LlamaServerTemplateOverride::default(),
+        );
+
+        assert_eq!(arg_value(&args, "--ctx-size"), Some("16384"));
+    }
+
+    #[test]
+    fn server_args_can_disable_gpu_offload() {
+        let args = LocalModel::server_args(
+            &PathBuf::from("/models/model.gguf"),
+            8192,
+            9650,
+            false,
+            None,
+            &LlamaServerTemplateOverride::default(),
+        );
+
+        assert_eq!(arg_value(&args, "--device"), Some("none"));
+        assert_eq!(arg_value(&args, "--n-gpu-layers"), Some("0"));
+        assert_eq!(arg_value(&args, "--flash-attn"), Some("off"));
     }
 }
 

--- a/packages/model-provider/src/llm/llamacpp.rs
+++ b/packages/model-provider/src/llm/llamacpp.rs
@@ -17,7 +17,7 @@ pub struct LlamaCppModel {
 impl LlamaCppModel {
     pub async fn new(provider: &ModelProvider, port: u16) -> flow_like_types::Result<Self> {
         let model_id = provider.model_id.clone();
-        let base_url = format!("http://localhost:{}", port);
+        let base_url = format!("http://127.0.0.1:{}", port);
 
         let client = LlamaCppClient::new(&base_url);
 

--- a/packages/ui/components/settings/profile/profile-settings-page.tsx
+++ b/packages/ui/components/settings/profile/profile-settings-page.tsx
@@ -344,7 +344,7 @@ export function ProfileSettingsPage({
 								<Label htmlFor="context_size">Max Context Size</Label>
 								<Input
 									id="context_size"
-									placeholder="8192"
+									placeholder="32000"
 									value={profile.execution_settings?.max_context_size || ""}
 									type="number"
 									onChange={(e) =>

--- a/packages/wasm/src/client.rs
+++ b/packages/wasm/src/client.rs
@@ -223,8 +223,8 @@ impl RegistryClient {
     ) -> Result<CachedPackage> {
         let state = self.state.read().await;
         if let Some(installed) = state.installed.get(package_id) {
-            let has_platform_artifact = !cfg!(target_os = "ios")
-                || installed.wasm_path.with_extension("cwasm").exists();
+            let has_platform_artifact =
+                !cfg!(target_os = "ios") || installed.wasm_path.with_extension("cwasm").exists();
 
             if (version.is_none() || version == Some(&installed.version))
                 && installed.wasm_path.exists()


### PR DESCRIPTION
This pull request introduces several improvements and fixes related to REST API argument handling, GPU mode defaults, and local model server configuration. The main focus is on ensuring that REST query parameters and body fields are merged correctly, with body fields taking precedence, and that internal argument keys are not overwritten. Additionally, the default for GPU mode is now enabled, and local model server logic has been updated for clarity and correctness. Version bumps and minor fixes are also included.

**REST API argument handling improvements:**
- Introduced a new `rest_args_from_body_and_query` function in both the API and catalog web layers to merge query parameters and body fields into named arguments, ensuring that body fields override query parameters and internal keys are excluded. Comprehensive tests were added to verify this behavior. [[1]](diffhunk://#diff-7825486f63ba8d1014f5367fe3e55dbef85bbed121a53d6fc40c4746a8b27cf4L1448-R1448) [[2]](diffhunk://#diff-7825486f63ba8d1014f5367fe3e55dbef85bbed121a53d6fc40c4746a8b27cf4R1721-R1758) [[3]](diffhunk://#diff-ad66502a4ef6ea691f54e7f447e61d29bc6cd220b460512e4da727f5255f2fdcL2308-R2308) [[4]](diffhunk://#diff-ad66502a4ef6ea691f54e7f447e61d29bc6cd220b460512e4da727f5255f2fdcR2327-R2348) [[5]](diffhunk://#diff-7825486f63ba8d1014f5367fe3e55dbef85bbed121a53d6fc40c4746a8b27cf4R4301-R4320) [[6]](diffhunk://#diff-ad66502a4ef6ea691f54e7f447e61d29bc6cd220b460512e4da727f5255f2fdcR2601-R2631) [[7]](diffhunk://#diff-ad66502a4ef6ea691f54e7f447e61d29bc6cd220b460512e4da727f5255f2fdcR2645-R2658) [[8]](diffhunk://#diff-ad66502a4ef6ea691f54e7f447e61d29bc6cd220b460512e4da727f5255f2fdcR2776-R2835)

- Updated REST request processing to consistently use the new argument merging logic and to avoid overwriting with internal argument keys. [[1]](diffhunk://#diff-7825486f63ba8d1014f5367fe3e55dbef85bbed121a53d6fc40c4746a8b27cf4L1469-R1469) [[2]](diffhunk://#diff-7825486f63ba8d1014f5367fe3e55dbef85bbed121a53d6fc40c4746a8b27cf4L1481-R1481)

**Local model server and GPU mode defaults:**
- Changed the default for `gpu_mode` to `true` and set `DEFAULT_MAX_CONTEXT_SIZE` to 32,000 tokens in both the desktop app and core model logic. [[1]](diffhunk://#diff-2c1f2aa6d5ef6bd09743602b1b64db0e79a80b7cc3ab7088f9cb0a148d5695c5L53-R53) [[2]](diffhunk://#diff-b6b65dad99d685cca4889386323d693678f3d76debd58a7c92f67432c1eb6cdbR27-R28) [[3]](diffhunk://#diff-b6b65dad99d685cca4889386323d693678f3d76debd58a7c92f67432c1eb6cdbL36-R39)
- Refactored local model server logic to clarify context length resolution and argument construction, and updated server launch logic to use `127.0.0.1` instead of `localhost`. Also improved GPU-related server arguments. [[1]](diffhunk://#diff-f0230bbbf37a9055b1153f552056c1ac0fb0194a91ef0f97bb848a372444c56eL24-R24) [[2]](diffhunk://#diff-f0230bbbf37a9055b1153f552056c1ac0fb0194a91ef0f97bb848a372444c56eL104-R104) [[3]](diffhunk://#diff-f0230bbbf37a9055b1153f552056c1ac0fb0194a91ef0f97bb848a372444c56eL135-R135) [[4]](diffhunk://#diff-f0230bbbf37a9055b1153f552056c1ac0fb0194a91ef0f97bb848a372444c56eL144-R199) [[5]](diffhunk://#diff-f0230bbbf37a9055b1153f552056c1ac0fb0194a91ef0f97bb848a372444c56eR213-R235)

**Query parameter decoding fixes:**
- Fixed query parameter decoding to treat `+` as a space and `%2B` as a literal plus, with new tests verifying the expected behavior. [[1]](diffhunk://#diff-0811c13bfb38c8d26f6438eaf1f619b0b845a8a36470e69197bad6d79ebe883dL417-R420) [[2]](diffhunk://#diff-0811c13bfb38c8d26f6438eaf1f619b0b845a8a36470e69197bad6d79ebe883dR464-R485)

**Version bumps:**
- Bumped application and configuration versions from `0.1.4` to `0.1.5` in desktop and Tauri config files. [[1]](diffhunk://#diff-4507fdd27e842ca02a7a7fd3b429ccce270607d0ab49cded81414afb4ab5d825L22-R22) [[2]](diffhunk://#diff-4507fdd27e842ca02a7a7fd3b429ccce270607d0ab49cded81414afb4ab5d825L35-R35) [[3]](diffhunk://#diff-25f93a9e45647c833a5769e5c21fb1735e0ffd08f536dad2337de462ed7d14ddL3-R3)