### PR TITLE
feat: enhance SMB address normalization and add related utility funct…

### DIFF
--- a/packages/catalog/data/src/data/datafusion/external_stores.rs
+++ b/packages/catalog/data/src/data/datafusion/external_stores.rs
@@ -936,11 +936,51 @@ fn normalize_smb_address(address: &str) -> flow_like_types::Result<String> {
         return Err(flow_like_types::anyhow!("SMB server address is required"));
     }
 
-    if address.contains(':') {
+    if smb_address_has_port(address)? {
         Ok(address.to_string())
+    } else if address.contains(':') && !address.starts_with('[') {
+        Ok(format!("[{address}]:445"))
     } else {
         Ok(format!("{address}:445"))
     }
+}
+
+fn smb_address_has_port(address: &str) -> flow_like_types::Result<bool> {
+    if address.starts_with('[') {
+        let Some((_, suffix)) = address.rsplit_once(']') else {
+            return Err(flow_like_types::anyhow!(
+                "Invalid bracketed IPv6 SMB address: missing closing ']'"
+            ));
+        };
+        if suffix.is_empty() {
+            return Ok(false);
+        }
+        let Some(port) = suffix.strip_prefix(':') else {
+            return Err(flow_like_types::anyhow!(
+                "Invalid bracketed IPv6 SMB address suffix: '{}'",
+                suffix
+            ));
+        };
+        return parse_smb_port(port).map(|_| true);
+    }
+
+    let colon_count = address.chars().filter(|&c| c == ':').count();
+    if colon_count == 0 {
+        return Ok(false);
+    }
+    if colon_count > 1 {
+        return Ok(false);
+    }
+
+    let Some((_, port)) = address.rsplit_once(':') else {
+        return Ok(false);
+    };
+    parse_smb_port(port).map(|_| true)
+}
+
+fn parse_smb_port(port: &str) -> flow_like_types::Result<u16> {
+    port.parse::<u16>()
+        .map_err(|_| flow_like_types::anyhow!("Invalid SMB port: '{}'", port))
 }
 
 async fn cache_and_wrap(
@@ -1154,6 +1194,29 @@ mod tests {
         assert!(node.get_pin_by_name("kerberos_kdc_address").is_none());
         assert!(node.get_pin_by_name("kerberos_ccache_path").is_none());
         assert!(node.get_pin_by_name("kerberos_spn_host").is_none());
+    }
+
+    #[test]
+    fn test_normalize_smb_address_handles_ipv4_hostnames_and_ipv6() {
+        assert_eq!(
+            normalize_smb_address("10.50.0.33").unwrap(),
+            "10.50.0.33:445"
+        );
+        assert_eq!(
+            normalize_smb_address("fileserver:1445").unwrap(),
+            "fileserver:1445"
+        );
+        assert_eq!(normalize_smb_address("fe80::1").unwrap(), "[fe80::1]:445");
+        assert_eq!(normalize_smb_address("[::1]").unwrap(), "[::1]:445");
+        assert_eq!(normalize_smb_address("[::1]:1445").unwrap(), "[::1]:1445");
+    }
+
+    #[test]
+    fn test_normalize_smb_address_rejects_invalid_ports() {
+        assert!(normalize_smb_address("").is_err());
+        assert!(normalize_smb_address("fileserver:notaport").is_err());
+        assert!(normalize_smb_address("[::1]:notaport").is_err());
+        assert!(normalize_smb_address("[::1").is_err());
     }
 
     #[test]

--- a/packages/catalog/data/src/data/datafusion/external_stores.rs
+++ b/packages/catalog/data/src/data/datafusion/external_stores.rs
@@ -947,11 +947,15 @@ fn normalize_smb_address(address: &str) -> flow_like_types::Result<String> {
 
 fn smb_address_has_port(address: &str) -> flow_like_types::Result<bool> {
     if address.starts_with('[') {
-        let Some((_, suffix)) = address.rsplit_once(']') else {
+        let Some((host, suffix)) = address.rsplit_once(']') else {
             return Err(flow_like_types::anyhow!(
                 "Invalid bracketed IPv6 SMB address: missing closing ']'"
             ));
         };
+        let host = host.trim_start_matches('[').trim();
+        if host.is_empty() {
+            return Err(flow_like_types::anyhow!("SMB server host is required"));
+        }
         if suffix.is_empty() {
             return Ok(false);
         }
@@ -972,15 +976,23 @@ fn smb_address_has_port(address: &str) -> flow_like_types::Result<bool> {
         return Ok(false);
     }
 
-    let Some((_, port)) = address.rsplit_once(':') else {
+    let Some((host, port)) = address.rsplit_once(':') else {
         return Ok(false);
     };
+    if host.trim().is_empty() {
+        return Err(flow_like_types::anyhow!("SMB server host is required"));
+    }
     parse_smb_port(port).map(|_| true)
 }
 
 fn parse_smb_port(port: &str) -> flow_like_types::Result<u16> {
-    port.parse::<u16>()
-        .map_err(|_| flow_like_types::anyhow!("Invalid SMB port: '{}'", port))
+    let port = port
+        .parse::<u16>()
+        .map_err(|_| flow_like_types::anyhow!("Invalid SMB port: '{}'", port))?;
+    if port == 0 {
+        return Err(flow_like_types::anyhow!("Invalid SMB port: '0'"));
+    }
+    Ok(port)
 }
 
 async fn cache_and_wrap(
@@ -1214,8 +1226,12 @@ mod tests {
     #[test]
     fn test_normalize_smb_address_rejects_invalid_ports() {
         assert!(normalize_smb_address("").is_err());
+        assert!(normalize_smb_address(":445").is_err());
+        assert!(normalize_smb_address("[]:445").is_err());
         assert!(normalize_smb_address("fileserver:notaport").is_err());
+        assert!(normalize_smb_address("fileserver:0").is_err());
         assert!(normalize_smb_address("[::1]:notaport").is_err());
+        assert!(normalize_smb_address("[::1]:0").is_err());
         assert!(normalize_smb_address("[::1").is_err());
     }
 

--- a/packages/catalog/data/src/data/datafusion/external_stores.rs
+++ b/packages/catalog/data/src/data/datafusion/external_stores.rs
@@ -936,8 +936,19 @@ fn normalize_smb_address(address: &str) -> flow_like_types::Result<String> {
         return Err(flow_like_types::anyhow!("SMB server address is required"));
     }
 
-    if smb_address_has_port(address)? {
-        Ok(address.to_string())
+    if let Some(port) = smb_address_port(address)? {
+        if address.starts_with('[') {
+            let (host, _) = split_bracketed_smb_address(address)?;
+            Ok(format!("[{host}]:{port}"))
+        } else {
+            let (host, _) = address.rsplit_once(':').ok_or_else(|| {
+                flow_like_types::anyhow!("Invalid SMB server address: '{}'", address)
+            })?;
+            Ok(format!("{}:{port}", host.trim()))
+        }
+    } else if address.starts_with('[') {
+        let (host, _) = split_bracketed_smb_address(address)?;
+        Ok(format!("[{host}]:445"))
     } else if address.contains(':') && !address.starts_with('[') {
         Ok(format!("[{address}]:445"))
     } else {
@@ -945,19 +956,11 @@ fn normalize_smb_address(address: &str) -> flow_like_types::Result<String> {
     }
 }
 
-fn smb_address_has_port(address: &str) -> flow_like_types::Result<bool> {
+fn smb_address_port(address: &str) -> flow_like_types::Result<Option<u16>> {
     if address.starts_with('[') {
-        let Some((host, suffix)) = address.rsplit_once(']') else {
-            return Err(flow_like_types::anyhow!(
-                "Invalid bracketed IPv6 SMB address: missing closing ']'"
-            ));
-        };
-        let host = host.trim_start_matches('[').trim();
-        if host.is_empty() {
-            return Err(flow_like_types::anyhow!("SMB server host is required"));
-        }
+        let (_, suffix) = split_bracketed_smb_address(address)?;
         if suffix.is_empty() {
-            return Ok(false);
+            return Ok(None);
         }
         let Some(port) = suffix.strip_prefix(':') else {
             return Err(flow_like_types::anyhow!(
@@ -965,27 +968,41 @@ fn smb_address_has_port(address: &str) -> flow_like_types::Result<bool> {
                 suffix
             ));
         };
-        return parse_smb_port(port).map(|_| true);
+        return parse_smb_port(port).map(Some);
     }
 
     let colon_count = address.chars().filter(|&c| c == ':').count();
     if colon_count == 0 {
-        return Ok(false);
+        return Ok(None);
     }
     if colon_count > 1 {
-        return Ok(false);
+        return Ok(None);
     }
 
     let Some((host, port)) = address.rsplit_once(':') else {
-        return Ok(false);
+        return Ok(None);
     };
     if host.trim().is_empty() {
         return Err(flow_like_types::anyhow!("SMB server host is required"));
     }
-    parse_smb_port(port).map(|_| true)
+    parse_smb_port(port).map(Some)
+}
+
+fn split_bracketed_smb_address(address: &str) -> flow_like_types::Result<(&str, &str)> {
+    let Some((host, suffix)) = address.rsplit_once(']') else {
+        return Err(flow_like_types::anyhow!(
+            "Invalid bracketed IPv6 SMB address: missing closing ']'"
+        ));
+    };
+    let host = host.trim_start_matches('[').trim();
+    if host.is_empty() {
+        return Err(flow_like_types::anyhow!("SMB server host is required"));
+    }
+    Ok((host, suffix.trim()))
 }
 
 fn parse_smb_port(port: &str) -> flow_like_types::Result<u16> {
+    let port = port.trim();
     let port = port
         .parse::<u16>()
         .map_err(|_| flow_like_types::anyhow!("Invalid SMB port: '{}'", port))?;
@@ -1218,9 +1235,14 @@ mod tests {
             normalize_smb_address("fileserver:1445").unwrap(),
             "fileserver:1445"
         );
+        assert_eq!(
+            normalize_smb_address("fileserver: 1445").unwrap(),
+            "fileserver:1445"
+        );
         assert_eq!(normalize_smb_address("fe80::1").unwrap(), "[fe80::1]:445");
         assert_eq!(normalize_smb_address("[::1]").unwrap(), "[::1]:445");
         assert_eq!(normalize_smb_address("[::1]:1445").unwrap(), "[::1]:1445");
+        assert_eq!(normalize_smb_address("[::1] :1445").unwrap(), "[::1]:1445");
     }
 
     #[test]

--- a/packages/storage/src/files/store/smb_store.rs
+++ b/packages/storage/src/files/store/smb_store.rs
@@ -395,10 +395,10 @@ fn trimmed_option(value: &str) -> Option<String> {
 }
 
 fn host_without_port(address: &str) -> &str {
-    if let Some(rest) = address.strip_prefix('[')
-        && let Some((host, _)) = rest.split_once(']')
-    {
-        return host;
+    if let Some(rest) = address.strip_prefix('[') {
+        if let Some((host, _)) = rest.split_once(']') {
+            return host;
+        }
     }
 
     if address.chars().filter(|&c| c == ':').count() != 1 {

--- a/packages/storage/src/files/store/smb_store.rs
+++ b/packages/storage/src/files/store/smb_store.rs
@@ -396,8 +396,12 @@ fn trimmed_option(value: &str) -> Option<String> {
 
 fn host_without_port(address: &str) -> &str {
     if let Some(rest) = address.strip_prefix('[') {
-        if let Some((host, _)) = rest.split_once(']') {
-            return host;
+        if let Some((host, suffix)) = rest.split_once(']') {
+            let host = host.trim();
+            let suffix = suffix.trim();
+            if !host.is_empty() && (suffix.is_empty() || suffix.starts_with(':')) {
+                return host;
+            }
         }
     }
 
@@ -851,6 +855,10 @@ mod tests {
     fn test_host_without_port_handles_ipv6() {
         assert_eq!(host_without_port("server:445"), "server");
         assert_eq!(host_without_port("[::1]:445"), "::1");
+        assert_eq!(host_without_port("[ ::1 ] :445"), "::1");
+        assert_eq!(host_without_port("[]:445"), "[]");
+        assert_eq!(host_without_port("[ ]:445"), "[ ]");
+        assert_eq!(host_without_port("[server]suffix:445"), "[server]suffix");
         assert_eq!(host_without_port("fe80::1"), "fe80::1");
     }
 

--- a/packages/storage/src/files/store/smb_store.rs
+++ b/packages/storage/src/files/store/smb_store.rs
@@ -15,7 +15,7 @@ use std::collections::HashMap;
 use std::fmt::{Debug, Display};
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, UNIX_EPOCH};
 
 const STORE_NAME: &str = "SMB";
 
@@ -208,62 +208,80 @@ impl SmbObjectStore {
 
 impl SmbSession {
     async fn stat(&mut self, path: &str) -> smb2::Result<FileInfo> {
+        let path = to_smb_path(path);
         match self {
-            SmbSession::Client { client, tree } => client.stat(tree, path).await,
-            SmbSession::Kerberos { conn, tree, .. } => tree.stat(conn, path).await,
+            SmbSession::Client { client, tree } => client.stat(tree, &path).await,
+            SmbSession::Kerberos { conn, tree, .. } => tree.stat(conn, &path).await,
         }
     }
 
     async fn create_directory(&mut self, path: &str) -> smb2::Result<()> {
+        let path = to_smb_path(path);
         match self {
-            SmbSession::Client { client, tree } => client.create_directory(tree, path).await,
-            SmbSession::Kerberos { conn, tree, .. } => tree.create_directory(conn, path).await,
+            SmbSession::Client { client, tree } => client.create_directory(tree, &path).await,
+            SmbSession::Kerberos { conn, tree, .. } => tree.create_directory(conn, &path).await,
         }
     }
 
     async fn list_directory(&mut self, path: &str) -> smb2::Result<Vec<DirectoryEntry>> {
+        let path = to_smb_path(path);
         match self {
-            SmbSession::Client { client, tree } => client.list_directory(tree, path).await,
-            SmbSession::Kerberos { conn, tree, .. } => tree.list_directory(conn, path).await,
+            SmbSession::Client { client, tree } => client.list_directory(tree, &path).await,
+            SmbSession::Kerberos { conn, tree, .. } => tree.list_directory(conn, &path).await,
         }
     }
 
-    async fn write_file_pipelined(&mut self, path: &str, data: &[u8]) -> smb2::Result<u64> {
+    async fn write_payload_streamed(
+        &mut self,
+        path: &str,
+        payload: PutPayload,
+    ) -> smb2::Result<u64> {
+        let path = to_smb_path(path);
+        let mut chunks = payload.into_iter();
+        let mut next_chunk = || chunks.next().map(|chunk| Ok(chunk.to_vec()));
+
         match self {
             SmbSession::Client { client, tree } => {
-                client.write_file_pipelined(tree, path, data).await
+                client
+                    .write_file_streamed(tree, &path, &mut next_chunk)
+                    .await
             }
             SmbSession::Kerberos { conn, tree, .. } => {
-                tree.write_file_pipelined(conn, path, data).await
+                tree.write_file_streamed(conn, &path, &mut next_chunk).await
             }
         }
     }
 
     async fn read_file_pipelined(&mut self, path: &str) -> smb2::Result<Vec<u8>> {
+        let path = to_smb_path(path);
         match self {
-            SmbSession::Client { client, tree } => client.read_file_pipelined(tree, path).await,
-            SmbSession::Kerberos { conn, tree, .. } => tree.read_file_pipelined(conn, path).await,
+            SmbSession::Client { client, tree } => client.read_file_pipelined(tree, &path).await,
+            SmbSession::Kerberos { conn, tree, .. } => tree.read_file_pipelined(conn, &path).await,
         }
     }
 
     async fn delete_directory(&mut self, path: &str) -> smb2::Result<()> {
+        let path = to_smb_path(path);
         match self {
-            SmbSession::Client { client, tree } => client.delete_directory(tree, path).await,
-            SmbSession::Kerberos { conn, tree, .. } => tree.delete_directory(conn, path).await,
+            SmbSession::Client { client, tree } => client.delete_directory(tree, &path).await,
+            SmbSession::Kerberos { conn, tree, .. } => tree.delete_directory(conn, &path).await,
         }
     }
 
     async fn delete_file(&mut self, path: &str) -> smb2::Result<()> {
+        let path = to_smb_path(path);
         match self {
-            SmbSession::Client { client, tree } => client.delete_file(tree, path).await,
-            SmbSession::Kerberos { conn, tree, .. } => tree.delete_file(conn, path).await,
+            SmbSession::Client { client, tree } => client.delete_file(tree, &path).await,
+            SmbSession::Kerberos { conn, tree, .. } => tree.delete_file(conn, &path).await,
         }
     }
 
     async fn rename(&mut self, from: &str, to: &str) -> smb2::Result<()> {
+        let from = to_smb_path(from);
+        let to = to_smb_path(to);
         match self {
-            SmbSession::Client { client, tree } => client.rename(tree, from, to).await,
-            SmbSession::Kerberos { conn, tree, .. } => tree.rename(conn, from, to).await,
+            SmbSession::Client { client, tree } => client.rename(tree, &from, &to).await,
+            SmbSession::Kerberos { conn, tree, .. } => tree.rename(conn, &from, &to).await,
         }
     }
 }
@@ -377,6 +395,16 @@ fn trimmed_option(value: &str) -> Option<String> {
 }
 
 fn host_without_port(address: &str) -> &str {
+    if let Some(rest) = address.strip_prefix('[')
+        && let Some((host, _)) = rest.split_once(']')
+    {
+        return host;
+    }
+
+    if address.chars().filter(|&c| c == ':').count() != 1 {
+        return address;
+    }
+
     address
         .rsplit_once(':')
         .map(|(host, _)| host)
@@ -424,11 +452,10 @@ impl ObjectStore for SmbObjectStore {
         }
 
         self.ensure_parent_directories(&path).await?;
-        let bytes = payload_to_bytes(payload);
         {
             let mut session = self.session.lock().await;
             session
-                .write_file_pipelined(&path, &bytes)
+                .write_payload_streamed(&path, payload)
                 .await
                 .map_err(|err| map_smb_error(err, path.clone()))?;
         }
@@ -442,15 +469,14 @@ impl ObjectStore for SmbObjectStore {
 
     async fn put_multipart_opts(
         &self,
-        location: &Path,
+        _location: &Path,
         opts: PutMultipartOptions,
     ) -> Result<Box<dyn MultipartUpload>> {
         reject_attributes(&opts.attributes)?;
-        Ok(Box::new(SmbMultipartUpload {
-            store: self.clone(),
-            location: location.clone(),
-            parts: Vec::new(),
-        }))
+        Err(object_store::Error::NotSupported {
+            source: "SMB multipart uploads are not supported; regular puts stream payload chunks"
+                .into(),
+        })
     }
 
     async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {
@@ -613,6 +639,9 @@ impl ObjectStore for SmbObjectStore {
     async fn rename(&self, from: &Path, to: &Path) -> Result<()> {
         let from_path = object_path(from);
         let to_path = object_path(to);
+        if from_path == to_path {
+            return Ok(());
+        }
 
         match self.delete(to).await {
             Ok(_) | Err(object_store::Error::NotFound { .. }) => {}
@@ -667,45 +696,16 @@ impl ObjectStore for SmbObjectStore {
     }
 }
 
-#[derive(Debug)]
-struct SmbMultipartUpload {
-    store: SmbObjectStore,
-    location: Path,
-    parts: Vec<PutPayload>,
-}
-
-#[async_trait]
-impl MultipartUpload for SmbMultipartUpload {
-    fn put_part(&mut self, data: PutPayload) -> object_store::UploadPart {
-        self.parts.push(data);
-        Box::pin(async { Ok(()) })
-    }
-
-    async fn complete(&mut self) -> Result<PutResult> {
-        let mut data = Vec::with_capacity(self.parts.iter().map(PutPayload::content_length).sum());
-        for payload in self.parts.drain(..) {
-            for chunk in payload {
-                data.extend_from_slice(&chunk);
-            }
-        }
-
-        self.store
-            .put(&self.location, PutPayload::from_bytes(Bytes::from(data)))
-            .await
-    }
-
-    async fn abort(&mut self) -> Result<()> {
-        self.parts.clear();
-        Ok(())
-    }
-}
-
 fn object_path(location: &Path) -> String {
     location
         .as_ref()
         .replace('\\', "/")
         .trim_matches('/')
         .to_string()
+}
+
+fn to_smb_path(path: &str) -> String {
+    path.replace('/', "\\")
 }
 
 fn parent_paths(path: &str) -> Vec<String> {
@@ -744,11 +744,7 @@ fn is_real_entry(name: &str) -> bool {
 }
 
 fn meta_from_info(path: &str, info: &FileInfo) -> ObjectMeta {
-    let last_modified = info
-        .modified
-        .to_system_time()
-        .map(DateTime::<Utc>::from)
-        .unwrap_or_else(Utc::now);
+    let last_modified = filetime_to_datetime(info.modified);
     ObjectMeta {
         location: Path::from(path),
         last_modified,
@@ -759,11 +755,7 @@ fn meta_from_info(path: &str, info: &FileInfo) -> ObjectMeta {
 }
 
 fn meta_from_entry(path: &str, entry: &DirectoryEntry) -> ObjectMeta {
-    let last_modified = entry
-        .modified
-        .to_system_time()
-        .map(DateTime::<Utc>::from)
-        .unwrap_or_else(Utc::now);
+    let last_modified = filetime_to_datetime(entry.modified);
     ObjectMeta {
         location: Path::from(path),
         last_modified,
@@ -773,23 +765,18 @@ fn meta_from_entry(path: &str, entry: &DirectoryEntry) -> ObjectMeta {
     }
 }
 
+fn filetime_to_datetime(filetime: smb2::pack::FileTime) -> DateTime<Utc> {
+    filetime
+        .to_system_time()
+        .map(DateTime::<Utc>::from)
+        .unwrap_or_else(|| DateTime::<Utc>::from(UNIX_EPOCH))
+}
+
 fn etag(size: u64, modified: DateTime<Utc>) -> String {
     let modified = modified
         .timestamp_nanos_opt()
         .unwrap_or_else(|| modified.timestamp_millis() * 1_000_000);
     format!("{size:x}-{modified:x}")
-}
-
-fn payload_to_bytes(payload: PutPayload) -> Bytes {
-    if payload.as_ref().len() == 1 {
-        return payload.into_iter().next().unwrap_or_else(Bytes::new);
-    }
-
-    let mut data = Vec::with_capacity(payload.content_length());
-    for chunk in payload {
-        data.extend_from_slice(&chunk);
-    }
-    Bytes::from(data)
 }
 
 fn reject_attributes(attributes: &Attributes) -> Result<()> {
@@ -840,5 +827,37 @@ fn range_error(path: &str) -> object_store::Error {
     object_store::Error::Generic {
         store: STORE_NAME,
         source: format!("Invalid SMB object range for {path}").into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_to_smb_path_uses_backslash_separators() {
+        assert_eq!(to_smb_path("dir/file.txt"), "dir\\file.txt");
+        assert_eq!(to_smb_path("dir\\file.txt"), "dir\\file.txt");
+        assert_eq!(to_smb_path(""), "");
+    }
+
+    #[test]
+    fn test_object_path_normalizes_for_object_store_keys() {
+        assert_eq!(object_path(&Path::from("/dir/file.txt")), "dir/file.txt");
+        assert_eq!(object_path(&Path::from("dir/file.txt")), "dir/file.txt");
+    }
+
+    #[test]
+    fn test_host_without_port_handles_ipv6() {
+        assert_eq!(host_without_port("server:445"), "server");
+        assert_eq!(host_without_port("[::1]:445"), "::1");
+        assert_eq!(host_without_port("fe80::1"), "fe80::1");
+    }
+
+    #[test]
+    fn test_filetime_to_datetime_uses_stable_fallback() {
+        let fallback = filetime_to_datetime(smb2::pack::FileTime::ZERO);
+        assert_eq!(fallback, DateTime::<Utc>::from(UNIX_EPOCH));
+        assert_eq!(etag(16, fallback), etag(16, fallback));
     }
 }


### PR DESCRIPTION
This pull request introduces significant improvements to SMB (Server Message Block) object store support, focusing on better handling of SMB addresses (especially IPv6), streaming payloads for file uploads, and simplifying the codebase by removing unsupported multipart upload logic. Additionally, it enhances test coverage and robustness for edge cases.

**SMB address normalization and validation:**

* Improved `normalize_smb_address` to correctly handle IPv4, IPv6, and hostnames, including validation for bracketed IPv6 addresses and port parsing. Added helper functions for port extraction and validation.
* Added comprehensive tests for SMB address normalization, covering IPv4, IPv6, ports, and error cases.

**SMB object store improvements:**

* Refactored SMB session methods to consistently convert paths to SMB format (backslash separators) using a new `to_smb_path` function, ensuring compatibility with SMB protocol expectations. [[1]](diffhunk://#diff-9dd17a353bddb0244c56df901b4481a35f465df3e8a0b22175c53fd1da514b2eR211-R284) [[2]](diffhunk://#diff-9dd17a353bddb0244c56df901b4481a35f465df3e8a0b22175c53fd1da514b2eR707-R710)
* Changed file upload logic to stream payload chunks directly (`write_payload_streamed`) instead of buffering all data in memory, improving efficiency for large files.
* Removed all multipart upload support for SMB, as streaming is now the default and only supported upload method. Updated error handling to clearly indicate lack of multipart support. [[1]](diffhunk://#diff-9dd17a353bddb0244c56df901b4481a35f465df3e8a0b22175c53fd1da514b2eL445-R479) [[2]](diffhunk://#diff-9dd17a353bddb0244c56df901b4481a35f465df3e8a0b22175c53fd1da514b2eL670-L702)

**Robustness and correctness:**

* Improved handling of file modification timestamps, ensuring a stable fallback to the UNIX epoch when conversion fails. [[1]](diffhunk://#diff-9dd17a353bddb0244c56df901b4481a35f465df3e8a0b22175c53fd1da514b2eL747-R747) [[2]](diffhunk://#diff-9dd17a353bddb0244c56df901b4481a35f465df3e8a0b22175c53fd1da514b2eL762-R758) [[3]](diffhunk://#diff-9dd17a353bddb0244c56df901b4481a35f465df3e8a0b22175c53fd1da514b2eR768-L794)
* Prevented unnecessary file operations by checking for redundant rename requests (i.e., renaming a file to itself).

**Testing and code quality:**

* Added targeted unit tests for new and refactored utility functions, including path normalization, host extraction, and timestamp conversion.

These changes collectively make SMB integration more robust, efficient, and easier to maintain.