### PR TITLE
fix: update Windows build platform to avoid compatibility issues with…

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -30,7 +30,9 @@ jobs:
             args: "--config src-tauri/configs/tauri.linux.x64.conf.json --verbose"
           - platform: "ubuntu-24.04-arm"
             args: "--verbose"
-          - platform: "windows-latest"
+          # windows-latest currently resolves to the VS 2026 image, which breaks
+          # libduckdb-sys 1.3.0's vendored fmt headers.
+          - platform: "windows-2022"
             args: "--config src-tauri/configs/tauri.win.x64.conf.json --verbose"
     runs-on: ${{ matrix.platform }}
     env:
@@ -185,8 +187,7 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           APPLE_SIGNING_IDENTITY: ${{ env.CERT_ID }}
           RUSTFLAGS: ${{ runner.os == 'Windows' && '-C link-arg=/STACK:8388608' || '' }}
-          # libduckdb-sys 1.3.0's vendored fmt trips over MSVC's removed stdext::checked_array_iterator.
-          CXXFLAGS_x86_64_pc_windows_msvc: ${{ runner.os == 'Windows' && '/std:c++17 /U_SECURE_SCL' || '' }}
+          CXXFLAGS_x86_64_pc_windows_msvc: ${{ runner.os == 'Windows' && '/std:c++17' || '' }}
         with:
           tagName: beta-v__VERSION__
           releaseName: "Flow Like - Beta v__VERSION__"


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for alpha releases to address compatibility issues with Windows build environments and to simplify build flags for MSVC. The main focus is on ensuring successful builds by targeting a stable Windows image and adjusting compiler flags.

Build environment updates:

* Changed the Windows build platform from `windows-latest` to `windows-2022` to avoid issues with `libduckdb-sys 1.3.0` and its vendored `fmt` headers, as the newer VS 2026 image breaks the build.

Compiler flags simplification:

* Removed the `/U_SECURE_SCL` flag from `CXXFLAGS_x86_64_pc_windows_msvc` since it is no longer needed; now only `/std:c++17` is used for Windows builds.