### PR TITLE
fix: improve fetchSize method to handle backend size retrieval and av…

### DIFF
--- a/packages/ui/lib/bit/bit.ts
+++ b/packages/ui/lib/bit/bit.ts
@@ -206,17 +206,16 @@ export class Bit implements IBit {
 
 	public async fetchSize(): Promise<number> {
 		if (this.backend?.bitState?.getBitSize) {
-			return await this.backend.bitState.getBitSize(this.toObject());
+			return this.backend.bitState.getBitSize(this.toObject());
 		}
 
 		const pack = await this.fetchDependencies();
-		const bits = [...pack.bits, this.toObject()];
-		const bitsConsidered = new Set<string>();
-		return bits.reduce((acc, bit) => {
+		const bitsConsidered = new Set<string>([this.hash]);
+		return pack.bits.reduce((acc, bit) => {
 			if (bitsConsidered.has(bit.hash)) return acc;
 			bitsConsidered.add(bit.hash);
 			return acc + (bit.size ?? 0);
-		}, 0);
+		}, this.size ?? 0);
 	}
 
 	async download(cb?: (progress: Download) => void): Promise<IBit[]> {

--- a/packages/ui/lib/bit/bit.ts
+++ b/packages/ui/lib/bit/bit.ts
@@ -205,10 +205,18 @@ export class Bit implements IBit {
 	}
 
 	public async fetchSize(): Promise<number> {
-		const pack = await this.fetchDependencies();
+		if (this.backend?.bitState?.getBitSize) {
+			return await this.backend.bitState.getBitSize(this.toObject());
+		}
 
-		console.dir(pack, { depth: null });
-		return pack.bits.reduce((acc, bit) => acc + (bit.size ?? 0), 0);
+		const pack = await this.fetchDependencies();
+		const bits = [...pack.bits, this.toObject()];
+		const bitsConsidered = new Set<string>();
+		return bits.reduce((acc, bit) => {
+			if (bitsConsidered.has(bit.hash)) return acc;
+			bitsConsidered.add(bit.hash);
+			return acc + (bit.size ?? 0);
+		}, 0);
 	}
 
 	async download(cb?: (progress: Download) => void): Promise<IBit[]> {


### PR DESCRIPTION
This pull request updates the logic for calculating the size of a `Bit` in the `fetchSize` method of the `Bit` class. The new implementation first tries to use a backend-provided method if available, and otherwise improves the fallback calculation by including the current bit and ensuring each bit is only counted once.

Improvements to bit size calculation:

* The `fetchSize` method now checks if the backend provides a `getBitSize` method and uses it if available, allowing for potentially more accurate or efficient size calculations.
* If the backend method is not available, the fallback logic now includes the current bit in the size calculation and prevents double-counting bits by tracking them with a `Set` of hashes.