### PR TITLE
Feature/623 read only user management nodes

### DIFF
--- a/apps/desktop/src-tauri/gen/apple/flow-like-desktop_iOS/Info.plist
+++ b/apps/desktop/src-tauri/gen/apple/flow-like-desktop_iOS/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.5</string>
+	<string>0.1.6</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.1.5</string>
+	<string>0.1.6</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>LSSupportsOpeningDocumentsInPlace</key>

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
 	"productName": "Flow Like",
-	"version": "0.1.5",
+	"version": "0.1.6",
 	"identifier": "com.flow-like.app",
 	"build": {
 		"beforeDevCommand": "bun run dev",

--- a/packages/api/src/routes/app/roles/get_roles.rs
+++ b/packages/api/src/routes/app/roles/get_roles.rs
@@ -1,5 +1,4 @@
 use crate::{
-    ensure_permission,
     entity::{app, role},
     error::ApiError,
     middleware::jwt::AppUser,
@@ -37,7 +36,13 @@ pub async fn get_roles(
     Extension(user): Extension<AppUser>,
     Path(app_id): Path<String>,
 ) -> Result<Json<(Option<String>, Vec<role::Model>)>, ApiError> {
-    ensure_permission!(user, &app_id, &state, RolePermissions::ReadRoles);
+    let permission = user.execution_app_permission(&app_id, &state).await?;
+    if !permission.has_permission(RolePermissions::ReadRoles) {
+        if let Ok(user_id) = permission.sub() {
+            state.invalidate_permission(&user_id, &app_id);
+        }
+        return Err(ApiError::FORBIDDEN);
+    }
 
     let txn = state.db.begin().await?;
 

--- a/packages/api/src/routes/app/team/get_team.rs
+++ b/packages/api/src/routes/app/team/get_team.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ensure_permission, entity::membership, error::ApiError, middleware::jwt::AppUser,
+    entity::membership, error::ApiError, middleware::jwt::AppUser,
     permission::role_permission::RolePermissions, routes::LanguageParams, state::AppState,
 };
 use axum::{
@@ -36,7 +36,13 @@ pub async fn get_team(
     Path(app_id): Path<String>,
     Query(params): Query<LanguageParams>,
 ) -> Result<Json<Vec<membership::Model>>, ApiError> {
-    ensure_permission!(user, &app_id, &state, RolePermissions::ReadTeam);
+    let permission = user.execution_app_permission(&app_id, &state).await?;
+    if !permission.has_permission(RolePermissions::ReadTeam) {
+        if let Ok(user_id) = permission.sub() {
+            state.invalidate_permission(&user_id, &app_id);
+        }
+        return Err(ApiError::FORBIDDEN);
+    }
 
     let members = membership::Entity::find()
         .order_by_asc(membership::Column::CreatedAt)

--- a/packages/api/src/routes/user/info.rs
+++ b/packages/api/src/routes/user/info.rs
@@ -52,11 +52,18 @@ pub async fn user_info(
     State(state): State<AppState>,
     Extension(user): Extension<AppUser>,
 ) -> Result<Json<user::Model>, ApiError> {
-    let sub = user.sub()?;
-    let user_info = user.user_info(&state).await?;
-    let email = user_info.email.clone();
-    let username = user_info.username.clone();
-    let preferred_username = user_info.preferred_username.clone();
+    let sub = user.executor_scoped_sub()?;
+    let identity_info = match &user {
+        AppUser::OpenID(_) => Some(user.user_info(&state).await?),
+        _ => None,
+    };
+    let email = identity_info.as_ref().and_then(|info| info.email.clone());
+    let username = identity_info
+        .as_ref()
+        .and_then(|info| info.username.clone());
+    let preferred_username = identity_info
+        .as_ref()
+        .and_then(|info| info.preferred_username.clone());
     let user_info = user::Entity::find_by_id(&sub).one(&state.db).await?;
     if let Some(mut user_info) = user_info {
         let mut updated_user: Option<user::ActiveModel> = None;
@@ -78,7 +85,7 @@ pub async fn user_info(
             updated_user = Some(tmp_updated_user);
         }
 
-        if user_info.tracking_id.is_none() {
+        if identity_info.is_some() && user_info.tracking_id.is_none() {
             let tracking_id = create_id();
             let mut tmp_updated_user: user::ActiveModel =
                 updated_user.unwrap_or(user_info.clone().into());
@@ -110,7 +117,9 @@ pub async fn user_info(
             user_info = new_user;
         }
 
-        user_info = ensure_stripe_user(&state, user_info, email.clone()).await?;
+        if identity_info.is_some() {
+            user_info = ensure_stripe_user(&state, user_info, email.clone()).await?;
+        }
 
         if let Some(avatar) = &user_info.avatar {
             let signed_avatar_url = sign_avatar(&user_info.id, avatar, &state).await?;
@@ -118,6 +127,10 @@ pub async fn user_info(
         }
 
         return Ok(Json(user_info));
+    }
+
+    if identity_info.is_none() {
+        return Err(ApiError::NOT_FOUND);
     }
 
     let user = user::ActiveModel {

--- a/packages/api/src/routes/user/lookup.rs
+++ b/packages/api/src/routes/user/lookup.rs
@@ -1,5 +1,9 @@
 use crate::{
-    entity::user, error::ApiError, middleware::jwt::AppUser, routes::user::sign_avatar,
+    entity::{membership, user},
+    error::ApiError,
+    middleware::jwt::AppUser,
+    permission::role_permission::RolePermissions,
+    routes::user::sign_avatar,
     state::AppState,
 };
 use axum::{
@@ -89,7 +93,8 @@ pub async fn user_lookup(
     Extension(user): Extension<AppUser>,
     Path(sub): Path<String>,
 ) -> Result<Json<UserLookupResponse>, ApiError> {
-    user.sub()?;
+    user.executor_scoped_sub()?;
+    let sub = scoped_lookup_id(&state, &user, sub).await?;
     let lookup_config = state.platform_config.lookup.clone();
     let found_user = user::Entity::find()
         .filter(user::Column::Id.eq(&sub))
@@ -123,7 +128,7 @@ pub async fn user_batch_lookup(
     Extension(user): Extension<AppUser>,
     Json(body): Json<UserBatchLookupBody>,
 ) -> Result<Json<Vec<UserLookupResponse>>, ApiError> {
-    user.sub()?;
+    user.executor_scoped_sub()?;
     let lookup_config = state.platform_config.lookup.clone();
     let ids = body
         .user_ids
@@ -134,6 +139,11 @@ pub async fn user_batch_lookup(
         .into_iter()
         .collect::<Vec<_>>();
 
+    if ids.is_empty() {
+        return Ok(Json(Vec::new()));
+    }
+
+    let ids = scoped_lookup_ids(&state, &user, ids).await?;
     if ids.is_empty() {
         return Ok(Json(Vec::new()));
     }
@@ -150,6 +160,63 @@ pub async fn user_batch_lookup(
     }
 
     Ok(Json(responses))
+}
+
+async fn scoped_lookup_id(
+    state: &AppState,
+    user: &AppUser,
+    sub: String,
+) -> Result<String, ApiError> {
+    if let AppUser::Executor(executor) = user {
+        ensure_executor_lookup_permission(state, user, &executor.app_id).await?;
+        let membership = membership::Entity::find()
+            .filter(membership::Column::AppId.eq(&executor.app_id))
+            .filter(membership::Column::UserId.eq(&sub))
+            .one(&state.db)
+            .await?;
+
+        if membership.is_none() {
+            return Err(ApiError::NOT_FOUND);
+        }
+    }
+
+    Ok(sub)
+}
+
+async fn scoped_lookup_ids(
+    state: &AppState,
+    user: &AppUser,
+    ids: Vec<String>,
+) -> Result<Vec<String>, ApiError> {
+    if let AppUser::Executor(executor) = user {
+        ensure_executor_lookup_permission(state, user, &executor.app_id).await?;
+        let ids = membership::Entity::find()
+            .filter(membership::Column::AppId.eq(&executor.app_id))
+            .filter(membership::Column::UserId.is_in(ids))
+            .limit(100)
+            .all(&state.db)
+            .await?
+            .into_iter()
+            .map(|membership| membership.user_id)
+            .collect();
+
+        return Ok(ids);
+    }
+
+    Ok(ids)
+}
+
+async fn ensure_executor_lookup_permission(
+    state: &AppState,
+    user: &AppUser,
+    app_id: &str,
+) -> Result<(), ApiError> {
+    let permission = user.execution_app_permission(app_id, state).await?;
+    if !permission.has_permission(RolePermissions::ReadTeam) {
+        return Err(ApiError::FORBIDDEN);
+    }
+
+    Ok(())
 }
 
 #[utoipa::path(

--- a/packages/catalog/std/src/utils/user/has_permission.rs
+++ b/packages/catalog/std/src/utils/user/has_permission.rs
@@ -8,7 +8,7 @@ use flow_like_types::{async_trait, json::json};
 
 /// Permission constants matching the API RolePermissions bitflags.
 /// These are used to populate the dropdown options.
-const PERMISSION_OPTIONS: &[(&str, i64)] = &[
+pub(crate) const PERMISSION_OPTIONS: &[(&str, i64)] = &[
     ("Owner", 0b00000000_00000000_00000000_00000001),
     ("Admin", 0b00000000_00000000_00000000_00000010),
     ("Read Team", 0b00000000_00000000_00000000_00000100),

--- a/packages/catalog/std/src/utils/user/mod.rs
+++ b/packages/catalog/std/src/utils/user/mod.rs
@@ -3,9 +3,11 @@ pub(crate) mod get_executing_user;
 pub(crate) mod has_attribute;
 pub(crate) mod has_permission;
 pub(crate) mod is_technical_user;
+pub(crate) mod project_users;
 
 pub use get_current_user_info::*;
 pub use get_executing_user::*;
 pub use has_attribute::*;
 pub use has_permission::*;
 pub use is_technical_user::*;
+pub use project_users::*;

--- a/packages/catalog/std/src/utils/user/project_users/check_user_has_role.rs
+++ b/packages/catalog/std/src/utils/user/project_users/check_user_has_role.rs
@@ -1,0 +1,73 @@
+use super::*;
+use flow_like::flow::{
+    execution::context::ExecutionContext,
+    node::{Node, NodeLogic},
+};
+use flow_like_types::async_trait;
+
+#[crate::register_node]
+#[derive(Default)]
+pub struct CheckUserHasRoleNode {}
+
+impl CheckUserHasRoleNode {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+#[async_trait]
+impl NodeLogic for CheckUserHasRoleNode {
+    fn get_node(&self) -> Node {
+        let mut node = base_node(
+            "utils_user_check_user_has_role",
+            "Check User Has Role",
+            "Checks whether a project user has the specified role ID or exact role name.",
+        );
+        add_app_pin(&mut node);
+        add_user_id_pin(&mut node);
+        node.add_input_pin(
+            "role",
+            "Role",
+            "Role ID or exact role name.",
+            VariableType::String,
+        )
+        .set_default_value(Some(json!("")));
+        node.add_output_pin(
+            "has_role",
+            "Has Role",
+            "True when the user has the requested role.",
+            VariableType::Boolean,
+        );
+        add_project_user_output(&mut node);
+        add_common_outputs(&mut node);
+        node
+    }
+
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        let role_query = eval_string_pin(context, "role", "").await;
+        let result = load_single_project_user(context).await;
+        match result {
+            Ok(Some((user, status))) => {
+                let has_role = role_matches(user.role.as_ref(), &role_query);
+                context.set_pin_value("has_role", json!(has_role)).await?;
+                context.set_pin_value("project_user", json!(user)).await?;
+                context.set_pin_value("found", json!(true)).await?;
+                set_common_outputs(context, true, status, "").await?;
+            }
+            Ok(None) => {
+                context.set_pin_value("has_role", json!(false)).await?;
+                context.set_pin_value("project_user", Value::Null).await?;
+                context.set_pin_value("found", json!(false)).await?;
+                set_common_outputs(context, true, 200, "").await?;
+            }
+            Err(err) => {
+                context.log_message(&err.message, LogLevel::Warn);
+                context.set_pin_value("has_role", json!(false)).await?;
+                context.set_pin_value("project_user", Value::Null).await?;
+                context.set_pin_value("found", json!(false)).await?;
+                set_common_outputs(context, false, err.status_code, &err.message).await?;
+            }
+        }
+        Ok(())
+    }
+}

--- a/packages/catalog/std/src/utils/user/project_users/check_user_permission.rs
+++ b/packages/catalog/std/src/utils/user/project_users/check_user_permission.rs
@@ -1,0 +1,97 @@
+use super::*;
+use flow_like::flow::{
+    execution::context::ExecutionContext,
+    node::{Node, NodeLogic},
+};
+use flow_like_types::async_trait;
+
+#[crate::register_node]
+#[derive(Default)]
+pub struct CheckUserPermissionNode {}
+
+impl CheckUserPermissionNode {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+#[async_trait]
+impl NodeLogic for CheckUserPermissionNode {
+    fn get_node(&self) -> Node {
+        let mut node = base_node(
+            "utils_user_check_user_permission",
+            "Check User Permission",
+            "Checks whether a project user effectively has a permission. Owner and Admin imply all permissions.",
+        );
+        add_app_pin(&mut node);
+        add_user_id_pin(&mut node);
+        node.add_input_pin(
+            "permission",
+            "Permission",
+            "Permission name or bit value to check.",
+            VariableType::String,
+        )
+        .set_default_value(Some(json!("Read Boards")))
+        .set_options(
+            PinOptions::new()
+                .set_valid_values(permission_names())
+                .build(),
+        );
+        node.add_output_pin(
+            "has_permission",
+            "Has Permission",
+            "True when the user effectively has the requested permission.",
+            VariableType::Boolean,
+        );
+        add_project_user_output(&mut node);
+        add_common_outputs(&mut node);
+        node
+    }
+
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        let permission = eval_string_pin(context, "permission", "Read Boards").await;
+        let requested_permission = permission_from_name(&permission);
+        let result = load_single_project_user(context).await;
+
+        match (requested_permission, result) {
+            (Some(requested_permission), Ok(Some((user, status)))) => {
+                let has_permission =
+                    has_effective_permission(user.permissions, requested_permission);
+                context
+                    .set_pin_value("has_permission", json!(has_permission))
+                    .await?;
+                context.set_pin_value("project_user", json!(user)).await?;
+                context.set_pin_value("found", json!(true)).await?;
+                set_common_outputs(context, true, status, "").await?;
+            }
+            (None, _) => {
+                let message = format!("Unknown permission: {permission}");
+                context.log_message(&message, LogLevel::Warn);
+                context
+                    .set_pin_value("has_permission", json!(false))
+                    .await?;
+                context.set_pin_value("project_user", Value::Null).await?;
+                context.set_pin_value("found", json!(false)).await?;
+                set_common_outputs(context, false, 0, &message).await?;
+            }
+            (_, Ok(None)) => {
+                context
+                    .set_pin_value("has_permission", json!(false))
+                    .await?;
+                context.set_pin_value("project_user", Value::Null).await?;
+                context.set_pin_value("found", json!(false)).await?;
+                set_common_outputs(context, true, 200, "").await?;
+            }
+            (_, Err(err)) => {
+                context.log_message(&err.message, LogLevel::Warn);
+                context
+                    .set_pin_value("has_permission", json!(false))
+                    .await?;
+                context.set_pin_value("project_user", Value::Null).await?;
+                context.set_pin_value("found", json!(false)).await?;
+                set_common_outputs(context, false, err.status_code, &err.message).await?;
+            }
+        }
+        Ok(())
+    }
+}

--- a/packages/catalog/std/src/utils/user/project_users/get_current_user.rs
+++ b/packages/catalog/std/src/utils/user/project_users/get_current_user.rs
@@ -1,0 +1,97 @@
+use super::*;
+use flow_like::flow::{
+    execution::context::ExecutionContext,
+    node::{Node, NodeLogic},
+};
+use flow_like_types::async_trait;
+
+#[crate::register_node]
+#[derive(Default)]
+pub struct GetCurrentUserNode {}
+
+impl GetCurrentUserNode {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+#[async_trait]
+impl NodeLogic for GetCurrentUserNode {
+    fn get_node(&self) -> Node {
+        let mut node = base_node(
+            "utils_user_get_current_user",
+            "Get Current User",
+            "Gets the current runtime user and, when available, their project membership, role, effective permissions, and attributes.",
+        );
+        add_app_pin(&mut node);
+        node.add_output_pin(
+            "current_user",
+            "Current User",
+            "Current runtime user with project membership details when available.",
+            VariableType::Struct,
+        )
+        .set_schema::<CurrentUser>()
+        .set_options(PinOptions::new().set_enforce_schema(true).build());
+        add_common_outputs(&mut node);
+        node
+    }
+
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        let app_id_input = eval_string_pin(context, "app_id", "").await;
+        let client = match HubClient::from_context(context) {
+            Ok(client) => client,
+            Err(err) => {
+                context.set_pin_value("current_user", Value::Null).await?;
+                set_common_outputs(context, false, err.status_code, &err.message).await?;
+                return Ok(());
+            }
+        };
+        let app_id = match app_id_from_context(context, app_id_input) {
+            Ok(app_id) => app_id,
+            Err(err) => {
+                context.set_pin_value("current_user", Value::Null).await?;
+                set_common_outputs(context, false, err.status_code, &err.message).await?;
+                return Ok(());
+            }
+        };
+
+        let result = async {
+            let (current_user, mut status) = client.current_user().await?;
+            let (roles, role_status) = load_roles(&client, &app_id).await?;
+            status = status.max(role_status);
+            let project_user =
+                get_project_user_by_id(&client, &app_id, &current_user.user_id, &roles).await?;
+            let project_user = match project_user {
+                Some((project_user, user_status)) => {
+                    status = status.max(user_status);
+                    Some(project_user)
+                }
+                None => None,
+            };
+
+            Ok::<_, HubError>((current_user, project_user, status))
+        }
+        .await;
+
+        match result {
+            Ok((user, project_user, status)) => {
+                let current_user = CurrentUser {
+                    user,
+                    has_project_user: project_user.is_some(),
+                    project_user,
+                };
+                context
+                    .set_pin_value("current_user", json!(current_user))
+                    .await?;
+                set_common_outputs(context, true, status, "").await?;
+            }
+            Err(err) => {
+                context.log_message(&err.message, LogLevel::Warn);
+                context.set_pin_value("current_user", Value::Null).await?;
+                set_common_outputs(context, false, err.status_code, &err.message).await?;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/packages/catalog/std/src/utils/user/project_users/get_effective_user_permissions.rs
+++ b/packages/catalog/std/src/utils/user/project_users/get_effective_user_permissions.rs
@@ -1,0 +1,79 @@
+use super::*;
+use flow_like::flow::{
+    execution::context::ExecutionContext,
+    node::{Node, NodeLogic},
+};
+use flow_like_types::async_trait;
+
+#[crate::register_node]
+#[derive(Default)]
+pub struct GetEffectiveUserPermissionsNode {}
+
+impl GetEffectiveUserPermissionsNode {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+#[async_trait]
+impl NodeLogic for GetEffectiveUserPermissionsNode {
+    fn get_node(&self) -> Node {
+        let mut node = base_node(
+            "utils_user_get_effective_user_permissions",
+            "Get Effective User Permissions",
+            "Gets a project user's effective permission bitfield and expanded permission names. Owner and Admin imply all permissions.",
+        );
+        add_app_pin(&mut node);
+        add_user_id_pin(&mut node);
+        node.add_output_pin(
+            "user_permissions",
+            "User Permissions",
+            "Effective permissions for the project user.",
+            VariableType::Struct,
+        )
+        .set_schema::<UserPermissions>()
+        .set_options(PinOptions::new().set_enforce_schema(true).build());
+        node.add_output_pin(
+            "found",
+            "Found",
+            "True when the user was found.",
+            VariableType::Boolean,
+        );
+        add_common_outputs(&mut node);
+        node
+    }
+
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        let result = load_single_project_user(context).await;
+        match result {
+            Ok(Some((user, status))) => {
+                let permissions = UserPermissions {
+                    user: user.user,
+                    permissions: user.permissions,
+                    permission_names: effective_permission_names(user.permissions),
+                };
+                context
+                    .set_pin_value("user_permissions", json!(permissions))
+                    .await?;
+                context.set_pin_value("found", json!(true)).await?;
+                set_common_outputs(context, true, status, "").await?;
+            }
+            Ok(None) => {
+                context
+                    .set_pin_value("user_permissions", Value::Null)
+                    .await?;
+                context.set_pin_value("found", json!(false)).await?;
+                set_common_outputs(context, true, 200, "").await?;
+            }
+            Err(err) => {
+                context.log_message(&err.message, LogLevel::Warn);
+                context
+                    .set_pin_value("user_permissions", Value::Null)
+                    .await?;
+                context.set_pin_value("found", json!(false)).await?;
+                set_common_outputs(context, false, err.status_code, &err.message).await?;
+            }
+        }
+        Ok(())
+    }
+}

--- a/packages/catalog/std/src/utils/user/project_users/get_project_user.rs
+++ b/packages/catalog/std/src/utils/user/project_users/get_project_user.rs
@@ -1,0 +1,36 @@
+use super::*;
+use flow_like::flow::{
+    execution::context::ExecutionContext,
+    node::{Node, NodeLogic},
+};
+use flow_like_types::async_trait;
+
+#[crate::register_node]
+#[derive(Default)]
+pub struct GetProjectUserNode {}
+
+impl GetProjectUserNode {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+#[async_trait]
+impl NodeLogic for GetProjectUserNode {
+    fn get_node(&self) -> Node {
+        let mut node = base_node(
+            "utils_user_get_project_user",
+            "Get Project User",
+            "Gets a project user membership by user ID/sub.",
+        );
+        add_app_pin(&mut node);
+        add_user_id_pin(&mut node);
+        add_project_user_output(&mut node);
+        add_common_outputs(&mut node);
+        node
+    }
+
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        run_single_project_user_node(context).await
+    }
+}

--- a/packages/catalog/std/src/utils/user/project_users/get_user_attribute.rs
+++ b/packages/catalog/std/src/utils/user/project_users/get_user_attribute.rs
@@ -1,0 +1,94 @@
+use super::*;
+use flow_like::flow::{
+    execution::context::ExecutionContext,
+    node::{Node, NodeLogic},
+};
+use flow_like_types::async_trait;
+
+#[crate::register_node]
+#[derive(Default)]
+pub struct GetUserAttributeNode {}
+
+impl GetUserAttributeNode {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+#[async_trait]
+impl NodeLogic for GetUserAttributeNode {
+    fn get_node(&self) -> Node {
+        let mut node = base_node(
+            "utils_user_get_user_attribute",
+            "Get User Attribute",
+            "Checks for one custom role attribute on a project user.",
+        );
+        add_app_pin(&mut node);
+        add_user_id_pin(&mut node);
+        node.add_input_pin(
+            "attribute",
+            "Attribute",
+            "Role attribute to read.",
+            VariableType::String,
+        )
+        .set_default_value(Some(json!("")));
+        node.add_output_pin(
+            "has_attribute",
+            "Has Attribute",
+            "True when the user has the requested attribute.",
+            VariableType::Boolean,
+        );
+        node.add_output_pin(
+            "attribute_value",
+            "Attribute",
+            "The matching attribute when present.",
+            VariableType::String,
+        );
+        add_project_user_output(&mut node);
+        add_common_outputs(&mut node);
+        node
+    }
+
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        let attribute = eval_string_pin(context, "attribute", "").await;
+        let result = load_single_project_user(context).await;
+
+        match result {
+            Ok(Some((user, status))) => {
+                let found_attribute = user
+                    .attributes
+                    .iter()
+                    .find(|candidate| candidate.eq_ignore_ascii_case(attribute.trim()))
+                    .cloned();
+                context
+                    .set_pin_value("has_attribute", json!(found_attribute.is_some()))
+                    .await?;
+                context
+                    .set_pin_value(
+                        "attribute_value",
+                        json!(found_attribute.unwrap_or_default()),
+                    )
+                    .await?;
+                context.set_pin_value("project_user", json!(user)).await?;
+                context.set_pin_value("found", json!(true)).await?;
+                set_common_outputs(context, true, status, "").await?;
+            }
+            Ok(None) => {
+                context.set_pin_value("has_attribute", json!(false)).await?;
+                context.set_pin_value("attribute_value", json!("")).await?;
+                context.set_pin_value("project_user", Value::Null).await?;
+                context.set_pin_value("found", json!(false)).await?;
+                set_common_outputs(context, true, 200, "").await?;
+            }
+            Err(err) => {
+                context.log_message(&err.message, LogLevel::Warn);
+                context.set_pin_value("has_attribute", json!(false)).await?;
+                context.set_pin_value("attribute_value", json!("")).await?;
+                context.set_pin_value("project_user", Value::Null).await?;
+                context.set_pin_value("found", json!(false)).await?;
+                set_common_outputs(context, false, err.status_code, &err.message).await?;
+            }
+        }
+        Ok(())
+    }
+}

--- a/packages/catalog/std/src/utils/user/project_users/get_user_attributes.rs
+++ b/packages/catalog/std/src/utils/user/project_users/get_user_attributes.rs
@@ -1,0 +1,78 @@
+use super::*;
+use flow_like::flow::{
+    execution::context::ExecutionContext,
+    node::{Node, NodeLogic},
+};
+use flow_like_types::async_trait;
+
+#[crate::register_node]
+#[derive(Default)]
+pub struct GetUserAttributesNode {}
+
+impl GetUserAttributesNode {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+#[async_trait]
+impl NodeLogic for GetUserAttributesNode {
+    fn get_node(&self) -> Node {
+        let mut node = base_node(
+            "utils_user_get_user_attributes",
+            "Get User Attributes",
+            "Gets custom role attributes assigned to a project user.",
+        );
+        add_app_pin(&mut node);
+        add_user_id_pin(&mut node);
+        node.add_output_pin(
+            "user_attributes",
+            "User Attributes",
+            "Role attributes for the project user.",
+            VariableType::Struct,
+        )
+        .set_schema::<UserAttributes>()
+        .set_options(PinOptions::new().set_enforce_schema(true).build());
+        node.add_output_pin(
+            "found",
+            "Found",
+            "True when the user was found.",
+            VariableType::Boolean,
+        );
+        add_common_outputs(&mut node);
+        node
+    }
+
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        let result = load_single_project_user(context).await;
+        match result {
+            Ok(Some((user, status))) => {
+                let attributes = UserAttributes {
+                    user: user.user,
+                    attributes: user.attributes,
+                };
+                context
+                    .set_pin_value("user_attributes", json!(attributes))
+                    .await?;
+                context.set_pin_value("found", json!(true)).await?;
+                set_common_outputs(context, true, status, "").await?;
+            }
+            Ok(None) => {
+                context
+                    .set_pin_value("user_attributes", Value::Null)
+                    .await?;
+                context.set_pin_value("found", json!(false)).await?;
+                set_common_outputs(context, true, 200, "").await?;
+            }
+            Err(err) => {
+                context.log_message(&err.message, LogLevel::Warn);
+                context
+                    .set_pin_value("user_attributes", Value::Null)
+                    .await?;
+                context.set_pin_value("found", json!(false)).await?;
+                set_common_outputs(context, false, err.status_code, &err.message).await?;
+            }
+        }
+        Ok(())
+    }
+}

--- a/packages/catalog/std/src/utils/user/project_users/get_user_roles.rs
+++ b/packages/catalog/std/src/utils/user/project_users/get_user_roles.rs
@@ -1,0 +1,77 @@
+use super::*;
+use flow_like::flow::{
+    execution::context::ExecutionContext,
+    node::{Node, NodeLogic},
+};
+use flow_like_types::async_trait;
+
+#[crate::register_node]
+#[derive(Default)]
+pub struct GetUserRolesNode {}
+
+impl GetUserRolesNode {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+#[async_trait]
+impl NodeLogic for GetUserRolesNode {
+    fn get_node(&self) -> Node {
+        let mut node = base_node(
+            "utils_user_get_user_roles",
+            "Get User Roles",
+            "Gets the project role assigned to a user.",
+        );
+        add_app_pin(&mut node);
+        add_user_id_pin(&mut node);
+        node.add_output_pin(
+            "user_roles",
+            "User Roles",
+            "Role assignment for the project user. Current projects have one role per user.",
+            VariableType::Struct,
+        )
+        .set_schema::<UserRoles>()
+        .set_options(PinOptions::new().set_enforce_schema(true).build());
+        node.add_output_pin(
+            "found",
+            "Found",
+            "True when the user was found.",
+            VariableType::Boolean,
+        );
+        add_common_outputs(&mut node);
+        node
+    }
+
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        let result = load_single_project_user(context).await;
+        match result {
+            Ok(Some((user, status))) => {
+                let roles = user.role.clone().into_iter().collect::<Vec<_>>();
+                let user_roles = UserRoles {
+                    user: user.user,
+                    role: user.role,
+                    role_ids: roles.iter().map(|role| role.id.clone()).collect(),
+                    roles,
+                };
+                context
+                    .set_pin_value("user_roles", json!(user_roles))
+                    .await?;
+                context.set_pin_value("found", json!(true)).await?;
+                set_common_outputs(context, true, status, "").await?;
+            }
+            Ok(None) => {
+                context.set_pin_value("user_roles", Value::Null).await?;
+                context.set_pin_value("found", json!(false)).await?;
+                set_common_outputs(context, true, 200, "").await?;
+            }
+            Err(err) => {
+                context.log_message(&err.message, LogLevel::Warn);
+                context.set_pin_value("user_roles", Value::Null).await?;
+                context.set_pin_value("found", json!(false)).await?;
+                set_common_outputs(context, false, err.status_code, &err.message).await?;
+            }
+        }
+        Ok(())
+    }
+}

--- a/packages/catalog/std/src/utils/user/project_users/list_project_users.rs
+++ b/packages/catalog/std/src/utils/user/project_users/list_project_users.rs
@@ -1,0 +1,45 @@
+use super::*;
+use flow_like::flow::{
+    execution::context::ExecutionContext,
+    node::{Node, NodeLogic},
+};
+use flow_like_types::async_trait;
+
+#[crate::register_node]
+#[derive(Default)]
+pub struct ListProjectUsersNode {}
+
+impl ListProjectUsersNode {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+#[async_trait]
+impl NodeLogic for ListProjectUsersNode {
+    fn get_node(&self) -> Node {
+        let mut node = base_node(
+            "utils_user_list_project_users",
+            "List Project Users",
+            "Lists project users with pagination.",
+        );
+        add_app_pin(&mut node);
+        add_pagination_pins(&mut node);
+        add_users_output(&mut node);
+        add_common_outputs(&mut node);
+        node
+    }
+
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        run_user_list_node(context, |client, app_id, roles, offset, limit| {
+            Box::pin(async move {
+                let (memberships, status) = client.memberships(app_id, offset, limit).await?;
+                let has_more = memberships.len() == limit as usize;
+                let (users, lookup_status) =
+                    hydrate_project_users(client, memberships, roles).await?;
+                Ok((users, has_more, status.max(lookup_status)))
+            })
+        })
+        .await
+    }
+}

--- a/packages/catalog/std/src/utils/user/project_users/list_users_with_attribute.rs
+++ b/packages/catalog/std/src/utils/user/project_users/list_users_with_attribute.rs
@@ -1,0 +1,53 @@
+use super::*;
+use flow_like::flow::{
+    execution::context::ExecutionContext,
+    node::{Node, NodeLogic},
+};
+use flow_like_types::async_trait;
+
+#[crate::register_node]
+#[derive(Default)]
+pub struct ListUsersWithAttributeNode {}
+
+impl ListUsersWithAttributeNode {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+#[async_trait]
+impl NodeLogic for ListUsersWithAttributeNode {
+    fn get_node(&self) -> Node {
+        let mut node = base_node(
+            "utils_user_list_users_with_attribute",
+            "List Users with Attribute",
+            "Lists project users whose assigned role contains a custom attribute.",
+        );
+        add_app_pin(&mut node);
+        node.add_input_pin(
+            "attribute",
+            "Attribute",
+            "Role attribute to match.",
+            VariableType::String,
+        )
+        .set_default_value(Some(json!("")));
+        add_pagination_pins(&mut node);
+        add_users_output(&mut node);
+        add_common_outputs(&mut node);
+        node
+    }
+
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        let attribute = eval_string_pin(context, "attribute", "").await;
+        run_user_list_node(context, |client, app_id, roles, offset, limit| {
+            let attribute = attribute.clone();
+            Box::pin(async move {
+                filter_project_users(client, app_id, roles, offset, limit, |user| {
+                    has_attribute(user, &attribute)
+                })
+                .await
+            })
+        })
+        .await
+    }
+}

--- a/packages/catalog/std/src/utils/user/project_users/list_users_with_role.rs
+++ b/packages/catalog/std/src/utils/user/project_users/list_users_with_role.rs
@@ -1,0 +1,53 @@
+use super::*;
+use flow_like::flow::{
+    execution::context::ExecutionContext,
+    node::{Node, NodeLogic},
+};
+use flow_like_types::async_trait;
+
+#[crate::register_node]
+#[derive(Default)]
+pub struct ListUsersWithRoleNode {}
+
+impl ListUsersWithRoleNode {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+#[async_trait]
+impl NodeLogic for ListUsersWithRoleNode {
+    fn get_node(&self) -> Node {
+        let mut node = base_node(
+            "utils_user_list_users_with_role",
+            "List Users with Role",
+            "Lists project users assigned to a role ID or exact role name.",
+        );
+        add_app_pin(&mut node);
+        node.add_input_pin(
+            "role",
+            "Role",
+            "Role ID or exact role name. Leave empty to return all project users.",
+            VariableType::String,
+        )
+        .set_default_value(Some(json!("")));
+        add_pagination_pins(&mut node);
+        add_users_output(&mut node);
+        add_common_outputs(&mut node);
+        node
+    }
+
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        let role_query = eval_string_pin(context, "role", "").await;
+        run_user_list_node(context, |client, app_id, roles, offset, limit| {
+            let role_query = role_query.clone();
+            Box::pin(async move {
+                filter_project_users(client, app_id, roles, offset, limit, |user| {
+                    role_matches(user.role.as_ref(), &role_query)
+                })
+                .await
+            })
+        })
+        .await
+    }
+}

--- a/packages/catalog/std/src/utils/user/project_users/mod.rs
+++ b/packages/catalog/std/src/utils/user/project_users/mod.rs
@@ -7,7 +7,7 @@ use flow_like::flow::{
 };
 use flow_like_types::{JsonSchema, Value, json::json, reqwest};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::OnceLock};
 
 const DEFAULT_LIMIT: i64 = 50;
 const MAX_LIMIT: i64 = 100;
@@ -133,8 +133,10 @@ impl HubClient {
         let base_url = api_base_url(&context.profile.hub, context.profile.secure)
             .ok_or_else(|| HubError::new(0, "No hub URL configured on the execution profile"))?;
 
+        static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+
         Ok(Self {
-            client: reqwest::Client::new(),
+            client: CLIENT.get_or_init(reqwest::Client::new).clone(),
             token: token.to_string(),
             base_url,
         })
@@ -504,6 +506,7 @@ async fn find_project_user_by_email(
             return Ok(None);
         }
 
+        let len = memberships.len();
         let (users, status) = hydrate_project_users(client, memberships, roles).await?;
         if let Some(user) = users.into_iter().find(|user| {
             user.user
@@ -513,6 +516,10 @@ async fn find_project_user_by_email(
                 .unwrap_or(false)
         }) {
             return Ok(Some((user, status)));
+        }
+
+        if len < MEMBERSHIP_PAGE_SIZE as usize {
+            return Ok(None);
         }
 
         offset += MEMBERSHIP_PAGE_SIZE;
@@ -550,6 +557,7 @@ async fn search_project_users(
             break;
         }
 
+        let len = memberships.len();
         let (users, lookup_status) = hydrate_project_users(client, memberships, roles).await?;
         last_status = lookup_status;
 
@@ -571,9 +579,7 @@ async fn search_project_users(
             }
         }
 
-        if results.len() > limit as usize {
-            has_more = true;
-            results.truncate(limit as usize);
+        if len < MEMBERSHIP_PAGE_SIZE as usize {
             break;
         }
 
@@ -610,6 +616,7 @@ where
             break;
         }
 
+        let len = memberships.len();
         let (users, lookup_status) = hydrate_project_users(client, memberships, roles).await?;
         last_status = lookup_status;
 
@@ -629,6 +636,10 @@ where
                 has_more = true;
                 break 'scan;
             }
+        }
+
+        if len < MEMBERSHIP_PAGE_SIZE as usize {
+            break;
         }
 
         membership_offset += MEMBERSHIP_PAGE_SIZE;

--- a/packages/catalog/std/src/utils/user/project_users/mod.rs
+++ b/packages/catalog/std/src/utils/user/project_users/mod.rs
@@ -1,0 +1,1058 @@
+use super::has_permission::PERMISSION_OPTIONS;
+use flow_like::flow::{
+    execution::{LogLevel, context::ExecutionContext},
+    node::{Node, NodeScores},
+    pin::{PinOptions, ValueType},
+    variable::VariableType,
+};
+use flow_like_types::{JsonSchema, Value, json::json, reqwest};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+const DEFAULT_LIMIT: i64 = 50;
+const MAX_LIMIT: i64 = 100;
+const MEMBERSHIP_PAGE_SIZE: u64 = 100;
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]
+pub struct UserRef {
+    #[serde(alias = "id")]
+    pub user_id: String,
+    pub sub: String,
+    pub email: Option<String>,
+    pub username: Option<String>,
+    pub preferred_username: Option<String>,
+    pub name: Option<String>,
+    pub avatar_url: Option<String>,
+    pub description: Option<String>,
+    pub created_at: Option<String>,
+    pub additional_information: Option<Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]
+pub struct ProjectRole {
+    pub id: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub attributes: Option<Vec<String>>,
+    pub permissions: i64,
+    pub app_id: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]
+pub struct ProjectMembership {
+    pub id: String,
+    pub user_id: String,
+    pub app_id: String,
+    pub role_id: String,
+    pub created_at: String,
+    pub updated_at: String,
+    pub joined_via: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]
+pub struct ProjectUser {
+    pub user: UserRef,
+    pub membership_id: String,
+    pub app_id: String,
+    pub role_id: String,
+    pub role: Option<ProjectRole>,
+    pub permissions: i64,
+    pub permission_names: Vec<String>,
+    pub attributes: Vec<String>,
+    pub joined_via: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]
+pub struct CurrentUser {
+    pub user: UserRef,
+    pub project_user: Option<ProjectUser>,
+    pub has_project_user: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]
+pub struct UserRoles {
+    pub user: UserRef,
+    pub role: Option<ProjectRole>,
+    pub roles: Vec<ProjectRole>,
+    pub role_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]
+pub struct UserPermissions {
+    pub user: UserRef,
+    pub permissions: i64,
+    pub permission_names: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]
+pub struct UserAttributes {
+    pub user: UserRef,
+    pub attributes: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+struct UserBatchLookupBody {
+    user_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct HubError {
+    status_code: i64,
+    message: String,
+}
+
+impl HubError {
+    fn new(status_code: i64, message: impl Into<String>) -> Self {
+        Self {
+            status_code,
+            message: message.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct HubClient {
+    client: reqwest::Client,
+    token: String,
+    base_url: String,
+}
+
+impl HubClient {
+    fn from_context(context: &ExecutionContext) -> Result<Self, HubError> {
+        let token = context
+            .token
+            .as_deref()
+            .map(str::trim)
+            .filter(|token| !token.is_empty())
+            .ok_or_else(|| HubError::new(0, "No runtime token available"))?;
+
+        let base_url = api_base_url(&context.profile.hub, context.profile.secure)
+            .ok_or_else(|| HubError::new(0, "No hub URL configured on the execution profile"))?;
+
+        Ok(Self {
+            client: reqwest::Client::new(),
+            token: token.to_string(),
+            base_url,
+        })
+    }
+
+    fn url(&self, path: &str) -> String {
+        format!(
+            "{}/{}",
+            self.base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+
+    async fn get_json<T: for<'de> Deserialize<'de>>(
+        &self,
+        path: &str,
+    ) -> Result<(T, i64), HubError> {
+        let url = self.url(path);
+        let response = self
+            .client
+            .get(&url)
+            .bearer_auth(&self.token)
+            .send()
+            .await
+            .map_err(|err| HubError::new(0, format!("Failed to call {path}: {err}")))?;
+
+        parse_response(response, path).await
+    }
+
+    async fn post_json<B: Serialize, T: for<'de> Deserialize<'de>>(
+        &self,
+        path: &str,
+        body: &B,
+    ) -> Result<(T, i64), HubError> {
+        let url = self.url(path);
+        let response = self
+            .client
+            .post(&url)
+            .bearer_auth(&self.token)
+            .json(body)
+            .send()
+            .await
+            .map_err(|err| HubError::new(0, format!("Failed to call {path}: {err}")))?;
+
+        parse_response(response, path).await
+    }
+
+    async fn current_user(&self) -> Result<(UserRef, i64), HubError> {
+        let (value, status) = self.get_json::<Value>("user/info").await?;
+        let user = UserRef {
+            user_id: string_field(&value, "id"),
+            sub: string_field(&value, "id"),
+            email: optional_string_field(&value, "email"),
+            username: optional_string_field(&value, "username"),
+            preferred_username: optional_string_field(&value, "preferred_username"),
+            name: optional_string_field(&value, "name"),
+            avatar_url: optional_string_field(&value, "avatar"),
+            description: optional_string_field(&value, "description"),
+            created_at: optional_string_field(&value, "created_at"),
+            additional_information: value.get("additional_information").cloned(),
+        };
+
+        Ok((user, status))
+    }
+
+    async fn roles(
+        &self,
+        app_id: &str,
+    ) -> Result<(Option<String>, Vec<ProjectRole>, i64), HubError> {
+        let path = format!("apps/{}/roles", urlencoding::encode(app_id));
+        let ((default_role_id, roles), status) = self
+            .get_json::<(Option<String>, Vec<ProjectRole>)>(&path)
+            .await?;
+        Ok((default_role_id, roles, status))
+    }
+
+    async fn memberships(
+        &self,
+        app_id: &str,
+        offset: u64,
+        limit: u64,
+    ) -> Result<(Vec<ProjectMembership>, i64), HubError> {
+        let path = format!(
+            "apps/{}/team?offset={offset}&limit={limit}",
+            urlencoding::encode(app_id)
+        );
+        self.get_json::<Vec<ProjectMembership>>(&path).await
+    }
+
+    async fn lookup_users(
+        &self,
+        user_ids: &[String],
+    ) -> Result<(HashMap<String, UserRef>, i64), HubError> {
+        let mut users = HashMap::new();
+        let mut last_status = 200;
+
+        for chunk in user_ids.chunks(100) {
+            if chunk.is_empty() {
+                continue;
+            }
+
+            let body = UserBatchLookupBody {
+                user_ids: chunk.to_vec(),
+            };
+            let (found, status) = self
+                .post_json::<_, Vec<UserRef>>("user/lookup", &body)
+                .await?;
+            last_status = status;
+
+            for mut user in found {
+                if user.sub.is_empty() {
+                    user.sub = user.user_id.clone();
+                }
+                if user.user_id.is_empty() {
+                    user.user_id = user.sub.clone();
+                }
+                users.insert(user.user_id.clone(), user);
+            }
+        }
+
+        Ok((users, last_status))
+    }
+}
+
+async fn parse_response<T: for<'de> Deserialize<'de>>(
+    response: reqwest::Response,
+    path: &str,
+) -> Result<(T, i64), HubError> {
+    let status = response.status();
+    let status_code = status.as_u16() as i64;
+
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        return Err(HubError::new(
+            status_code,
+            format!("{path} returned {}: {}", status, truncate_error_body(&body)),
+        ));
+    }
+
+    response
+        .json::<T>()
+        .await
+        .map(|value| (value, status_code))
+        .map_err(|err| HubError::new(status_code, format!("Failed to parse {path}: {err}")))
+}
+
+fn api_base_url(hub: &str, secure: bool) -> Option<String> {
+    let hub = hub.trim().trim_end_matches('/');
+    if hub.is_empty() {
+        return None;
+    }
+
+    let origin = if hub.starts_with("http://") || hub.starts_with("https://") {
+        hub.to_string()
+    } else {
+        let protocol = if secure { "https" } else { "http" };
+        format!("{protocol}://{hub}")
+    };
+
+    if origin.ends_with("/api/v1") {
+        return Some(origin);
+    }
+
+    Some(format!("{origin}/api/v1"))
+}
+
+fn truncate_error_body(body: &str) -> String {
+    const MAX_CHARS: usize = 500;
+    let body = body.trim();
+    let mut chars = body.chars();
+    let truncated: String = chars.by_ref().take(MAX_CHARS).collect();
+    if chars.next().is_none() {
+        return body.to_string();
+    }
+
+    format!("{truncated}...")
+}
+
+fn string_field(value: &Value, key: &str) -> String {
+    optional_string_field(value, key).unwrap_or_default()
+}
+
+fn optional_string_field(value: &Value, key: &str) -> Option<String> {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn app_id_from_context(context: &ExecutionContext, app_id: String) -> Result<String, HubError> {
+    let app_id = app_id.trim();
+    if !app_id.is_empty() {
+        return Ok(app_id.to_string());
+    }
+
+    context
+        .execution_cache
+        .as_ref()
+        .map(|cache| cache.app_id.clone())
+        .filter(|app_id| !app_id.trim().is_empty())
+        .ok_or_else(|| {
+            HubError::new(
+                0,
+                "No app_id provided and no execution app context available",
+            )
+        })
+}
+
+fn normalize_offset(offset: i64) -> u64 {
+    offset.max(0) as u64
+}
+
+fn normalize_limit(limit: i64) -> u64 {
+    limit.clamp(1, MAX_LIMIT) as u64
+}
+
+async fn eval_string_pin(context: &mut ExecutionContext, pin: &str, default_value: &str) -> String {
+    context
+        .evaluate_pin::<String>(pin)
+        .await
+        .unwrap_or_else(|_| default_value.to_string())
+}
+
+async fn eval_i64_pin(context: &mut ExecutionContext, pin: &str, default_value: i64) -> i64 {
+    context
+        .evaluate_pin::<i64>(pin)
+        .await
+        .unwrap_or(default_value)
+}
+
+fn role_map(roles: Vec<ProjectRole>) -> HashMap<String, ProjectRole> {
+    roles
+        .into_iter()
+        .map(|role| (role.id.clone(), role))
+        .collect()
+}
+
+fn user_from_membership(
+    membership: ProjectMembership,
+    users: &HashMap<String, UserRef>,
+    roles: &HashMap<String, ProjectRole>,
+) -> ProjectUser {
+    let user = users
+        .get(&membership.user_id)
+        .cloned()
+        .unwrap_or_else(|| UserRef {
+            user_id: membership.user_id.clone(),
+            sub: membership.user_id.clone(),
+            ..Default::default()
+        });
+
+    let role = roles.get(&membership.role_id).cloned();
+    let permissions = role
+        .as_ref()
+        .map(|role| role.permissions)
+        .unwrap_or_default();
+    let attributes = role
+        .as_ref()
+        .and_then(|role| role.attributes.clone())
+        .unwrap_or_default();
+
+    ProjectUser {
+        user,
+        membership_id: membership.id,
+        app_id: membership.app_id,
+        role_id: membership.role_id,
+        role,
+        permissions,
+        permission_names: effective_permission_names(permissions),
+        attributes,
+        joined_via: membership.joined_via,
+        created_at: membership.created_at,
+        updated_at: membership.updated_at,
+    }
+}
+
+async fn hydrate_project_users(
+    client: &HubClient,
+    memberships: Vec<ProjectMembership>,
+    roles: &HashMap<String, ProjectRole>,
+) -> Result<(Vec<ProjectUser>, i64), HubError> {
+    let user_ids = memberships
+        .iter()
+        .map(|membership| membership.user_id.clone())
+        .collect::<Vec<_>>();
+    let (users, status) = client.lookup_users(&user_ids).await?;
+
+    Ok((
+        memberships
+            .into_iter()
+            .map(|membership| user_from_membership(membership, &users, roles))
+            .collect(),
+        status,
+    ))
+}
+
+async fn get_project_user_by_id(
+    client: &HubClient,
+    app_id: &str,
+    user_id: &str,
+    roles: &HashMap<String, ProjectRole>,
+) -> Result<Option<(ProjectUser, i64)>, HubError> {
+    let mut offset = 0;
+
+    loop {
+        let (memberships, status) = client
+            .memberships(app_id, offset, MEMBERSHIP_PAGE_SIZE)
+            .await?;
+
+        if memberships.is_empty() {
+            return Ok(None);
+        }
+
+        if let Some(membership) = memberships
+            .iter()
+            .find(|membership| membership.user_id == user_id)
+            .cloned()
+        {
+            let (mut users, lookup_status) = client
+                .lookup_users(std::slice::from_ref(&membership.user_id))
+                .await?;
+            let user = users
+                .remove(&membership.user_id)
+                .unwrap_or_else(|| UserRef {
+                    user_id: membership.user_id.clone(),
+                    sub: membership.user_id.clone(),
+                    ..Default::default()
+                });
+            let mut user_map = HashMap::new();
+            user_map.insert(user.user_id.clone(), user);
+            return Ok(Some((
+                user_from_membership(membership, &user_map, roles),
+                lookup_status,
+            )));
+        }
+
+        if memberships.len() < MEMBERSHIP_PAGE_SIZE as usize {
+            return Ok(None);
+        }
+
+        offset += MEMBERSHIP_PAGE_SIZE;
+        if status == 0 {
+            return Ok(None);
+        }
+    }
+}
+
+async fn find_project_user_by_email(
+    client: &HubClient,
+    app_id: &str,
+    email: &str,
+    roles: &HashMap<String, ProjectRole>,
+) -> Result<Option<(ProjectUser, i64)>, HubError> {
+    let email = email.trim().to_ascii_lowercase();
+    if email.is_empty() {
+        return Ok(None);
+    }
+
+    let mut offset = 0;
+
+    loop {
+        let (memberships, _) = client
+            .memberships(app_id, offset, MEMBERSHIP_PAGE_SIZE)
+            .await?;
+        if memberships.is_empty() {
+            return Ok(None);
+        }
+
+        let (users, status) = hydrate_project_users(client, memberships, roles).await?;
+        if let Some(user) = users.into_iter().find(|user| {
+            user.user
+                .email
+                .as_deref()
+                .map(|candidate| candidate.eq_ignore_ascii_case(&email))
+                .unwrap_or(false)
+        }) {
+            return Ok(Some((user, status)));
+        }
+
+        offset += MEMBERSHIP_PAGE_SIZE;
+    }
+}
+
+async fn search_project_users(
+    client: &HubClient,
+    app_id: &str,
+    roles: &HashMap<String, ProjectRole>,
+    query: &str,
+    offset: u64,
+    limit: u64,
+) -> Result<(Vec<ProjectUser>, bool, i64), HubError> {
+    if query.trim().is_empty() {
+        let (memberships, status) = client.memberships(app_id, offset, limit).await?;
+        let has_more = memberships.len() == limit as usize;
+        let (users, lookup_status) = hydrate_project_users(client, memberships, roles).await?;
+        return Ok((users, has_more, lookup_status.max(status)));
+    }
+
+    let mut membership_offset = 0;
+    let mut skipped = 0_u64;
+    let mut results = Vec::new();
+    let mut has_more = false;
+    let mut last_status: i64;
+
+    'scan: loop {
+        let (memberships, status) = client
+            .memberships(app_id, membership_offset, MEMBERSHIP_PAGE_SIZE)
+            .await?;
+        last_status = status;
+
+        if memberships.is_empty() {
+            break;
+        }
+
+        let (users, lookup_status) = hydrate_project_users(client, memberships, roles).await?;
+        last_status = lookup_status;
+
+        for user in users {
+            if !matches_project_user(&user, query) {
+                continue;
+            }
+
+            if skipped < offset {
+                skipped += 1;
+                continue;
+            }
+
+            if results.len() < limit as usize {
+                results.push(user);
+            } else {
+                has_more = true;
+                break 'scan;
+            }
+        }
+
+        if results.len() > limit as usize {
+            has_more = true;
+            results.truncate(limit as usize);
+            break;
+        }
+
+        membership_offset += MEMBERSHIP_PAGE_SIZE;
+    }
+
+    Ok((results, has_more, last_status))
+}
+
+async fn filter_project_users<F>(
+    client: &HubClient,
+    app_id: &str,
+    roles: &HashMap<String, ProjectRole>,
+    offset: u64,
+    limit: u64,
+    mut predicate: F,
+) -> Result<(Vec<ProjectUser>, bool, i64), HubError>
+where
+    F: FnMut(&ProjectUser) -> bool,
+{
+    let mut membership_offset = 0;
+    let mut skipped = 0_u64;
+    let mut results = Vec::new();
+    let mut has_more = false;
+    let mut last_status: i64;
+
+    'scan: loop {
+        let (memberships, status) = client
+            .memberships(app_id, membership_offset, MEMBERSHIP_PAGE_SIZE)
+            .await?;
+        last_status = status;
+
+        if memberships.is_empty() {
+            break;
+        }
+
+        let (users, lookup_status) = hydrate_project_users(client, memberships, roles).await?;
+        last_status = lookup_status;
+
+        for user in users {
+            if !predicate(&user) {
+                continue;
+            }
+
+            if skipped < offset {
+                skipped += 1;
+                continue;
+            }
+
+            if results.len() < limit as usize {
+                results.push(user);
+            } else {
+                has_more = true;
+                break 'scan;
+            }
+        }
+
+        membership_offset += MEMBERSHIP_PAGE_SIZE;
+    }
+
+    Ok((results, has_more, last_status))
+}
+
+fn matches_project_user(user: &ProjectUser, query: &str) -> bool {
+    let query = query.trim().to_ascii_lowercase();
+    if query.is_empty() {
+        return true;
+    }
+
+    let fields = [
+        Some(user.user.user_id.as_str()),
+        Some(user.user.sub.as_str()),
+        user.user.email.as_deref(),
+        user.user.username.as_deref(),
+        user.user.preferred_username.as_deref(),
+        user.user.name.as_deref(),
+        user.role.as_ref().map(|role| role.name.as_str()),
+    ];
+
+    fields
+        .into_iter()
+        .flatten()
+        .any(|value| value.to_ascii_lowercase().contains(query.as_str()))
+}
+
+fn role_matches(role: Option<&ProjectRole>, role_query: &str) -> bool {
+    let role_query = role_query.trim();
+    if role_query.is_empty() {
+        return true;
+    }
+
+    role.map(|role| {
+        role.id.eq_ignore_ascii_case(role_query) || role.name.eq_ignore_ascii_case(role_query)
+    })
+    .unwrap_or(false)
+}
+
+fn has_attribute(user: &ProjectUser, attribute: &str) -> bool {
+    let attribute = attribute.trim();
+    if attribute.is_empty() {
+        return false;
+    }
+
+    user.attributes
+        .iter()
+        .any(|candidate| candidate.eq_ignore_ascii_case(attribute))
+}
+
+fn permission_from_name(name: &str) -> Option<i64> {
+    let normalized = normalize_label(name);
+    PERMISSION_OPTIONS
+        .iter()
+        .find(|(candidate, _)| normalize_label(candidate) == normalized)
+        .map(|(_, value)| *value)
+        .or_else(|| name.trim().parse::<i64>().ok())
+}
+
+fn normalize_label(value: &str) -> String {
+    value
+        .chars()
+        .filter(|c| !c.is_whitespace() && *c != '_' && *c != '-')
+        .flat_map(char::to_lowercase)
+        .collect()
+}
+
+fn has_effective_permission(permissions: i64, permission: i64) -> bool {
+    let is_owner = (permissions & PERMISSION_OPTIONS[0].1) != 0;
+    let is_admin = (permissions & PERMISSION_OPTIONS[1].1) != 0;
+    is_owner || is_admin || (permissions & permission) != 0
+}
+
+fn effective_permission_names(permissions: i64) -> Vec<String> {
+    let is_owner = (permissions & PERMISSION_OPTIONS[0].1) != 0;
+    let is_admin = (permissions & PERMISSION_OPTIONS[1].1) != 0;
+
+    PERMISSION_OPTIONS
+        .iter()
+        .filter(|(_, value)| is_owner || is_admin || (permissions & *value) != 0)
+        .map(|(name, _)| (*name).to_string())
+        .collect()
+}
+
+async fn set_common_outputs(
+    context: &mut ExecutionContext,
+    success: bool,
+    status_code: i64,
+    error: &str,
+) -> flow_like_types::Result<()> {
+    context.set_pin_value("success", json!(success)).await?;
+    context
+        .set_pin_value("status_code", json!(status_code))
+        .await?;
+    context.set_pin_value("error", json!(error)).await?;
+    Ok(())
+}
+
+fn base_node(id: &str, name: &str, description: &str) -> Node {
+    let mut node = Node::new(id, name, description, "Utils/User");
+    node.add_icon("/flow/icons/user.svg");
+    node.set_scores(
+        NodeScores::new()
+            .set_privacy(6)
+            .set_security(8)
+            .set_performance(6)
+            .set_governance(8)
+            .set_reliability(7)
+            .set_cost(9)
+            .build(),
+    );
+    node
+}
+
+fn add_app_pin(node: &mut Node) {
+    node.add_input_pin(
+        "app_id",
+        "App ID",
+        "Project/app ID. Leave empty to use the current execution app.",
+        VariableType::String,
+    )
+    .set_default_value(Some(json!("")));
+}
+
+fn add_user_id_pin(node: &mut Node) {
+    node.add_input_pin(
+        "user_id",
+        "User ID",
+        "User subject / user ID within the project.",
+        VariableType::String,
+    )
+    .set_default_value(Some(json!("")));
+}
+
+fn add_pagination_pins(node: &mut Node) {
+    node.add_input_pin(
+        "offset",
+        "Offset",
+        "Number of matching users to skip.",
+        VariableType::Integer,
+    )
+    .set_default_value(Some(json!(0)));
+    node.add_input_pin(
+        "limit",
+        "Limit",
+        "Maximum number of users to return, capped at 100.",
+        VariableType::Integer,
+    )
+    .set_default_value(Some(json!(DEFAULT_LIMIT)));
+}
+
+fn add_common_outputs(node: &mut Node) {
+    node.add_output_pin(
+        "success",
+        "Success",
+        "True when the read operation completed successfully.",
+        VariableType::Boolean,
+    );
+    node.add_output_pin(
+        "status_code",
+        "Status Code",
+        "HTTP status code returned by the hub, or 0 if no request was made.",
+        VariableType::Integer,
+    );
+    node.add_output_pin(
+        "error",
+        "Error",
+        "Error message when the read operation could not complete.",
+        VariableType::String,
+    );
+}
+
+fn add_project_user_output(node: &mut Node) {
+    node.add_output_pin(
+        "project_user",
+        "Project User",
+        "Project membership, sanitized user ref, role, effective permissions, and attributes.",
+        VariableType::Struct,
+    )
+    .set_schema::<ProjectUser>()
+    .set_options(PinOptions::new().set_enforce_schema(true).build());
+    node.add_output_pin(
+        "found",
+        "Found",
+        "True when a matching project user was found.",
+        VariableType::Boolean,
+    );
+}
+
+fn add_users_output(node: &mut Node) {
+    node.add_output_pin(
+        "users",
+        "Users",
+        "Matching project users.",
+        VariableType::Generic,
+    )
+    .set_value_type(ValueType::Array)
+    .set_schema::<Vec<ProjectUser>>();
+    node.add_output_pin(
+        "count",
+        "Count",
+        "Number of users returned.",
+        VariableType::Integer,
+    );
+    node.add_output_pin(
+        "next_offset",
+        "Next Offset",
+        "Offset to use for the next page.",
+        VariableType::Integer,
+    );
+    node.add_output_pin(
+        "has_more",
+        "Has More",
+        "True when another page may contain more matching users.",
+        VariableType::Boolean,
+    );
+}
+
+fn permission_names() -> Vec<String> {
+    PERMISSION_OPTIONS
+        .iter()
+        .map(|(name, _)| (*name).to_string())
+        .collect()
+}
+
+async fn load_roles(
+    client: &HubClient,
+    app_id: &str,
+) -> Result<(HashMap<String, ProjectRole>, i64), HubError> {
+    let (_, roles, status) = client.roles(app_id).await?;
+    Ok((role_map(roles), status))
+}
+
+pub mod check_user_has_role;
+pub mod check_user_permission;
+pub mod get_current_user;
+pub mod get_effective_user_permissions;
+pub mod get_project_user;
+pub mod get_user_attribute;
+pub mod get_user_attributes;
+pub mod get_user_roles;
+pub mod list_project_users;
+pub mod list_users_with_attribute;
+pub mod list_users_with_role;
+pub mod resolve_user;
+pub mod search_users;
+
+pub use check_user_has_role::*;
+pub use check_user_permission::*;
+pub use get_current_user::*;
+pub use get_effective_user_permissions::*;
+pub use get_project_user::*;
+pub use get_user_attribute::*;
+pub use get_user_attributes::*;
+pub use get_user_roles::*;
+pub use list_project_users::*;
+pub use list_users_with_attribute::*;
+pub use list_users_with_role::*;
+pub use resolve_user::*;
+pub use search_users::*;
+
+async fn load_single_project_user(
+    context: &mut ExecutionContext,
+) -> Result<Option<(ProjectUser, i64)>, HubError> {
+    let app_id_input = eval_string_pin(context, "app_id", "").await;
+    let user_id = eval_string_pin(context, "user_id", "").await;
+    let client = HubClient::from_context(context)?;
+    let app_id = app_id_from_context(context, app_id_input)?;
+    let (roles, role_status) = load_roles(&client, &app_id).await?;
+
+    get_project_user_by_id(&client, &app_id, user_id.trim(), &roles)
+        .await
+        .map(|found| found.map(|(user, status)| (user, status.max(role_status))))
+}
+
+async fn run_single_project_user_node(
+    context: &mut ExecutionContext,
+) -> flow_like_types::Result<()> {
+    match load_single_project_user(context).await {
+        Ok(Some((user, status))) => {
+            context.set_pin_value("project_user", json!(user)).await?;
+            context.set_pin_value("found", json!(true)).await?;
+            set_common_outputs(context, true, status, "").await?;
+        }
+        Ok(None) => {
+            context.set_pin_value("project_user", Value::Null).await?;
+            context.set_pin_value("found", json!(false)).await?;
+            set_common_outputs(context, true, 200, "").await?;
+        }
+        Err(err) => {
+            context.log_message(&err.message, LogLevel::Warn);
+            context.set_pin_value("project_user", Value::Null).await?;
+            context.set_pin_value("found", json!(false)).await?;
+            set_common_outputs(context, false, err.status_code, &err.message).await?;
+        }
+    }
+    Ok(())
+}
+
+async fn run_user_list_node<'a, F>(
+    context: &'a mut ExecutionContext,
+    handler: F,
+) -> flow_like_types::Result<()>
+where
+    F: for<'b> FnOnce(
+        &'b HubClient,
+        &'b str,
+        &'b HashMap<String, ProjectRole>,
+        u64,
+        u64,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<Output = Result<(Vec<ProjectUser>, bool, i64), HubError>>
+                + Send
+                + 'b,
+        >,
+    >,
+{
+    let app_id_input = eval_string_pin(context, "app_id", "").await;
+    let offset = normalize_offset(eval_i64_pin(context, "offset", 0).await);
+    let limit = normalize_limit(eval_i64_pin(context, "limit", DEFAULT_LIMIT).await);
+
+    let client = match HubClient::from_context(context) {
+        Ok(client) => client,
+        Err(err) => {
+            context.set_pin_value("users", json!([])).await?;
+            context.set_pin_value("count", json!(0)).await?;
+            context
+                .set_pin_value("next_offset", json!(offset as i64))
+                .await?;
+            context.set_pin_value("has_more", json!(false)).await?;
+            set_common_outputs(context, false, err.status_code, &err.message).await?;
+            return Ok(());
+        }
+    };
+
+    let app_id = match app_id_from_context(context, app_id_input) {
+        Ok(app_id) => app_id,
+        Err(err) => {
+            context.set_pin_value("users", json!([])).await?;
+            context.set_pin_value("count", json!(0)).await?;
+            context
+                .set_pin_value("next_offset", json!(offset as i64))
+                .await?;
+            context.set_pin_value("has_more", json!(false)).await?;
+            set_common_outputs(context, false, err.status_code, &err.message).await?;
+            return Ok(());
+        }
+    };
+
+    let result = async {
+        let (roles, role_status) = load_roles(&client, &app_id).await?;
+        let (users, has_more, status) = handler(&client, &app_id, &roles, offset, limit).await?;
+        Ok::<_, HubError>((users, has_more, status.max(role_status)))
+    }
+    .await;
+
+    match result {
+        Ok((users, has_more, status)) => {
+            let count = users.len() as i64;
+            let next_offset = offset as i64 + count;
+            context.set_pin_value("users", json!(users)).await?;
+            context.set_pin_value("count", json!(count)).await?;
+            context
+                .set_pin_value("next_offset", json!(next_offset))
+                .await?;
+            context.set_pin_value("has_more", json!(has_more)).await?;
+            set_common_outputs(context, true, status, "").await?;
+        }
+        Err(err) => {
+            context.log_message(&err.message, LogLevel::Warn);
+            context.set_pin_value("users", json!([])).await?;
+            context.set_pin_value("count", json!(0)).await?;
+            context
+                .set_pin_value("next_offset", json!(offset as i64))
+                .await?;
+            context.set_pin_value("has_more", json!(false)).await?;
+            set_common_outputs(context, false, err.status_code, &err.message).await?;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        api_base_url, effective_permission_names, has_effective_permission, permission_from_name,
+    };
+
+    #[test]
+    fn builds_api_base_url() {
+        assert_eq!(
+            api_base_url("https://hub.flow-like.com/", true).as_deref(),
+            Some("https://hub.flow-like.com/api/v1")
+        );
+        assert_eq!(
+            api_base_url("https://hub.flow-like.com/api/v1", true).as_deref(),
+            Some("https://hub.flow-like.com/api/v1")
+        );
+        assert_eq!(
+            api_base_url("localhost:8080", false).as_deref(),
+            Some("http://localhost:8080/api/v1")
+        );
+        assert_eq!(api_base_url(" ", true), None);
+    }
+
+    #[test]
+    fn resolves_permissions_by_name_and_alias_shape() {
+        assert_eq!(permission_from_name("Read Boards"), Some(256));
+        assert_eq!(permission_from_name("read_boards"), Some(256));
+        assert_eq!(permission_from_name("read-boards"), Some(256));
+        assert_eq!(permission_from_name("256"), Some(256));
+        assert_eq!(permission_from_name("missing"), None);
+    }
+
+    #[test]
+    fn expands_owner_and_admin_permissions() {
+        assert!(has_effective_permission(1, 256));
+        assert!(has_effective_permission(2, 256));
+        assert!(effective_permission_names(1).contains(&"Read Boards".to_string()));
+        assert!(effective_permission_names(256).contains(&"Read Boards".to_string()));
+    }
+}

--- a/packages/catalog/std/src/utils/user/project_users/resolve_user.rs
+++ b/packages/catalog/std/src/utils/user/project_users/resolve_user.rs
@@ -1,0 +1,115 @@
+use super::*;
+use flow_like::flow::{
+    execution::context::ExecutionContext,
+    node::{Node, NodeLogic},
+};
+use flow_like_types::async_trait;
+
+#[crate::register_node]
+#[derive(Default)]
+pub struct ResolveUserNode {}
+
+impl ResolveUserNode {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+#[async_trait]
+impl NodeLogic for ResolveUserNode {
+    fn get_node(&self) -> Node {
+        let mut node = base_node(
+            "utils_user_resolve_user",
+            "Resolve User",
+            "Resolves a project user by user ID/sub or by email when email is exposed by platform lookup settings. Email matching is constrained to project members.",
+        );
+        add_app_pin(&mut node);
+        node.add_input_pin(
+            "identifier",
+            "Identifier",
+            "Email, sub, or user ID to resolve within the project.",
+            VariableType::String,
+        )
+        .set_default_value(Some(json!("")));
+        node.add_input_pin(
+            "identifier_type",
+            "Identifier Type",
+            "How to interpret the identifier.",
+            VariableType::String,
+        )
+        .set_default_value(Some(json!("auto")))
+        .set_options(
+            PinOptions::new()
+                .set_valid_values(vec![
+                    "auto".to_string(),
+                    "email".to_string(),
+                    "sub".to_string(),
+                    "user_id".to_string(),
+                ])
+                .build(),
+        );
+        add_project_user_output(&mut node);
+        add_common_outputs(&mut node);
+        node
+    }
+
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        let app_id_input = eval_string_pin(context, "app_id", "").await;
+        let identifier = eval_string_pin(context, "identifier", "").await;
+        let identifier_type = eval_string_pin(context, "identifier_type", "auto").await;
+
+        let client = match HubClient::from_context(context) {
+            Ok(client) => client,
+            Err(err) => {
+                context.set_pin_value("project_user", Value::Null).await?;
+                context.set_pin_value("found", json!(false)).await?;
+                set_common_outputs(context, false, err.status_code, &err.message).await?;
+                return Ok(());
+            }
+        };
+        let app_id = match app_id_from_context(context, app_id_input) {
+            Ok(app_id) => app_id,
+            Err(err) => {
+                context.set_pin_value("project_user", Value::Null).await?;
+                context.set_pin_value("found", json!(false)).await?;
+                set_common_outputs(context, false, err.status_code, &err.message).await?;
+                return Ok(());
+            }
+        };
+
+        let result = async {
+            let (roles, status) = load_roles(&client, &app_id).await?;
+            let kind = identifier_type.trim().to_ascii_lowercase();
+            let by_email = kind == "email" || (kind == "auto" && identifier.contains('@'));
+            let found = if by_email {
+                find_project_user_by_email(&client, &app_id, &identifier, &roles).await?
+            } else {
+                get_project_user_by_id(&client, &app_id, identifier.trim(), &roles).await?
+            };
+
+            Ok::<_, HubError>((found, status))
+        }
+        .await;
+
+        match result {
+            Ok((Some((user, status)), role_status)) => {
+                context.set_pin_value("project_user", json!(user)).await?;
+                context.set_pin_value("found", json!(true)).await?;
+                set_common_outputs(context, true, status.max(role_status), "").await?;
+            }
+            Ok((None, status)) => {
+                context.set_pin_value("project_user", Value::Null).await?;
+                context.set_pin_value("found", json!(false)).await?;
+                set_common_outputs(context, true, status, "").await?;
+            }
+            Err(err) => {
+                context.log_message(&err.message, LogLevel::Warn);
+                context.set_pin_value("project_user", Value::Null).await?;
+                context.set_pin_value("found", json!(false)).await?;
+                set_common_outputs(context, false, err.status_code, &err.message).await?;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/packages/catalog/std/src/utils/user/project_users/search_users.rs
+++ b/packages/catalog/std/src/utils/user/project_users/search_users.rs
@@ -1,0 +1,50 @@
+use super::*;
+use flow_like::flow::{
+    execution::context::ExecutionContext,
+    node::{Node, NodeLogic},
+};
+use flow_like_types::async_trait;
+
+#[crate::register_node]
+#[derive(Default)]
+pub struct SearchUsersNode {}
+
+impl SearchUsersNode {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+#[async_trait]
+impl NodeLogic for SearchUsersNode {
+    fn get_node(&self) -> Node {
+        let mut node = base_node(
+            "utils_user_search_users",
+            "Search Users",
+            "Searches project users by exposed profile fields. Email is only searchable when the platform returns email in user lookup results.",
+        );
+        add_app_pin(&mut node);
+        node.add_input_pin(
+            "query",
+            "Query",
+            "Search text matched against project user ID, username, preferred username, name, visible email, or role name.",
+            VariableType::String,
+        )
+        .set_default_value(Some(json!("")));
+        add_pagination_pins(&mut node);
+        add_users_output(&mut node);
+        add_common_outputs(&mut node);
+        node
+    }
+
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        let query = eval_string_pin(context, "query", "").await;
+        run_user_list_node(context, |client, app_id, roles, offset, limit| {
+            let query = query.clone();
+            Box::pin(async move {
+                search_project_users(client, app_id, roles, &query, offset, limit).await
+            })
+        })
+        .await
+    }
+}


### PR DESCRIPTION
This pull request introduces several improvements and new features to user and permission handling in both the backend API and the catalog's user utilities. The changes focus on enhancing permission checks, improving user lookup security, and adding new nodes for working with project users in the catalog. Additionally, there are minor version bumps for the desktop app.

**Backend API improvements:**

* Replaced the `ensure_permission!` macro in `get_roles` and `get_team` endpoints with explicit permission checks, including invalidating permissions and returning `FORBIDDEN` errors when appropriate. [[1]](diffhunk://#diff-9f01d88950cc9c194116eecb8752531a724b61c40b956069b9e4f9f095dd610dL2) [[2]](diffhunk://#diff-9f01d88950cc9c194116eecb8752531a724b61c40b956069b9e4f9f095dd610dL40-R45) [[3]](diffhunk://#diff-b0004936c518d2a1b134436d239393d4fbf2010cde0a178bbbef9833ec1fc564L2-R2) [[4]](diffhunk://#diff-b0004936c518d2a1b134436d239393d4fbf2010cde0a178bbbef9833ec1fc564L39-R45)
* Updated user info and lookup endpoints to use `executor_scoped_sub` for more secure user identification, and added logic to restrict user lookup to only users within the executor's app context. Batch lookup now filters user IDs to only those belonging to the same app. [[1]](diffhunk://#diff-54bd1502a4859a26630f0e833c3ecef74ef3d87fad061bb735d6a50f1f557f19L55-R66) [[2]](diffhunk://#diff-54bd1502a4859a26630f0e833c3ecef74ef3d87fad061bb735d6a50f1f557f19L81-R88) [[3]](diffhunk://#diff-54bd1502a4859a26630f0e833c3ecef74ef3d87fad061bb735d6a50f1f557f19R120-R122) [[4]](diffhunk://#diff-54bd1502a4859a26630f0e833c3ecef74ef3d87fad061bb735d6a50f1f557f19R132-R135) [[5]](diffhunk://#diff-2a54a5276b492d94c42b2cc12639da5af82d68d210a0548a23568a3db0d781d8L2-R6) [[6]](diffhunk://#diff-2a54a5276b492d94c42b2cc12639da5af82d68d210a0548a23568a3db0d781d8L92-R97) [[7]](diffhunk://#diff-2a54a5276b492d94c42b2cc12639da5af82d68d210a0548a23568a3db0d781d8L126-R131) [[8]](diffhunk://#diff-2a54a5276b492d94c42b2cc12639da5af82d68d210a0548a23568a3db0d781d8R146-R150) [[9]](diffhunk://#diff-2a54a5276b492d94c42b2cc12639da5af82d68d210a0548a23568a3db0d781d8R165-R221)

**Catalog user utilities enhancements:**

* Added new nodes in `project_users`:
  - [`CheckUserHasRoleNode`](diffhunk://#diff-423561fe08e066adba74fff947dc26c826bf48a3ec040f4145f6de416355aa3fR1-R73): Checks if a project user has a specific role by ID or exact name.
  - [`CheckUserPermissionNode`](diffhunk://#diff-3888a8617ed373ed61f278da4dba91c3ceaf4dcaba5304d973b743f8b42b7e72R1-R97): Checks if a project user has a specific permission, including implied permissions from Owner/Admin roles.
  - [`GetCurrentUserNode`](diffhunk://#diff-2e4fc140eecceb90bb1ad8e4b79fdc5308340cbdf278b0f70914067199330b83R1-R97): Retrieves the current runtime user with project membership, role, permissions, and attributes.
* Exposed `PERMISSION_OPTIONS` as `pub(crate)` for use in other modules.
* Re-exported new project user utilities in `mod.rs`.

**Version updates:**

* Bumped the desktop app version from `0.1.5` to `0.1.6` in both `tauri.conf.json` and iOS `Info.plist`. [[1]](diffhunk://#diff-4507fdd27e842ca02a7a7fd3b429ccce270607d0ab49cded81414afb4ab5d825L22-R22) [[2]](diffhunk://#diff-4507fdd27e842ca02a7a7fd3b429ccce270607d0ab49cded81414afb4ab5d825L35-R35) [[3]](diffhunk://#diff-25f93a9e45647c833a5769e5c21fb1735e0ffd08f536dad2337de462ed7d14ddL3-R3)