### PR TITLE
Feature/605 implement smb storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,13 +216,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "aead"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef60ac202874e574ce7a7158cc8bca7313dd344322482e4fadee288bf4a306b8"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04097e08a47d9ad181c2e1f4a5fabc9ae06ce8839a333ba9a949bcb0d31fd2a3"
+dependencies = [
+ "cipher 0.5.2",
+ "cpubits",
  "cpufeatures 0.2.17",
 ]
 
@@ -232,11 +253,25 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
- "aead",
- "aes",
- "cipher",
- "ctr",
- "ghash",
+ "aead 0.5.2",
+ "aes 0.8.4",
+ "cipher 0.4.4",
+ "ctr 0.9.2",
+ "ghash 0.5.1",
+ "subtle",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.11.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22c0c90bbe8d4f77c3ca9ddabe41a1f8382d6fc1f7cea89459d0f320371f972"
+dependencies = [
+ "aead 0.6.0",
+ "aes 0.9.0-rc.4",
+ "cipher 0.5.2",
+ "ctr 0.10.1",
+ "ghash 0.6.0",
  "subtle",
 ]
 
@@ -603,7 +638,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -1531,7 +1566,7 @@ dependencies = [
  "fastrand 2.4.1",
  "hex",
  "http 1.4.0",
- "sha1",
+ "sha1 0.10.6",
  "time",
  "tokio",
  "tracing",
@@ -2076,7 +2111,7 @@ dependencies = [
  "http-body 0.4.6",
  "md-5 0.10.6",
  "pin-project-lite",
- "sha1",
+ "sha1 0.10.6",
  "sha2 0.10.9",
  "tracing",
 ]
@@ -2947,7 +2982,7 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.23.0",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -3386,7 +3421,7 @@ dependencies = [
  "cap-primitives",
  "cap-std",
  "io-lifetimes 2.0.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3414,7 +3449,7 @@ dependencies = [
  "maybe-owned",
  "rustix 1.1.4",
  "rustix-linux-procfs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "winx",
 ]
 
@@ -3497,7 +3532,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -3510,6 +3545,18 @@ dependencies = [
  "jobserver",
  "libc",
  "shlex",
+]
+
+[[package]]
+name = "ccm"
+version = "0.6.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4edea5ea70a1285565ac264767613d6c88351a9a0557e7af793a0942590baaed"
+dependencies = [
+ "aead 0.6.0",
+ "cipher 0.5.2",
+ "ctr 0.10.1",
+ "subtle",
 ]
 
 [[package]]
@@ -3611,7 +3658,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
 ]
 
@@ -3632,9 +3679,9 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
- "aead",
+ "aead 0.5.2",
  "chacha20 0.9.1",
- "cipher",
+ "cipher 0.4.4",
  "poly1305",
  "zeroize",
 ]
@@ -3719,8 +3766,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.7",
- "inout",
+ "inout 0.1.4",
  "zeroize",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -3836,6 +3894,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmac"
+version = "0.8.0-rc.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f7f5c25253a49afbdd6a256a21a554c509cf0e6400f59d6dd85e0f15b5f15f6"
+dependencies = [
+ "cipher 0.5.2",
+ "dbl",
+ "digest 0.11.2",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3948,7 +4017,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3957,7 +4026,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4296,6 +4365,12 @@ checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -4695,11 +4770,13 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
+ "getrandom 0.4.2",
  "hybrid-array",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4824,7 +4901,16 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
+]
+
+[[package]]
+name = "ctr"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
+dependencies = [
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -5856,6 +5942,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbl"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d7a944e61df464668c5f51f56cc667396a8821434273112948ea0b66e405d7"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6286,7 +6381,7 @@ checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "ctutils",
 ]
 
@@ -6328,7 +6423,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6720,7 +6815,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a8bfa975b1aec2145850fcaa1c6fe269a16578c44705a532ae3edc92b8881c7"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -7150,7 +7245,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7697,7 +7792,7 @@ dependencies = [
 name = "flow-like-api"
 version = "0.1.0"
 dependencies = [
- "aes-gcm",
+ "aes-gcm 0.10.3",
  "async-stream",
  "async-stripe",
  "async-trait",
@@ -8125,7 +8220,7 @@ dependencies = [
 name = "flow-like-catalog-std"
 version = "0.1.0"
 dependencies = [
- "aes-gcm",
+ "aes-gcm 0.10.3",
  "ahash 0.8.12",
  "async-trait",
  "chacha20poly1305",
@@ -8414,6 +8509,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "blake3",
+ "chrono",
  "crossbeam-channel",
  "datafusion",
  "datafusion-federation",
@@ -8441,6 +8537,7 @@ dependencies = [
  "serde",
  "serde_arrow",
  "serde_json",
+ "smb2",
  "tokio",
  "urlencoding",
 ]
@@ -8691,7 +8788,7 @@ checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes 2.0.4",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9336,8 +9433,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -9571,7 +9668,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
 dependencies = [
  "opaque-debug",
- "polyval",
+ "polyval 0.6.2",
+]
+
+[[package]]
+name = "ghash"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
+dependencies = [
+ "polyval 0.7.1",
 ]
 
 [[package]]
@@ -10458,7 +10564,7 @@ dependencies = [
  "http 1.4.0",
  "httpdate",
  "mime",
- "sha1",
+ "sha1 0.10.6",
 ]
 
 [[package]]
@@ -11033,13 +11139,13 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration 0.7.0",
  "tokio",
  "tower-layer",
  "tower-service",
  "tracing",
- "windows-registry 0.5.3",
+ "windows-registry 0.6.1",
 ]
 
 [[package]]
@@ -11106,7 +11212,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -11544,6 +11650,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "input"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11623,7 +11738,7 @@ version = "0.18.4"
 source = "git+https://github.com/Rheosoph/io-extras.git?rev=515df16351274387cb14d661874ed731fff1350b#515df16351274387cb14d661874ed731fff1350b"
 dependencies = [
  "io-lifetimes 2.0.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11833,7 +11948,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -14026,7 +14141,7 @@ version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7184fdea2bc3cd272a1acec4030c321a8f9875e877b3f92a53f2f6033fdc289"
 dependencies = [
- "aes",
+ "aes 0.8.4",
  "bitflags 2.11.1",
  "cbc",
  "ecb",
@@ -14054,7 +14169,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f560f57dfb9142a02d673e137622fd515d4231e51feb8b4af28d92647d83f35b"
 dependencies = [
- "aes",
+ "aes 0.8.4",
  "bitflags 2.11.1",
  "cbc",
  "chrono",
@@ -14137,6 +14252,15 @@ name = "lz4_flex"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98c23545df7ecf1b16c303910a69b079e8e251d60f7dd2cc9b4177f2afaf1746"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
+name = "lz4_flex"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
 dependencies = [
  "twox-hash",
 ]
@@ -14465,6 +14589,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
+ "digest 0.11.2",
+]
+
+[[package]]
+name = "md4"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd76fb0fd6b2e4be62a73f8e0858ca97f81babcb1af322dcaca196f735f17f80"
+dependencies = [
  "digest 0.11.2",
 ]
 
@@ -14938,7 +15071,7 @@ dependencies = [
  "saturating",
  "serde",
  "serde_json",
- "sha1",
+ "sha1 0.10.6",
  "sha2 0.10.9",
  "thiserror 2.0.18",
  "time",
@@ -15287,7 +15420,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -15543,7 +15676,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "chrono",
  "getrandom 0.2.17",
  "http 1.4.0",
@@ -16644,7 +16777,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -16905,6 +17038,16 @@ checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest 0.10.7",
  "hmac 0.12.1",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.13.0-rc.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f24f3eb2f4471b1730d59e4b730b747939960a8c7eb0c33c5a9076f2d3dddea"
+dependencies = [
+ "digest 0.11.2",
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -17391,10 +17534,10 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
 dependencies = [
- "aes",
+ "aes 0.8.4",
  "cbc",
  "der 0.7.10",
- "pbkdf2",
+ "pbkdf2 0.12.2",
  "scrypt",
  "sha2 0.10.9",
  "spki 0.7.3",
@@ -17881,7 +18024,7 @@ checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
  "cpufeatures 0.2.17",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.5.1",
 ]
 
 [[package]]
@@ -17893,7 +18036,18 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.5.1",
+]
+
+[[package]]
+name = "polyval"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dfc63250416fea14f5749b90725916a6c903f599d51cb635aa7a52bfd03eede"
+dependencies = [
+ "cpubits",
+ "cpufeatures 0.3.0",
+ "universal-hash 0.6.1",
 ]
 
 [[package]]
@@ -18207,7 +18361,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -18227,7 +18381,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -18582,7 +18736,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls 0.23.38",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -18620,9 +18774,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -19296,7 +19450,7 @@ dependencies = [
  "rust-ini",
  "serde",
  "serde_json",
- "sha1",
+ "sha1 0.10.6",
  "sha2 0.10.9",
  "tokio",
 ]
@@ -19966,7 +20120,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -19979,7 +20133,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -20105,7 +20259,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -20230,7 +20384,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -20384,7 +20538,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
 dependencies = [
- "pbkdf2",
+ "pbkdf2 0.12.2",
  "salsa20",
  "sha2 0.10.9",
 ]
@@ -21262,6 +21416,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
+]
+
+[[package]]
 name = "sha1_smol"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -21535,6 +21700,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "smb2"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20c0c2512afe348ee078716d3c0e28d68aafbf544c16f50afe8a68185dd172b1"
+dependencies = [
+ "aes 0.9.0-rc.4",
+ "aes-gcm 0.11.0-rc.3",
+ "async-trait",
+ "ccm",
+ "cmac",
+ "digest 0.11.2",
+ "futures-util",
+ "getrandom 0.4.2",
+ "hmac 0.13.0",
+ "log",
+ "lz4_flex 0.13.1",
+ "md-5 0.11.0",
+ "md4",
+ "num_enum 0.7.6",
+ "pbkdf2 0.13.0-rc.10",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
 name = "smol_str"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -21576,7 +21768,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -21588,7 +21780,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54254b8531cafa275c5e096f62d48c81435d1015405a91198ddb11e967301d40"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -21937,7 +22129,7 @@ dependencies = [
  "rsa",
  "rust_decimal",
  "serde",
- "sha1",
+ "sha1 0.10.6",
  "sha2 0.10.9",
  "smallvec 1.15.1",
  "sqlx-core",
@@ -22048,7 +22240,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 
@@ -23448,7 +23639,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -24778,7 +24969,7 @@ dependencies = [
  "rand 0.8.6",
  "rustls 0.22.4",
  "rustls-pki-types",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 1.0.69",
  "url",
  "utf-8",
@@ -24799,7 +24990,7 @@ dependencies = [
  "rand 0.8.6",
  "rustls 0.23.38",
  "rustls-pki-types",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 1.0.69",
  "utf-8",
 ]
@@ -24818,7 +25009,7 @@ dependencies = [
  "rand 0.9.3",
  "rustls 0.23.38",
  "rustls-pki-types",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 2.0.18",
  "utf-8",
 ]
@@ -25043,7 +25234,7 @@ version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "408c7e039c96ec1d517a1111ade7fadab889f32c096dac691a1e3b8018c3e39a"
 dependencies = [
- "aes",
+ "aes 0.8.4",
  "ahash 0.8.12",
  "base64 0.22.1",
  "byteorder",
@@ -25211,6 +25402,16 @@ checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
  "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+dependencies = [
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -26569,7 +26770,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -27267,7 +27468,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
  "bitflags 2.11.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -28086,7 +28287,7 @@ version = "8.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcab981e19633ebcf0b001ddd37dd802996098bc1864f90b7c5d970ce76c1d59"
 dependencies = [
- "aes",
+ "aes 0.8.4",
  "constant_time_eq",
  "crc32fast",
  "flate2",
@@ -28094,8 +28295,8 @@ dependencies = [
  "hmac 0.12.1",
  "indexmap 2.14.0",
  "memchr",
- "pbkdf2",
- "sha1",
+ "pbkdf2 0.12.2",
+ "sha1 0.10.6",
  "time",
  "typed-path",
  "zeroize",

--- a/packages/catalog/data/src/data/datafusion/external_stores.rs
+++ b/packages/catalog/data/src/data/datafusion/external_stores.rs
@@ -12,7 +12,9 @@ use flow_like::flow::{
     variable::VariableType,
 };
 use flow_like_storage::files::store::FlowLikeStore;
-use flow_like_storage::files::store::smb_store::{SmbConfig, SmbObjectStore};
+use flow_like_storage::files::store::smb_store::{
+    SmbAuth, SmbConfig, SmbKerberosCcacheConfig, SmbObjectStore,
+};
 use flow_like_storage::object_store::{
     aws::AmazonS3Builder, azure::MicrosoftAzureBuilder, gcp::GoogleCloudStorageBuilder,
 };
@@ -564,7 +566,8 @@ impl NodeLogic for CloudflareR2StoreNode {
 
 const SMB_CREDENTIALS: &str = "credentials";
 const SMB_GUEST: &str = "guest";
-const SMB_AUTH_MODES: &[&str] = &[SMB_CREDENTIALS, SMB_GUEST];
+const SMB_KERBEROS_CCACHE: &str = "kerberos_ccache";
+const SMB_AUTH_MODES: &[&str] = &[SMB_CREDENTIALS, SMB_GUEST, SMB_KERBEROS_CCACHE];
 
 #[crate::register_node]
 #[derive(Default)]
@@ -677,20 +680,20 @@ impl NodeLogic for SmbStoreNode {
             ));
         }
 
-        let (username, password, domain) = if auth_mode == SMB_GUEST {
-            (String::new(), String::new(), String::new())
-        } else {
+        let address = normalize_smb_address(&address)?;
+        if share.trim().is_empty() {
+            return Err(flow_like_types::anyhow!("SMB share name is required"));
+        }
+
+        let (username, password, domain) = if auth_mode == SMB_CREDENTIALS {
             (
                 context.evaluate_pin("username").await.unwrap_or_default(),
                 context.evaluate_pin("password").await.unwrap_or_default(),
                 context.evaluate_pin("domain").await.unwrap_or_default(),
             )
+        } else {
+            (String::new(), String::new(), String::new())
         };
-
-        let address = normalize_smb_address(&address)?;
-        if share.trim().is_empty() {
-            return Err(flow_like_types::anyhow!("SMB share name is required"));
-        }
 
         let mut config = SmbConfig::new(
             address.clone(),
@@ -702,12 +705,52 @@ impl NodeLogic for SmbStoreNode {
         config.timeout = Duration::from_secs(timeout_seconds.max(1) as u64);
         config.compression = compression;
         config.dfs_enabled = dfs_enabled;
+        let auth_key = if auth_mode == SMB_KERBEROS_CCACHE {
+            let kerberos_username: String = context
+                .evaluate_pin("kerberos_username")
+                .await
+                .unwrap_or_default();
+            let kerberos_realm: String = context
+                .evaluate_pin("kerberos_realm")
+                .await
+                .unwrap_or_default();
+            let kerberos_kdc_address: String = context
+                .evaluate_pin("kerberos_kdc_address")
+                .await
+                .unwrap_or_default();
+            let kerberos_ccache_path: String = context
+                .evaluate_pin("kerberos_ccache_path")
+                .await
+                .unwrap_or_default();
+            let kerberos_spn_host: String = context
+                .evaluate_pin("kerberos_spn_host")
+                .await
+                .unwrap_or_default();
+
+            config.auth = SmbAuth::KerberosCcache(SmbKerberosCcacheConfig {
+                username: kerberos_username.clone(),
+                realm: kerberos_realm.clone(),
+                kdc_address: kerberos_kdc_address.clone(),
+                ccache_path: kerberos_ccache_path.clone(),
+                server_hostname: kerberos_spn_host.clone(),
+            });
+            format!(
+                "{}:{}:{}:{}:{}:{}",
+                auth_mode,
+                kerberos_username,
+                kerberos_realm,
+                kerberos_kdc_address,
+                kerberos_ccache_path,
+                kerberos_spn_host
+            )
+        } else {
+            format!("{}:{}:{}", auth_mode, username, domain)
+        };
 
         let store = SmbObjectStore::connect(config)
             .await
             .map_err(|e| flow_like_types::anyhow!("Failed to connect SMB share: {}", e))?;
         let store = FlowLikeStore::Other(Arc::new(store));
-        let auth_key = format!("{}:{}:{}", auth_mode, username, domain);
         let share_key = format!("{}/{}", address, share.trim());
         let path =
             cache_and_wrap(context, "smb_store", &share_key, &prefix, &auth_key, store).await;
@@ -731,7 +774,7 @@ fn add_smb_auth_mode_pin(node: &mut Node) {
     node.add_input_pin(
         "auth_mode",
         "Auth Mode",
-        "How to authenticate: 'credentials' (username/password/domain) or 'guest' (anonymous/null session if the server allows it)",
+        "How to authenticate: 'credentials' (username/password/domain), 'guest', or 'kerberos_ccache' (local FILE ccache/kinit)",
         VariableType::String,
     )
     .set_options(
@@ -775,10 +818,86 @@ fn add_smb_credential_pins(node: &mut Node) {
     }
 }
 
+fn add_smb_kerberos_username_pin(node: &mut Node) {
+    node.add_input_pin(
+        "kerberos_username",
+        "Principal",
+        "Optional Kerberos username. Defaults to the ccache principal.",
+        VariableType::String,
+    )
+    .set_default_value(Some(json!("")));
+}
+
+fn add_smb_kerberos_realm_pin(node: &mut Node) {
+    node.add_input_pin(
+        "kerberos_realm",
+        "Realm",
+        "Optional Kerberos realm. Defaults to the ccache principal realm.",
+        VariableType::String,
+    )
+    .set_default_value(Some(json!("")));
+}
+
+fn add_smb_kerberos_kdc_pin(node: &mut Node) {
+    node.add_input_pin(
+        "kerberos_kdc_address",
+        "KDC",
+        "Optional KDC address. Required if the ccache has only a TGT and needs a service ticket.",
+        VariableType::String,
+    )
+    .set_default_value(Some(json!("")));
+}
+
+fn add_smb_kerberos_ccache_pin(node: &mut Node) {
+    node.add_input_pin(
+        "kerberos_ccache_path",
+        "CCache",
+        "Optional FILE ccache path. Empty uses KRB5CCNAME.",
+        VariableType::String,
+    )
+    .set_default_value(Some(json!("")));
+}
+
+fn add_smb_kerberos_spn_pin(node: &mut Node) {
+    node.add_input_pin(
+        "kerberos_spn_host",
+        "SPN Host",
+        "Optional hostname used for the cifs/<host> service principal. Defaults to the SMB address host.",
+        VariableType::String,
+    )
+    .set_default_value(Some(json!("")));
+}
+
+fn add_smb_kerberos_pins(node: &mut Node) {
+    if node.get_pin_by_name("kerberos_username").is_none() {
+        add_smb_kerberos_username_pin(node);
+    }
+    if node.get_pin_by_name("kerberos_realm").is_none() {
+        add_smb_kerberos_realm_pin(node);
+    }
+    if node.get_pin_by_name("kerberos_kdc_address").is_none() {
+        add_smb_kerberos_kdc_pin(node);
+    }
+    if node.get_pin_by_name("kerberos_ccache_path").is_none() {
+        add_smb_kerberos_ccache_pin(node);
+    }
+    if node.get_pin_by_name("kerberos_spn_host").is_none() {
+        add_smb_kerberos_spn_pin(node);
+    }
+}
+
 fn remove_smb_credential_pins(node: &mut Node) {
     remove_pin_by_name(node, "username");
     remove_pin_by_name(node, "password");
     remove_pin_by_name(node, "domain");
+}
+
+fn remove_smb_kerberos_pins(node: &mut Node) {
+    remove_pin_by_name(node, "kerberos_username");
+    remove_pin_by_name(node, "kerberos_realm");
+    remove_pin_by_name(node, "kerberos_kdc_address");
+    remove_pin_by_name(node, "kerberos_ccache_path");
+    remove_pin_by_name(node, "kerberos_spn_host");
 }
 
 fn sync_smb_auth_mode_pins(node: &mut Node, auth_mode: &str) {
@@ -788,14 +907,26 @@ fn sync_smb_auth_mode_pins(node: &mut Node, auth_mode: &str) {
         auth_mode
     };
     let want_credentials = mode == SMB_CREDENTIALS;
+    let want_kerberos = mode == SMB_KERBEROS_CCACHE;
     let has_credentials = node.get_pin_by_name("username").is_some()
         || node.get_pin_by_name("password").is_some()
         || node.get_pin_by_name("domain").is_some();
+    let has_kerberos = node.get_pin_by_name("kerberos_username").is_some()
+        || node.get_pin_by_name("kerberos_realm").is_some()
+        || node.get_pin_by_name("kerberos_kdc_address").is_some()
+        || node.get_pin_by_name("kerberos_ccache_path").is_some()
+        || node.get_pin_by_name("kerberos_spn_host").is_some();
 
     if want_credentials {
         add_smb_credential_pins(node);
     } else if has_credentials {
         remove_smb_credential_pins(node);
+    }
+
+    if want_kerberos {
+        add_smb_kerberos_pins(node);
+    } else if has_kerberos {
+        remove_smb_kerberos_pins(node);
     }
 }
 
@@ -929,6 +1060,15 @@ mod tests {
             let pin = find_pin(&node, pin, PinType::Input).expect("input pin");
             assert_eq!(pin.data_type, VariableType::String);
         }
+        for pin in [
+            "kerberos_username",
+            "kerberos_realm",
+            "kerberos_kdc_address",
+            "kerberos_ccache_path",
+            "kerberos_spn_host",
+        ] {
+            assert!(find_pin(&node, pin, PinType::Input).is_none());
+        }
         assert_eq!(
             find_pin(&node, "timeout_seconds", PinType::Input)
                 .expect("timeout input")
@@ -948,7 +1088,11 @@ mod tests {
             .expect("auth_mode valid values");
         assert_eq!(
             values,
-            vec![SMB_CREDENTIALS.to_string(), SMB_GUEST.to_string()]
+            vec![
+                SMB_CREDENTIALS.to_string(),
+                SMB_GUEST.to_string(),
+                SMB_KERBEROS_CCACHE.to_string()
+            ]
         );
     }
 
@@ -969,6 +1113,7 @@ mod tests {
         assert!(node.get_pin_by_name("username").is_none());
         assert!(node.get_pin_by_name("password").is_none());
         assert!(node.get_pin_by_name("domain").is_none());
+        assert!(node.get_pin_by_name("kerberos_username").is_none());
 
         let pin_count_after_guest = node.pins.len();
         sync_smb_auth_mode_pins(&mut node, SMB_GUEST);
@@ -978,10 +1123,37 @@ mod tests {
             "guest sync should be stable when repeated"
         );
 
+        sync_smb_auth_mode_pins(&mut node, SMB_KERBEROS_CCACHE);
+        assert!(node.get_pin_by_name("username").is_none());
+        assert!(node.get_pin_by_name("password").is_none());
+        assert!(node.get_pin_by_name("domain").is_none());
+        assert!(node.get_pin_by_name("kerberos_username").is_some());
+        assert!(node.get_pin_by_name("kerberos_realm").is_some());
+        assert!(node.get_pin_by_name("kerberos_kdc_address").is_some());
+        assert!(node.get_pin_by_name("kerberos_ccache_path").is_some());
+        assert!(node.get_pin_by_name("kerberos_spn_host").is_some());
+
+        let kerberos_username_id = node
+            .get_pin_by_name("kerberos_username")
+            .unwrap()
+            .id
+            .clone();
+        sync_smb_auth_mode_pins(&mut node, SMB_KERBEROS_CCACHE);
+        assert_eq!(
+            kerberos_username_id,
+            node.get_pin_by_name("kerberos_username").unwrap().id,
+            "kerberos sync should not recreate existing kerberos pins"
+        );
+
         sync_smb_auth_mode_pins(&mut node, SMB_CREDENTIALS);
         assert!(node.get_pin_by_name("username").is_some());
         assert!(node.get_pin_by_name("password").is_some());
         assert!(node.get_pin_by_name("domain").is_some());
+        assert!(node.get_pin_by_name("kerberos_username").is_none());
+        assert!(node.get_pin_by_name("kerberos_realm").is_none());
+        assert!(node.get_pin_by_name("kerberos_kdc_address").is_none());
+        assert!(node.get_pin_by_name("kerberos_ccache_path").is_none());
+        assert!(node.get_pin_by_name("kerberos_spn_host").is_none());
     }
 
     #[test]

--- a/packages/catalog/data/src/data/datafusion/external_stores.rs
+++ b/packages/catalog/data/src/data/datafusion/external_stores.rs
@@ -3,18 +3,22 @@ use crate::data::providers::aws::AwsProvider;
 use crate::data::providers::azure::AzureProvider;
 use crate::data::providers::cloudflare::CloudflareProvider;
 use crate::data::providers::gcp::GcpProvider;
+use crate::data::providers::util::get_pin_string_value;
 use flow_like::flow::{
+    board::Board,
     execution::context::ExecutionContext,
-    node::{Node, NodeLogic, NodeScores},
+    node::{Node, NodeLogic, NodeScores, remove_pin_by_name},
     pin::PinOptions,
     variable::VariableType,
 };
 use flow_like_storage::files::store::FlowLikeStore;
+use flow_like_storage::files::store::smb_store::{SmbConfig, SmbObjectStore};
 use flow_like_storage::object_store::{
     aws::AmazonS3Builder, azure::MicrosoftAzureBuilder, gcp::GoogleCloudStorageBuilder,
 };
 use flow_like_types::{Cacheable, async_trait, json::json};
 use std::sync::Arc;
+use std::time::Duration;
 
 // =============================================================================
 // AWS S3 -> FlowPath
@@ -555,8 +559,258 @@ impl NodeLogic for CloudflareR2StoreNode {
 }
 
 // =============================================================================
+// SMB Share -> FlowPath
+// =============================================================================
+
+const SMB_CREDENTIALS: &str = "credentials";
+const SMB_GUEST: &str = "guest";
+const SMB_AUTH_MODES: &[&str] = &[SMB_CREDENTIALS, SMB_GUEST];
+
+#[crate::register_node]
+#[derive(Default)]
+pub struct SmbStoreNode {}
+
+impl SmbStoreNode {
+    pub fn new() -> Self {
+        SmbStoreNode {}
+    }
+}
+
+#[async_trait]
+impl NodeLogic for SmbStoreNode {
+    fn get_node(&self) -> Node {
+        let mut node = Node::new(
+            "external_smb_store",
+            "SMB Share",
+            "Turn an SMB2/3 share into a FlowPath.",
+            "Data/Files/External",
+        );
+        node.add_icon("/flow/icons/cloud.svg");
+
+        node.add_input_pin(
+            "exec_in",
+            "Input",
+            "Trigger execution",
+            VariableType::Execution,
+        );
+        node.add_input_pin(
+            "address",
+            "Address",
+            "SMB server address. Use host:port, or host to use port 445.",
+            VariableType::String,
+        );
+        node.add_input_pin("share", "Share", "SMB share name", VariableType::String);
+
+        add_smb_auth_mode_pin(&mut node);
+
+        node.add_input_pin(
+            "prefix",
+            "Prefix",
+            "Optional path prefix within the share",
+            VariableType::String,
+        )
+        .set_default_value(Some(json!("")));
+
+        add_smb_credential_pins(&mut node);
+
+        node.add_input_pin(
+            "timeout_seconds",
+            "Timeout",
+            "Connection timeout in seconds",
+            VariableType::Integer,
+        )
+        .set_default_value(Some(json!(5)));
+        node.add_input_pin(
+            "compression",
+            "Compression",
+            "Enable SMB compression when supported by the server",
+            VariableType::Boolean,
+        )
+        .set_default_value(Some(json!(true)));
+        node.add_input_pin(
+            "dfs_enabled",
+            "DFS",
+            "Enable DFS referral handling",
+            VariableType::Boolean,
+        )
+        .set_default_value(Some(json!(true)));
+
+        node.add_output_pin("exec_out", "Done", "Store created", VariableType::Execution);
+        node.add_output_pin(
+            "path",
+            "Path",
+            "FlowPath pointing to the SMB share",
+            VariableType::Struct,
+        )
+        .set_schema::<FlowPath>();
+
+        node.scores = Some(NodeScores {
+            privacy: 5,
+            security: 5,
+            performance: 6,
+            governance: 5,
+            reliability: 6,
+            cost: 8,
+        });
+        node
+    }
+
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        context.deactivate_exec_pin("exec_out").await?;
+
+        let address: String = context.evaluate_pin("address").await?;
+        let share: String = context.evaluate_pin("share").await?;
+        let auth_mode: String = context
+            .evaluate_pin("auth_mode")
+            .await
+            .unwrap_or_else(|_| SMB_CREDENTIALS.to_string());
+        let prefix: String = context.evaluate_pin("prefix").await.unwrap_or_default();
+        let timeout_seconds: i64 = context.evaluate_pin("timeout_seconds").await.unwrap_or(5);
+        let compression: bool = context.evaluate_pin("compression").await.unwrap_or(true);
+        let dfs_enabled: bool = context.evaluate_pin("dfs_enabled").await.unwrap_or(true);
+
+        if !SMB_AUTH_MODES.iter().any(|mode| *mode == auth_mode) {
+            return Err(flow_like_types::anyhow!(
+                "Unknown SMB auth_mode: '{}'. Expected one of {:?}",
+                auth_mode,
+                SMB_AUTH_MODES
+            ));
+        }
+
+        let (username, password, domain) = if auth_mode == SMB_GUEST {
+            (String::new(), String::new(), String::new())
+        } else {
+            (
+                context.evaluate_pin("username").await.unwrap_or_default(),
+                context.evaluate_pin("password").await.unwrap_or_default(),
+                context.evaluate_pin("domain").await.unwrap_or_default(),
+            )
+        };
+
+        let address = normalize_smb_address(&address)?;
+        if share.trim().is_empty() {
+            return Err(flow_like_types::anyhow!("SMB share name is required"));
+        }
+
+        let mut config = SmbConfig::new(
+            address.clone(),
+            share.trim().to_string(),
+            username.clone(),
+            password,
+        );
+        config.domain = domain.clone();
+        config.timeout = Duration::from_secs(timeout_seconds.max(1) as u64);
+        config.compression = compression;
+        config.dfs_enabled = dfs_enabled;
+
+        let store = SmbObjectStore::connect(config)
+            .await
+            .map_err(|e| flow_like_types::anyhow!("Failed to connect SMB share: {}", e))?;
+        let store = FlowLikeStore::Other(Arc::new(store));
+        let auth_key = format!("{}:{}:{}", auth_mode, username, domain);
+        let share_key = format!("{}/{}", address, share.trim());
+        let path =
+            cache_and_wrap(context, "smb_store", &share_key, &prefix, &auth_key, store).await;
+
+        context.set_pin_value("path", json!(path)).await?;
+        context.activate_exec_pin("exec_out").await?;
+        Ok(())
+    }
+
+    async fn on_update(&self, node: &mut Node, _board: &Board) {
+        let auth_mode = get_pin_string_value(node, "auth_mode");
+        sync_smb_auth_mode_pins(node, &auth_mode);
+    }
+}
+
+// =============================================================================
 // Shared cache + FlowPath wrapping
 // =============================================================================
+
+fn add_smb_auth_mode_pin(node: &mut Node) {
+    node.add_input_pin(
+        "auth_mode",
+        "Auth Mode",
+        "How to authenticate: 'credentials' (username/password/domain) or 'guest' (anonymous/null session if the server allows it)",
+        VariableType::String,
+    )
+    .set_options(
+        PinOptions::new()
+            .set_valid_values(SMB_AUTH_MODES.iter().map(|mode| mode.to_string()).collect())
+            .build(),
+    )
+    .set_default_value(Some(json!(SMB_CREDENTIALS)));
+}
+
+fn add_smb_username_pin(node: &mut Node) {
+    node.add_input_pin("username", "Username", "SMB username", VariableType::String)
+        .set_default_value(Some(json!("")));
+}
+
+fn add_smb_password_pin(node: &mut Node) {
+    node.add_input_pin("password", "Password", "SMB password", VariableType::String)
+        .set_default_value(Some(json!("")))
+        .set_options(PinOptions::new().set_sensitive(true).build());
+}
+
+fn add_smb_domain_pin(node: &mut Node) {
+    node.add_input_pin(
+        "domain",
+        "Domain",
+        "Optional SMB domain or workgroup",
+        VariableType::String,
+    )
+    .set_default_value(Some(json!("")));
+}
+
+fn add_smb_credential_pins(node: &mut Node) {
+    if node.get_pin_by_name("username").is_none() {
+        add_smb_username_pin(node);
+    }
+    if node.get_pin_by_name("password").is_none() {
+        add_smb_password_pin(node);
+    }
+    if node.get_pin_by_name("domain").is_none() {
+        add_smb_domain_pin(node);
+    }
+}
+
+fn remove_smb_credential_pins(node: &mut Node) {
+    remove_pin_by_name(node, "username");
+    remove_pin_by_name(node, "password");
+    remove_pin_by_name(node, "domain");
+}
+
+fn sync_smb_auth_mode_pins(node: &mut Node, auth_mode: &str) {
+    let mode = if auth_mode.is_empty() {
+        SMB_CREDENTIALS
+    } else {
+        auth_mode
+    };
+    let want_credentials = mode == SMB_CREDENTIALS;
+    let has_credentials = node.get_pin_by_name("username").is_some()
+        || node.get_pin_by_name("password").is_some()
+        || node.get_pin_by_name("domain").is_some();
+
+    if want_credentials {
+        add_smb_credential_pins(node);
+    } else if has_credentials {
+        remove_smb_credential_pins(node);
+    }
+}
+
+fn normalize_smb_address(address: &str) -> flow_like_types::Result<String> {
+    let address = address.trim();
+    if address.is_empty() {
+        return Err(flow_like_types::anyhow!("SMB server address is required"));
+    }
+
+    if address.contains(':') {
+        Ok(address.to_string())
+    } else {
+        Ok(format!("{address}:445"))
+    }
+}
 
 async fn cache_and_wrap(
     context: &mut ExecutionContext,
@@ -659,6 +913,78 @@ mod tests {
     }
 
     #[test]
+    fn test_smb_node_has_connection_pins() {
+        let node = SmbStoreNode::new().get_node();
+        assert_eq!(node.name, "external_smb_store");
+        assert_eq!(node.friendly_name, "SMB Share");
+        for pin in [
+            "address",
+            "share",
+            "prefix",
+            "auth_mode",
+            "username",
+            "password",
+            "domain",
+        ] {
+            let pin = find_pin(&node, pin, PinType::Input).expect("input pin");
+            assert_eq!(pin.data_type, VariableType::String);
+        }
+        assert_eq!(
+            find_pin(&node, "timeout_seconds", PinType::Input)
+                .expect("timeout input")
+                .data_type,
+            VariableType::Integer
+        );
+    }
+
+    #[test]
+    fn test_smb_auth_mode_pin_has_supported_values() {
+        let node = SmbStoreNode::new().get_node();
+        let pin = find_pin(&node, "auth_mode", PinType::Input).expect("auth_mode input");
+        let values = pin
+            .options
+            .as_ref()
+            .and_then(|options| options.valid_values.clone())
+            .expect("auth_mode valid values");
+        assert_eq!(
+            values,
+            vec![SMB_CREDENTIALS.to_string(), SMB_GUEST.to_string()]
+        );
+    }
+
+    #[test]
+    fn test_smb_auth_mode_sync_switches_and_is_idempotent() {
+        let mut node = SmbStoreNode::new().get_node();
+        assert!(node.get_pin_by_name("username").is_some());
+        let username_id = node.get_pin_by_name("username").unwrap().id.clone();
+
+        sync_smb_auth_mode_pins(&mut node, SMB_CREDENTIALS);
+        assert_eq!(
+            username_id,
+            node.get_pin_by_name("username").unwrap().id,
+            "credentials sync should not recreate existing credential pins"
+        );
+
+        sync_smb_auth_mode_pins(&mut node, SMB_GUEST);
+        assert!(node.get_pin_by_name("username").is_none());
+        assert!(node.get_pin_by_name("password").is_none());
+        assert!(node.get_pin_by_name("domain").is_none());
+
+        let pin_count_after_guest = node.pins.len();
+        sync_smb_auth_mode_pins(&mut node, SMB_GUEST);
+        assert_eq!(
+            pin_count_after_guest,
+            node.pins.len(),
+            "guest sync should be stable when repeated"
+        );
+
+        sync_smb_auth_mode_pins(&mut node, SMB_CREDENTIALS);
+        assert!(node.get_pin_by_name("username").is_some());
+        assert!(node.get_pin_by_name("password").is_some());
+        assert!(node.get_pin_by_name("domain").is_some());
+    }
+
+    #[test]
     fn test_all_bucket_nodes_emit_flowpath() {
         for node in [
             S3StoreNode::new().get_node(),
@@ -666,6 +992,7 @@ mod tests {
             AzureBlobStoreNode::new().get_node(),
             GcpStorageStoreNode::new().get_node(),
             CloudflareR2StoreNode::new().get_node(),
+            SmbStoreNode::new().get_node(),
         ] {
             let path = find_pin(&node, "path", PinType::Output).expect("path output");
             assert_eq!(path.data_type, VariableType::Struct);

--- a/packages/storage/Cargo.toml
+++ b/packages/storage/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2024"
 [dependencies]
 flow-like-types.workspace = true
 object_store = {version="0.12.4", features = ["gcp", "aws", "azure", "serde", "serde_json", "cloud"] }
+chrono.workspace = true
+smb2 = "0.11.3"
 # fp16kernels are not supported on Windows (lance skips compiling the C kernels for MSVC)
 lancedb = { version = "=0.27.2", features = ["polars", "remote", "aws", "azure", "gcs"] }
 lance-io = { version = "=4.0.0" }

--- a/packages/storage/src/files/store.rs
+++ b/packages/storage/src/files/store.rs
@@ -12,6 +12,7 @@ use std::{sync::Arc, time::Duration};
 use urlencoding::{decode, encode};
 mod helper;
 pub mod local_store;
+pub mod smb_store;
 
 #[derive(Clone, Serialize, Deserialize, JsonSchema)]
 pub struct StorageItem {

--- a/packages/storage/src/files/store/smb_store.rs
+++ b/packages/storage/src/files/store/smb_store.rs
@@ -6,9 +6,14 @@ use object_store::{
     Attributes, GetOptions, GetResult, GetResultPayload, ListResult, MultipartUpload, ObjectMeta,
     ObjectStore, PutMode, PutMultipartOptions, PutOptions, PutPayload, PutResult, Result,
 };
-use smb2::{ClientConfig, DirectoryEntry, ErrorKind, FileInfo, SmbClient, Tree};
+use smb2::auth::kerberos::ccache::load_ccache;
+use smb2::client::{Cipher, Connection, Session};
+use smb2::{
+    ClientConfig, DirectoryEntry, ErrorKind, FileInfo, KerberosCredentials, SmbClient, Tree,
+};
 use std::collections::HashMap;
 use std::fmt::{Debug, Display};
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -21,10 +26,26 @@ pub struct SmbConfig {
     pub username: String,
     pub password: String,
     pub domain: String,
+    pub auth: SmbAuth,
     pub timeout: Duration,
     pub auto_reconnect: bool,
     pub compression: bool,
     pub dfs_enabled: bool,
+}
+
+#[derive(Clone, Debug)]
+pub enum SmbAuth {
+    Credentials,
+    KerberosCcache(SmbKerberosCcacheConfig),
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct SmbKerberosCcacheConfig {
+    pub username: String,
+    pub realm: String,
+    pub kdc_address: String,
+    pub ccache_path: String,
+    pub server_hostname: String,
 }
 
 impl SmbConfig {
@@ -40,6 +61,7 @@ impl SmbConfig {
             username: username.into(),
             password: password.into(),
             domain: String::new(),
+            auth: SmbAuth::Credentials,
             timeout: Duration::from_secs(5),
             auto_reconnect: false,
             compression: true,
@@ -56,6 +78,7 @@ impl Debug for SmbConfig {
             .field("username", &self.username)
             .field("password", &"[REDACTED]")
             .field("domain", &self.domain)
+            .field("auth", &self.auth)
             .field("timeout", &self.timeout)
             .field("auto_reconnect", &self.auto_reconnect)
             .field("compression", &self.compression)
@@ -64,9 +87,16 @@ impl Debug for SmbConfig {
     }
 }
 
-struct SmbSession {
-    client: SmbClient,
-    tree: Tree,
+enum SmbSession {
+    Client {
+        client: SmbClient,
+        tree: Tree,
+    },
+    Kerberos {
+        conn: Connection,
+        _session: Session,
+        tree: Tree,
+    },
 }
 
 #[derive(Clone)]
@@ -101,37 +131,25 @@ impl SmbObjectStore {
             return Err(generic_error("SMB share is required"));
         }
 
-        let client_config = ClientConfig {
-            addr: config.addr.clone(),
-            timeout: config.timeout,
-            username: config.username.clone(),
-            password: config.password.clone(),
-            domain: config.domain.clone(),
-            auto_reconnect: config.auto_reconnect,
-            compression: config.compression,
-            dfs_enabled: config.dfs_enabled,
-            dfs_target_overrides: HashMap::new(),
-        };
-
-        let mut client = SmbClient::connect(client_config)
-            .await
-            .map_err(|err| map_smb_error(err, format!("//{}", config.addr)))?;
-        let tree = client
-            .connect_share(&config.share)
-            .await
-            .map_err(|err| map_smb_error(err, config.share.clone()))?;
+        let connect_path = format!("//{}/{}", config.addr, config.share);
+        let session = match &config.auth {
+            SmbAuth::Credentials => connect_credentials_session(&config).await,
+            SmbAuth::KerberosCcache(kerberos) => {
+                connect_kerberos_ccache_session(&config, kerberos).await
+            }
+        }
+        .map_err(|err| map_smb_error(err, connect_path))?;
 
         Ok(Self {
             config,
-            session: Arc::new(Mutex::new(SmbSession { client, tree })),
+            session: Arc::new(Mutex::new(session)),
         })
     }
 
     async fn stat_info(&self, path: &str) -> Result<FileInfo> {
         let mut session = self.session.lock().await;
-        let SmbSession { client, tree } = &mut *session;
-        client
-            .stat(tree, path)
+        session
+            .stat(path)
             .await
             .map_err(|err| map_smb_error(err, path.to_string()))
     }
@@ -139,8 +157,7 @@ impl SmbObjectStore {
     async fn ensure_parent_directories(&self, path: &str) -> Result<()> {
         for parent in parent_paths(path) {
             let mut session = self.session.lock().await;
-            let SmbSession { client, tree } = &mut *session;
-            match client.create_directory(tree, &parent).await {
+            match session.create_directory(&parent).await {
                 Ok(_) => {}
                 Err(err) if err.kind() == ErrorKind::AlreadyExists => {}
                 Err(err) => return Err(map_smb_error(err, parent)),
@@ -166,9 +183,8 @@ impl SmbObjectStore {
         while let Some(dir) = dirs.pop() {
             let entries = {
                 let mut session = self.session.lock().await;
-                let SmbSession { client, tree } = &mut *session;
-                client
-                    .list_directory(tree, &dir)
+                session
+                    .list_directory(&dir)
                     .await
                     .map_err(|err| map_smb_error(err, dir.clone()))?
             };
@@ -188,6 +204,183 @@ impl SmbObjectStore {
 
         Ok(objects)
     }
+}
+
+impl SmbSession {
+    async fn stat(&mut self, path: &str) -> smb2::Result<FileInfo> {
+        match self {
+            SmbSession::Client { client, tree } => client.stat(tree, path).await,
+            SmbSession::Kerberos { conn, tree, .. } => tree.stat(conn, path).await,
+        }
+    }
+
+    async fn create_directory(&mut self, path: &str) -> smb2::Result<()> {
+        match self {
+            SmbSession::Client { client, tree } => client.create_directory(tree, path).await,
+            SmbSession::Kerberos { conn, tree, .. } => tree.create_directory(conn, path).await,
+        }
+    }
+
+    async fn list_directory(&mut self, path: &str) -> smb2::Result<Vec<DirectoryEntry>> {
+        match self {
+            SmbSession::Client { client, tree } => client.list_directory(tree, path).await,
+            SmbSession::Kerberos { conn, tree, .. } => tree.list_directory(conn, path).await,
+        }
+    }
+
+    async fn write_file_pipelined(&mut self, path: &str, data: &[u8]) -> smb2::Result<u64> {
+        match self {
+            SmbSession::Client { client, tree } => {
+                client.write_file_pipelined(tree, path, data).await
+            }
+            SmbSession::Kerberos { conn, tree, .. } => {
+                tree.write_file_pipelined(conn, path, data).await
+            }
+        }
+    }
+
+    async fn read_file_pipelined(&mut self, path: &str) -> smb2::Result<Vec<u8>> {
+        match self {
+            SmbSession::Client { client, tree } => client.read_file_pipelined(tree, path).await,
+            SmbSession::Kerberos { conn, tree, .. } => tree.read_file_pipelined(conn, path).await,
+        }
+    }
+
+    async fn delete_directory(&mut self, path: &str) -> smb2::Result<()> {
+        match self {
+            SmbSession::Client { client, tree } => client.delete_directory(tree, path).await,
+            SmbSession::Kerberos { conn, tree, .. } => tree.delete_directory(conn, path).await,
+        }
+    }
+
+    async fn delete_file(&mut self, path: &str) -> smb2::Result<()> {
+        match self {
+            SmbSession::Client { client, tree } => client.delete_file(tree, path).await,
+            SmbSession::Kerberos { conn, tree, .. } => tree.delete_file(conn, path).await,
+        }
+    }
+
+    async fn rename(&mut self, from: &str, to: &str) -> smb2::Result<()> {
+        match self {
+            SmbSession::Client { client, tree } => client.rename(tree, from, to).await,
+            SmbSession::Kerberos { conn, tree, .. } => tree.rename(conn, from, to).await,
+        }
+    }
+}
+
+async fn connect_credentials_session(config: &SmbConfig) -> smb2::Result<SmbSession> {
+    let client_config = ClientConfig {
+        addr: config.addr.clone(),
+        timeout: config.timeout,
+        username: config.username.clone(),
+        password: config.password.clone(),
+        domain: config.domain.clone(),
+        auto_reconnect: config.auto_reconnect,
+        compression: config.compression,
+        dfs_enabled: config.dfs_enabled,
+        dfs_target_overrides: HashMap::new(),
+    };
+
+    let mut client = SmbClient::connect(client_config).await?;
+    let tree = client.connect_share(&config.share).await?;
+
+    Ok(SmbSession::Client { client, tree })
+}
+
+async fn connect_kerberos_ccache_session(
+    config: &SmbConfig,
+    kerberos: &SmbKerberosCcacheConfig,
+) -> smb2::Result<SmbSession> {
+    let ccache_path = kerberos_ccache_path(&kerberos.ccache_path);
+    let ccache = load_ccache(ccache_path.as_deref())?;
+    let username = trimmed_or_default(
+        &kerberos.username,
+        ccache.default_principal.components.first().cloned(),
+        "Kerberos username is required when the ccache default principal has no name component",
+    )?;
+    let realm = trimmed_or_default(
+        &kerberos.realm,
+        Some(ccache.default_principal.realm.clone()),
+        "Kerberos realm is required when the ccache default principal has no realm",
+    )?;
+    let server_hostname = trimmed_or_else(&kerberos.server_hostname, || {
+        host_without_port(&config.addr).to_string()
+    });
+
+    let credentials = KerberosCredentials {
+        username,
+        password: String::new(),
+        realm,
+        kdc_address: kerberos.kdc_address.trim().to_string(),
+    };
+
+    let mut conn = Connection::connect(&config.addr, config.timeout).await?;
+    conn.set_compression_requested(config.compression);
+    conn.negotiate().await?;
+
+    let session =
+        Session::setup_kerberos_from_ccache(&mut conn, &credentials, &server_hostname, &ccache)
+            .await?;
+    let tree = Tree::connect(&mut conn, &config.share).await?;
+    activate_share_encryption(&mut conn, &session, &tree);
+
+    Ok(SmbSession::Kerberos {
+        conn,
+        _session: session,
+        tree,
+    })
+}
+
+fn activate_share_encryption(conn: &mut Connection, session: &Session, tree: &Tree) {
+    if !tree.encrypt_data || conn.should_encrypt() {
+        return;
+    }
+
+    if let (Some(enc_key), Some(dec_key)) = (&session.encryption_key, &session.decryption_key) {
+        let cipher = conn
+            .params()
+            .and_then(|params| params.cipher)
+            .unwrap_or(Cipher::Aes128Ccm);
+        conn.activate_encryption(enc_key.clone(), dec_key.clone(), cipher);
+    }
+}
+
+fn kerberos_ccache_path(path: &str) -> Option<PathBuf> {
+    let path = path.trim();
+    if path.is_empty() {
+        return None;
+    }
+
+    Some(PathBuf::from(path.strip_prefix("FILE:").unwrap_or(path)))
+}
+
+fn trimmed_or_default(
+    value: &str,
+    default: Option<String>,
+    missing_message: &str,
+) -> smb2::Result<String> {
+    let value = trimmed_option(value).or_else(|| default.and_then(|value| trimmed_option(&value)));
+    value.ok_or_else(|| smb2::Error::invalid_data(missing_message))
+}
+
+fn trimmed_or_else(value: &str, default: impl FnOnce() -> String) -> String {
+    trimmed_option(value).unwrap_or_else(default)
+}
+
+fn trimmed_option(value: &str) -> Option<String> {
+    let value = value.trim();
+    if value.is_empty() {
+        None
+    } else {
+        Some(value.to_string())
+    }
+}
+
+fn host_without_port(address: &str) -> &str {
+    address
+        .rsplit_once(':')
+        .map(|(host, _)| host)
+        .unwrap_or(address)
 }
 
 #[async_trait]
@@ -234,9 +427,8 @@ impl ObjectStore for SmbObjectStore {
         let bytes = payload_to_bytes(payload);
         {
             let mut session = self.session.lock().await;
-            let SmbSession { client, tree } = &mut *session;
-            client
-                .write_file_pipelined(tree, &path, &bytes)
+            session
+                .write_file_pipelined(&path, &bytes)
                 .await
                 .map_err(|err| map_smb_error(err, path.clone()))?;
         }
@@ -295,9 +487,8 @@ impl ObjectStore for SmbObjectStore {
 
         let data = {
             let mut session = self.session.lock().await;
-            let SmbSession { client, tree } = &mut *session;
-            client
-                .read_file_pipelined(tree, &path)
+            session
+                .read_file_pipelined(&path)
                 .await
                 .map_err(|err| map_smb_error(err, path.clone()))?
         };
@@ -335,16 +526,15 @@ impl ObjectStore for SmbObjectStore {
         let path = object_path(location);
         let info = self.stat_info(&path).await?;
         let mut session = self.session.lock().await;
-        let SmbSession { client, tree } = &mut *session;
 
         if info.is_directory {
-            client
-                .delete_directory(tree, &path)
+            session
+                .delete_directory(&path)
                 .await
                 .map_err(|err| map_smb_error(err, path))
         } else {
-            client
-                .delete_file(tree, &path)
+            session
+                .delete_file(&path)
                 .await
                 .map_err(|err| map_smb_error(err, path))
         }
@@ -387,9 +577,8 @@ impl ObjectStore for SmbObjectStore {
 
         let entries = {
             let mut session = self.session.lock().await;
-            let SmbSession { client, tree } = &mut *session;
-            client
-                .list_directory(tree, &prefix)
+            session
+                .list_directory(&prefix)
                 .await
                 .map_err(|err| map_smb_error(err, prefix.clone()))?
         };
@@ -432,9 +621,8 @@ impl ObjectStore for SmbObjectStore {
         self.ensure_parent_directories(&to_path).await?;
 
         let mut session = self.session.lock().await;
-        let SmbSession { client, tree } = &mut *session;
-        client
-            .rename(tree, &from_path, &to_path)
+        session
+            .rename(&from_path, &to_path)
             .await
             .map_err(|err| map_smb_error(err, from_path))
     }
@@ -472,9 +660,8 @@ impl ObjectStore for SmbObjectStore {
         let from_path = object_path(from);
         let to_path = object_path(to);
         let mut session = self.session.lock().await;
-        let SmbSession { client, tree } = &mut *session;
-        client
-            .rename(tree, &from_path, &to_path)
+        session
+            .rename(&from_path, &to_path)
             .await
             .map_err(|err| map_smb_error(err, from_path))
     }

--- a/packages/storage/src/files/store/smb_store.rs
+++ b/packages/storage/src/files/store/smb_store.rs
@@ -1,0 +1,657 @@
+use chrono::{DateTime, Utc};
+use flow_like_types::{Bytes, async_trait, sync::Mutex};
+use futures::{StreamExt, stream};
+use object_store::path::Path;
+use object_store::{
+    Attributes, GetOptions, GetResult, GetResultPayload, ListResult, MultipartUpload, ObjectMeta,
+    ObjectStore, PutMode, PutMultipartOptions, PutOptions, PutPayload, PutResult, Result,
+};
+use smb2::{ClientConfig, DirectoryEntry, ErrorKind, FileInfo, SmbClient, Tree};
+use std::collections::HashMap;
+use std::fmt::{Debug, Display};
+use std::sync::Arc;
+use std::time::Duration;
+
+const STORE_NAME: &str = "SMB";
+
+#[derive(Clone)]
+pub struct SmbConfig {
+    pub addr: String,
+    pub share: String,
+    pub username: String,
+    pub password: String,
+    pub domain: String,
+    pub timeout: Duration,
+    pub auto_reconnect: bool,
+    pub compression: bool,
+    pub dfs_enabled: bool,
+}
+
+impl SmbConfig {
+    pub fn new(
+        addr: impl Into<String>,
+        share: impl Into<String>,
+        username: impl Into<String>,
+        password: impl Into<String>,
+    ) -> Self {
+        Self {
+            addr: addr.into(),
+            share: share.into(),
+            username: username.into(),
+            password: password.into(),
+            domain: String::new(),
+            timeout: Duration::from_secs(5),
+            auto_reconnect: false,
+            compression: true,
+            dfs_enabled: true,
+        }
+    }
+}
+
+impl Debug for SmbConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SmbConfig")
+            .field("addr", &self.addr)
+            .field("share", &self.share)
+            .field("username", &self.username)
+            .field("password", &"[REDACTED]")
+            .field("domain", &self.domain)
+            .field("timeout", &self.timeout)
+            .field("auto_reconnect", &self.auto_reconnect)
+            .field("compression", &self.compression)
+            .field("dfs_enabled", &self.dfs_enabled)
+            .finish()
+    }
+}
+
+struct SmbSession {
+    client: SmbClient,
+    tree: Tree,
+}
+
+#[derive(Clone)]
+pub struct SmbObjectStore {
+    config: SmbConfig,
+    session: Arc<Mutex<SmbSession>>,
+}
+
+impl Debug for SmbObjectStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SmbObjectStore")
+            .field("addr", &self.config.addr)
+            .field("share", &self.config.share)
+            .field("username", &self.config.username)
+            .field("domain", &self.config.domain)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Display for SmbObjectStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SMB({}/{})", self.config.addr, self.config.share)
+    }
+}
+
+impl SmbObjectStore {
+    pub async fn connect(config: SmbConfig) -> Result<Self> {
+        if config.addr.trim().is_empty() {
+            return Err(generic_error("SMB address is required"));
+        }
+        if config.share.trim().is_empty() {
+            return Err(generic_error("SMB share is required"));
+        }
+
+        let client_config = ClientConfig {
+            addr: config.addr.clone(),
+            timeout: config.timeout,
+            username: config.username.clone(),
+            password: config.password.clone(),
+            domain: config.domain.clone(),
+            auto_reconnect: config.auto_reconnect,
+            compression: config.compression,
+            dfs_enabled: config.dfs_enabled,
+            dfs_target_overrides: HashMap::new(),
+        };
+
+        let mut client = SmbClient::connect(client_config)
+            .await
+            .map_err(|err| map_smb_error(err, format!("//{}", config.addr)))?;
+        let tree = client
+            .connect_share(&config.share)
+            .await
+            .map_err(|err| map_smb_error(err, config.share.clone()))?;
+
+        Ok(Self {
+            config,
+            session: Arc::new(Mutex::new(SmbSession { client, tree })),
+        })
+    }
+
+    async fn stat_info(&self, path: &str) -> Result<FileInfo> {
+        let mut session = self.session.lock().await;
+        let SmbSession { client, tree } = &mut *session;
+        client
+            .stat(tree, path)
+            .await
+            .map_err(|err| map_smb_error(err, path.to_string()))
+    }
+
+    async fn ensure_parent_directories(&self, path: &str) -> Result<()> {
+        for parent in parent_paths(path) {
+            let mut session = self.session.lock().await;
+            let SmbSession { client, tree } = &mut *session;
+            match client.create_directory(tree, &parent).await {
+                Ok(_) => {}
+                Err(err) if err.kind() == ErrorKind::AlreadyExists => {}
+                Err(err) => return Err(map_smb_error(err, parent)),
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn list_recursive_from(&self, prefix: &str) -> Result<Vec<ObjectMeta>> {
+        if !prefix.is_empty() {
+            match self.stat_info(prefix).await {
+                Ok(info) if !info.is_directory => return Ok(vec![meta_from_info(prefix, &info)]),
+                Ok(_) => {}
+                Err(object_store::Error::NotFound { .. }) => return Ok(Vec::new()),
+                Err(err) => return Err(err),
+            }
+        }
+
+        let mut objects = Vec::new();
+        let mut dirs = vec![prefix.to_string()];
+
+        while let Some(dir) = dirs.pop() {
+            let entries = {
+                let mut session = self.session.lock().await;
+                let SmbSession { client, tree } = &mut *session;
+                client
+                    .list_directory(tree, &dir)
+                    .await
+                    .map_err(|err| map_smb_error(err, dir.clone()))?
+            };
+
+            for entry in entries
+                .into_iter()
+                .filter(|entry| is_real_entry(&entry.name))
+            {
+                let path = join_path(&dir, &entry.name);
+                if entry.is_directory {
+                    dirs.push(path);
+                } else {
+                    objects.push(meta_from_entry(&path, &entry));
+                }
+            }
+        }
+
+        Ok(objects)
+    }
+}
+
+#[async_trait]
+impl ObjectStore for SmbObjectStore {
+    async fn put_opts(
+        &self,
+        location: &Path,
+        payload: PutPayload,
+        opts: PutOptions,
+    ) -> Result<PutResult> {
+        reject_attributes(&opts.attributes)?;
+        let path = object_path(location);
+
+        match &opts.mode {
+            PutMode::Overwrite => {}
+            PutMode::Create => match self.stat_info(&path).await {
+                Ok(_) => {
+                    return Err(object_store::Error::AlreadyExists {
+                        path,
+                        source: "SMB path already exists".into(),
+                    });
+                }
+                Err(object_store::Error::NotFound { .. }) => {}
+                Err(err) => return Err(err),
+            },
+            PutMode::Update(expected) => {
+                let current = self.head(location).await?;
+                if expected.e_tag.is_some() && current.e_tag != expected.e_tag {
+                    return Err(object_store::Error::Precondition {
+                        path,
+                        source: "SMB object ETag did not match update precondition".into(),
+                    });
+                }
+                if expected.version.is_some() && current.version != expected.version {
+                    return Err(object_store::Error::Precondition {
+                        path,
+                        source: "SMB object version did not match update precondition".into(),
+                    });
+                }
+            }
+        }
+
+        self.ensure_parent_directories(&path).await?;
+        let bytes = payload_to_bytes(payload);
+        {
+            let mut session = self.session.lock().await;
+            let SmbSession { client, tree } = &mut *session;
+            client
+                .write_file_pipelined(tree, &path, &bytes)
+                .await
+                .map_err(|err| map_smb_error(err, path.clone()))?;
+        }
+
+        let e_tag = self.head(location).await.ok().and_then(|meta| meta.e_tag);
+        Ok(PutResult {
+            e_tag,
+            version: None,
+        })
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        location: &Path,
+        opts: PutMultipartOptions,
+    ) -> Result<Box<dyn MultipartUpload>> {
+        reject_attributes(&opts.attributes)?;
+        Ok(Box::new(SmbMultipartUpload {
+            store: self.clone(),
+            location: location.clone(),
+            parts: Vec::new(),
+        }))
+    }
+
+    async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {
+        if let Some(version) = &options.version {
+            return Err(object_store::Error::NotSupported {
+                source: format!("SMB object versions are not supported: {version}").into(),
+            });
+        }
+
+        let path = object_path(location);
+        let meta = self.head(location).await?;
+        options.check_preconditions(&meta)?;
+
+        let range = match &options.range {
+            Some(range) => {
+                range
+                    .as_range(meta.size)
+                    .map_err(|err| object_store::Error::Generic {
+                        store: STORE_NAME,
+                        source: Box::new(err),
+                    })?
+            }
+            None => 0..meta.size,
+        };
+
+        if options.head {
+            return Ok(GetResult {
+                payload: GetResultPayload::Stream(stream::empty().boxed()),
+                meta,
+                range: 0..0,
+                attributes: Attributes::default(),
+            });
+        }
+
+        let data = {
+            let mut session = self.session.lock().await;
+            let SmbSession { client, tree } = &mut *session;
+            client
+                .read_file_pipelined(tree, &path)
+                .await
+                .map_err(|err| map_smb_error(err, path.clone()))?
+        };
+
+        let bytes = Bytes::from(data);
+        let start = usize::try_from(range.start).map_err(|_| range_error(&path))?;
+        let end = usize::try_from(range.end).map_err(|_| range_error(&path))?;
+        if start > bytes.len() || end > bytes.len() || start > end {
+            return Err(range_error(&path));
+        }
+        let bytes = bytes.slice(start..end);
+
+        Ok(GetResult {
+            payload: GetResultPayload::Stream(stream::once(async move { Ok(bytes) }).boxed()),
+            meta,
+            range,
+            attributes: Attributes::default(),
+        })
+    }
+
+    async fn head(&self, location: &Path) -> Result<ObjectMeta> {
+        let path = object_path(location);
+        let info = self.stat_info(&path).await?;
+        if info.is_directory {
+            return Err(object_store::Error::NotFound {
+                path,
+                source: "SMB path is a directory".into(),
+            });
+        }
+
+        Ok(meta_from_info(location.as_ref(), &info))
+    }
+
+    async fn delete(&self, location: &Path) -> Result<()> {
+        let path = object_path(location);
+        let info = self.stat_info(&path).await?;
+        let mut session = self.session.lock().await;
+        let SmbSession { client, tree } = &mut *session;
+
+        if info.is_directory {
+            client
+                .delete_directory(tree, &path)
+                .await
+                .map_err(|err| map_smb_error(err, path))
+        } else {
+            client
+                .delete_file(tree, &path)
+                .await
+                .map_err(|err| map_smb_error(err, path))
+        }
+    }
+
+    fn list(
+        &self,
+        prefix: Option<&Path>,
+    ) -> futures::stream::BoxStream<'static, Result<ObjectMeta>> {
+        let store = self.clone();
+        let prefix = prefix.map(object_path).unwrap_or_default();
+        stream::once(async move { store.list_recursive_from(&prefix).await })
+            .flat_map(|result| match result {
+                Ok(objects) => stream::iter(objects.into_iter().map(Ok)).boxed(),
+                Err(err) => stream::iter(vec![Err(err)]).boxed(),
+            })
+            .boxed()
+    }
+
+    async fn list_with_delimiter(&self, prefix: Option<&Path>) -> Result<ListResult> {
+        let prefix = prefix.map(object_path).unwrap_or_default();
+        if !prefix.is_empty() {
+            match self.stat_info(&prefix).await {
+                Ok(info) if !info.is_directory => {
+                    return Ok(ListResult {
+                        common_prefixes: Vec::new(),
+                        objects: vec![meta_from_info(&prefix, &info)],
+                    });
+                }
+                Ok(_) => {}
+                Err(object_store::Error::NotFound { .. }) => {
+                    return Ok(ListResult {
+                        common_prefixes: Vec::new(),
+                        objects: Vec::new(),
+                    });
+                }
+                Err(err) => return Err(err),
+            }
+        }
+
+        let entries = {
+            let mut session = self.session.lock().await;
+            let SmbSession { client, tree } = &mut *session;
+            client
+                .list_directory(tree, &prefix)
+                .await
+                .map_err(|err| map_smb_error(err, prefix.clone()))?
+        };
+
+        let mut common_prefixes = Vec::new();
+        let mut objects = Vec::new();
+
+        for entry in entries
+            .into_iter()
+            .filter(|entry| is_real_entry(&entry.name))
+        {
+            let path = join_path(&prefix, &entry.name);
+            if entry.is_directory {
+                common_prefixes.push(Path::from(path));
+            } else {
+                objects.push(meta_from_entry(&path, &entry));
+            }
+        }
+
+        Ok(ListResult {
+            common_prefixes,
+            objects,
+        })
+    }
+
+    async fn copy(&self, from: &Path, to: &Path) -> Result<()> {
+        let bytes = self.get(from).await?.bytes().await?;
+        self.put(to, PutPayload::from_bytes(bytes)).await?;
+        Ok(())
+    }
+
+    async fn rename(&self, from: &Path, to: &Path) -> Result<()> {
+        let from_path = object_path(from);
+        let to_path = object_path(to);
+
+        match self.delete(to).await {
+            Ok(_) | Err(object_store::Error::NotFound { .. }) => {}
+            Err(err) => return Err(err),
+        }
+        self.ensure_parent_directories(&to_path).await?;
+
+        let mut session = self.session.lock().await;
+        let SmbSession { client, tree } = &mut *session;
+        client
+            .rename(tree, &from_path, &to_path)
+            .await
+            .map_err(|err| map_smb_error(err, from_path))
+    }
+
+    async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> Result<()> {
+        let to_path = object_path(to);
+        match self.stat_info(&to_path).await {
+            Ok(_) => {
+                return Err(object_store::Error::AlreadyExists {
+                    path: to_path,
+                    source: "SMB path already exists".into(),
+                });
+            }
+            Err(object_store::Error::NotFound { .. }) => {}
+            Err(err) => return Err(err),
+        }
+
+        self.copy(from, to).await
+    }
+
+    async fn rename_if_not_exists(&self, from: &Path, to: &Path) -> Result<()> {
+        let to_path = object_path(to);
+        match self.stat_info(&to_path).await {
+            Ok(_) => {
+                return Err(object_store::Error::AlreadyExists {
+                    path: to_path,
+                    source: "SMB path already exists".into(),
+                });
+            }
+            Err(object_store::Error::NotFound { .. }) => {}
+            Err(err) => return Err(err),
+        }
+
+        self.ensure_parent_directories(&object_path(to)).await?;
+        let from_path = object_path(from);
+        let to_path = object_path(to);
+        let mut session = self.session.lock().await;
+        let SmbSession { client, tree } = &mut *session;
+        client
+            .rename(tree, &from_path, &to_path)
+            .await
+            .map_err(|err| map_smb_error(err, from_path))
+    }
+}
+
+#[derive(Debug)]
+struct SmbMultipartUpload {
+    store: SmbObjectStore,
+    location: Path,
+    parts: Vec<PutPayload>,
+}
+
+#[async_trait]
+impl MultipartUpload for SmbMultipartUpload {
+    fn put_part(&mut self, data: PutPayload) -> object_store::UploadPart {
+        self.parts.push(data);
+        Box::pin(async { Ok(()) })
+    }
+
+    async fn complete(&mut self) -> Result<PutResult> {
+        let mut data = Vec::with_capacity(self.parts.iter().map(PutPayload::content_length).sum());
+        for payload in self.parts.drain(..) {
+            for chunk in payload {
+                data.extend_from_slice(&chunk);
+            }
+        }
+
+        self.store
+            .put(&self.location, PutPayload::from_bytes(Bytes::from(data)))
+            .await
+    }
+
+    async fn abort(&mut self) -> Result<()> {
+        self.parts.clear();
+        Ok(())
+    }
+}
+
+fn object_path(location: &Path) -> String {
+    location
+        .as_ref()
+        .replace('\\', "/")
+        .trim_matches('/')
+        .to_string()
+}
+
+fn parent_paths(path: &str) -> Vec<String> {
+    let mut current = String::new();
+    let mut parents = Vec::new();
+    let mut parts = path.split('/').filter(|part| !part.is_empty()).peekable();
+
+    while let Some(part) = parts.next() {
+        if parts.peek().is_none() {
+            break;
+        }
+        if !current.is_empty() {
+            current.push('/');
+        }
+        current.push_str(part);
+        parents.push(current.clone());
+    }
+
+    parents
+}
+
+fn join_path(parent: &str, child: &str) -> String {
+    let parent = parent.trim_matches('/');
+    let child = child.trim_matches('/');
+    if parent.is_empty() {
+        child.to_string()
+    } else if child.is_empty() {
+        parent.to_string()
+    } else {
+        format!("{parent}/{child}")
+    }
+}
+
+fn is_real_entry(name: &str) -> bool {
+    name != "." && name != ".." && !name.is_empty()
+}
+
+fn meta_from_info(path: &str, info: &FileInfo) -> ObjectMeta {
+    let last_modified = info
+        .modified
+        .to_system_time()
+        .map(DateTime::<Utc>::from)
+        .unwrap_or_else(Utc::now);
+    ObjectMeta {
+        location: Path::from(path),
+        last_modified,
+        size: info.size,
+        e_tag: Some(etag(info.size, last_modified)),
+        version: None,
+    }
+}
+
+fn meta_from_entry(path: &str, entry: &DirectoryEntry) -> ObjectMeta {
+    let last_modified = entry
+        .modified
+        .to_system_time()
+        .map(DateTime::<Utc>::from)
+        .unwrap_or_else(Utc::now);
+    ObjectMeta {
+        location: Path::from(path),
+        last_modified,
+        size: entry.size,
+        e_tag: Some(etag(entry.size, last_modified)),
+        version: None,
+    }
+}
+
+fn etag(size: u64, modified: DateTime<Utc>) -> String {
+    let modified = modified
+        .timestamp_nanos_opt()
+        .unwrap_or_else(|| modified.timestamp_millis() * 1_000_000);
+    format!("{size:x}-{modified:x}")
+}
+
+fn payload_to_bytes(payload: PutPayload) -> Bytes {
+    if payload.as_ref().len() == 1 {
+        return payload.into_iter().next().unwrap_or_else(Bytes::new);
+    }
+
+    let mut data = Vec::with_capacity(payload.content_length());
+    for chunk in payload {
+        data.extend_from_slice(&chunk);
+    }
+    Bytes::from(data)
+}
+
+fn reject_attributes(attributes: &Attributes) -> Result<()> {
+    if attributes.is_empty() {
+        return Ok(());
+    }
+
+    Err(object_store::Error::NotSupported {
+        source: "SMB object store does not support object attributes".into(),
+    })
+}
+
+fn map_smb_error(err: smb2::Error, path: String) -> object_store::Error {
+    match err.kind() {
+        ErrorKind::NotFound => object_store::Error::NotFound {
+            path,
+            source: Box::new(err),
+        },
+        ErrorKind::AlreadyExists => object_store::Error::AlreadyExists {
+            path,
+            source: Box::new(err),
+        },
+        ErrorKind::AccessDenied => object_store::Error::PermissionDenied {
+            path,
+            source: Box::new(err),
+        },
+        ErrorKind::AuthRequired | ErrorKind::SigningRequired => {
+            object_store::Error::Unauthenticated {
+                path,
+                source: Box::new(err),
+            }
+        }
+        _ => object_store::Error::Generic {
+            store: STORE_NAME,
+            source: Box::new(err),
+        },
+    }
+}
+
+fn generic_error(message: impl Into<String>) -> object_store::Error {
+    object_store::Error::Generic {
+        store: STORE_NAME,
+        source: message.into().into(),
+    }
+}
+
+fn range_error(path: &str) -> object_store::Error {
+    object_store::Error::Generic {
+        store: STORE_NAME,
+        source: format!("Invalid SMB object range for {path}").into(),
+    }
+}


### PR DESCRIPTION
This pull request adds support for SMB (Server Message Block) storage to the storage package, along with some dependency updates to enable this functionality. The main changes are the introduction of a new module for SMB storage and the addition of relevant dependencies.

New SMB storage support:

* Added the `smb2` crate as a dependency in `Cargo.toml` to enable interaction with SMB shares.
* Introduced a new module, `smb_store`, in `packages/storage/src/files/store.rs` for handling SMB storage operations.

Dependency updates:

* Added the `chrono` crate as a workspace dependency in `Cargo.toml`, likely for date and time handling in the new or existing modules.