### PR TITLE
feat: add search component and link documentation pages to nodes

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -21,6 +21,7 @@ export default defineConfig({
 				"Documentation for Flow-Like, the open source local-first workflow engine. Build type-safe, self-hosted automation with Rust performance.",
 			components: {
 				Hero: "./src/components/docs/Hero.astro",
+				Search: "./src/components/docs/Search.astro",
 				SiteTitle: "./src/components/docs/SiteTitle.astro",
 			},
 			head: [

--- a/apps/docs/src/components/docs/Search.astro
+++ b/apps/docs/src/components/docs/Search.astro
@@ -1,0 +1,381 @@
+---
+import { Icon } from "@astrojs/starlight/components";
+import project from "virtual:starlight/project-context";
+
+const pagefindTranslations = {
+	placeholder: Astro.locals.t("search.label"),
+	...Object.fromEntries(
+		Object.entries(Astro.locals.t.all())
+			.filter(([key]) => key.startsWith("pagefind."))
+			.map(([key, value]) => [key.replace("pagefind.", ""), value]),
+	),
+};
+
+const dataAttributes: DOMStringMap = {
+	"data-translations": JSON.stringify(pagefindTranslations),
+};
+if (project.trailingSlash === "never") {
+	dataAttributes["data-strip-trailing-slash"] = "";
+}
+---
+
+<site-search class={Astro.props.class} {...dataAttributes}>
+	<button
+		data-open-modal
+		disabled
+		aria-label={Astro.locals.t("search.label")}
+		aria-keyshortcuts="Control+K"
+	>
+		<Icon name="magnifier" />
+		<span class="sl-hidden md:sl-block" aria-hidden="true">
+			{Astro.locals.t("search.label")}
+		</span>
+		<kbd class="sl-hidden md:sl-flex" style="display: none;">
+			<kbd>{Astro.locals.t("search.ctrlKey")}</kbd><kbd>K</kbd>
+		</kbd>
+	</button>
+
+	<dialog style="padding:0" aria-label={Astro.locals.t("search.label")}>
+		<div class="dialog-frame sl-flex">
+			<button data-close-modal class="sl-flex md:sl-hidden">
+				{Astro.locals.t("search.cancelLabel")}
+			</button>
+			{
+				import.meta.env.DEV ? (
+					<div style="margin: auto; text-align: center; white-space: pre-line;" dir="ltr">
+						<p>{Astro.locals.t("search.devWarning")}</p>
+					</div>
+				) : (
+					<div class="search-container">
+						<div id="starlight__search" />
+					</div>
+				)
+			}
+		</div>
+	</dialog>
+</site-search>
+
+<script is:inline>
+	(() => {
+		const openBtn = document.querySelector("button[data-open-modal]");
+		const shortcut = openBtn?.querySelector("kbd");
+		if (!openBtn || !(shortcut instanceof HTMLElement)) return;
+		const platformKey = shortcut.querySelector("kbd");
+		if (platformKey && /(Mac|iPhone|iPod|iPad)/i.test(navigator.platform)) {
+			platformKey.textContent = "⌘";
+			openBtn.setAttribute("aria-keyshortcuts", "Meta+K");
+		}
+		shortcut.style.display = "";
+	})();
+</script>
+
+<script>
+	import { pagefindUserConfig } from "virtual:starlight/pagefind-config";
+
+	class SiteSearch extends HTMLElement {
+		private initPromise?: Promise<void>;
+
+		constructor() {
+			super();
+
+			const openBtn = this.querySelector<HTMLButtonElement>(
+				"button[data-open-modal]",
+			);
+			const closeBtn = this.querySelector<HTMLButtonElement>(
+				"button[data-close-modal]",
+			);
+			const dialog = this.querySelector("dialog");
+			const dialogFrame = this.querySelector(".dialog-frame");
+
+			if (!openBtn || !closeBtn || !dialog || !dialogFrame) return;
+
+			const closeModal = () => dialog.close();
+			const onClick = (event: MouseEvent) => {
+				const target = event.target;
+				const isLink = target instanceof Element && target.closest("a[href]");
+				if (
+					isLink ||
+					(target instanceof Node &&
+						document.body.contains(target) &&
+						!dialogFrame.contains(target))
+				) {
+					closeModal();
+				}
+			};
+
+			const focusInput = () => {
+				this.querySelector<HTMLInputElement>("#starlight__search input")?.focus();
+			};
+
+			const openModal = (event?: MouseEvent) => {
+				dialog.showModal();
+				document.body.toggleAttribute("data-search-modal-open", true);
+				void this.initSearch().then(focusInput);
+				event?.stopPropagation();
+				window.addEventListener("click", onClick);
+			};
+
+			openBtn.addEventListener("click", openModal);
+			openBtn.disabled = false;
+			closeBtn.addEventListener("click", closeModal);
+
+			dialog.addEventListener("close", () => {
+				document.body.toggleAttribute("data-search-modal-open", false);
+				window.removeEventListener("click", onClick);
+			});
+
+			window.addEventListener("keydown", (event) => {
+				if ((event.metaKey || event.ctrlKey) && event.key === "k") {
+					dialog.open ? closeModal() : openModal();
+					event.preventDefault();
+				}
+			});
+
+			this.scheduleInit();
+		}
+
+		private scheduleInit() {
+			if (import.meta.env.DEV) return;
+
+			const start = () => {
+				const run = () => {
+					void this.initSearch();
+				};
+				if ("requestIdleCallback" in window) {
+					window.requestIdleCallback(run);
+				} else {
+					window.setTimeout(run, 1);
+				}
+				window.setTimeout(run, 750);
+			};
+
+			if (document.readyState === "loading") {
+				window.addEventListener("DOMContentLoaded", start, { once: true });
+			} else {
+				start();
+			}
+		}
+
+		private initSearch() {
+			if (import.meta.env.DEV) return Promise.resolve();
+			if (this.querySelector("#starlight__search .pagefind-ui")) {
+				return Promise.resolve();
+			}
+			if (this.initPromise) return this.initPromise;
+
+			let translations = {};
+			try {
+				translations = JSON.parse(this.dataset.translations || "{}");
+			} catch {}
+
+			const shouldStrip = this.dataset.stripTrailingSlash !== undefined;
+			const formatUrl = shouldStrip
+				? (path: string) => path.replace(/(.)\/(#.*)?$/, "$1$2")
+				: (path: string) => path;
+
+			this.initPromise = import("@pagefind/default-ui")
+				.then(({ PagefindUI }) => {
+					if (this.querySelector("#starlight__search .pagefind-ui")) return;
+
+					new PagefindUI({
+						...pagefindUserConfig,
+						element: "#starlight__search",
+						baseUrl: import.meta.env.BASE_URL,
+						bundlePath:
+							import.meta.env.BASE_URL.replace(/\/$/, "") + "/pagefind/",
+						showImages: false,
+						translations,
+						showSubResults: true,
+						processResult: (result: {
+							url: string;
+							sub_results: Array<{ url: string }>;
+						}) => {
+							result.url = formatUrl(result.url);
+							result.sub_results = result.sub_results.map((subResult) => {
+								subResult.url = formatUrl(subResult.url);
+								return subResult;
+							});
+						},
+					});
+				})
+				.catch((error) => {
+					this.initPromise = undefined;
+					console.error("Failed to initialize docs search", error);
+				});
+
+			return this.initPromise;
+		}
+	}
+
+	if (!customElements.get("site-search")) {
+		customElements.define("site-search", SiteSearch);
+	}
+</script>
+
+<style>
+	@layer starlight.core {
+		site-search {
+			display: contents;
+		}
+
+		button[data-open-modal] {
+			display: flex;
+			align-items: center;
+			gap: 0.5rem;
+			height: 2.5rem;
+			border: 0;
+			background-color: transparent;
+			color: var(--sl-color-gray-1);
+			cursor: pointer;
+			font-size: var(--sl-text-xl);
+		}
+
+		@media (min-width: 50rem) {
+			button[data-open-modal] {
+				width: 100%;
+				max-width: 22rem;
+				border: 1px solid var(--sl-color-gray-5);
+				border-radius: 0.5rem;
+				padding-inline-start: 0.75rem;
+				padding-inline-end: 0.5rem;
+				background-color: var(--sl-color-black);
+				color: var(--sl-color-gray-2);
+				font-size: var(--sl-text-sm);
+			}
+
+			button[data-open-modal]:hover {
+				border-color: var(--sl-color-gray-2);
+				color: var(--sl-color-white);
+			}
+
+			button[data-open-modal] > :last-child {
+				margin-inline-start: auto;
+			}
+		}
+
+		button > kbd {
+			gap: 0.25em;
+			border-radius: 0.25rem;
+			padding-inline: 0.375rem;
+			background-color: var(--sl-color-gray-6);
+			font-size: var(--sl-text-2xs);
+		}
+
+		kbd {
+			font-family: var(--__sl-font);
+		}
+
+		dialog {
+			width: 100%;
+			max-width: 100%;
+			height: 100%;
+			max-height: 100%;
+			margin: 0;
+			border: 1px solid var(--sl-color-gray-5);
+			background-color: var(--sl-color-gray-6);
+			box-shadow: var(--sl-shadow-lg);
+		}
+
+		dialog[open] {
+			display: flex;
+		}
+
+		dialog::backdrop {
+			background-color: var(--sl-color-backdrop-overlay);
+			backdrop-filter: blur(0.25rem);
+			-webkit-backdrop-filter: blur(0.25rem);
+		}
+
+		.dialog-frame {
+			position: relative;
+			flex-direction: column;
+			flex-grow: 1;
+			gap: 1rem;
+			overflow: auto;
+			padding: 1rem;
+		}
+
+		button[data-close-modal] {
+			position: absolute;
+			z-index: 1;
+			align-items: center;
+			align-self: flex-end;
+			height: calc(64px * var(--pagefind-ui-scale));
+			border: 0;
+			padding: 0.25rem;
+			background: transparent;
+			color: var(--sl-color-text-accent);
+			cursor: pointer;
+		}
+
+		#starlight__search {
+			--pagefind-ui-primary: var(--sl-color-text);
+			--pagefind-ui-text: var(--sl-color-gray-2);
+			--pagefind-ui-font: var(--__sl-font);
+			--pagefind-ui-background: var(--sl-color-black);
+			--pagefind-ui-border: var(--sl-color-gray-5);
+			--pagefind-ui-border-width: 1px;
+			--pagefind-ui-tag: var(--sl-color-gray-5);
+			--sl-search-cancel-space: 5rem;
+		}
+
+		:root[data-theme="light"] #starlight__search {
+			--pagefind-ui-tag: var(--sl-color-gray-6);
+		}
+
+		@media (min-width: 50rem) {
+			#starlight__search {
+				--sl-search-cancel-space: 0px;
+			}
+
+			dialog {
+				width: 90%;
+				max-width: 40rem;
+				height: max-content;
+				min-height: 15rem;
+				max-height: calc(100% - 8rem);
+				margin: 4rem auto auto;
+				border-radius: 0.5rem;
+			}
+
+			.dialog-frame {
+				padding: 1.5rem;
+			}
+		}
+	}
+</style>
+
+<style is:global>
+	@import url("@pagefind/default-ui/css/ui.css") layer(starlight.core);
+
+	@layer starlight.core {
+		[data-search-modal-open] {
+			overflow: hidden;
+		}
+
+		#starlight__search .pagefind-ui__search-input {
+			width: calc(100% - var(--sl-search-cancel-space));
+			color: var(--sl-color-white);
+			font-weight: 400;
+		}
+
+		#starlight__search input:focus {
+			--pagefind-ui-border: var(--sl-color-accent);
+		}
+
+		#starlight__search .pagefind-ui__search-clear {
+			inset-inline-end: var(--sl-search-cancel-space);
+			background-color: transparent;
+		}
+
+		#starlight__search .pagefind-ui__result-link {
+			--pagefind-ui-text: var(--sl-color-white);
+		}
+
+		#starlight__search mark {
+			background-color: transparent;
+			color: var(--sl-color-gray-2);
+			font-weight: 600;
+		}
+	}
+</style>

--- a/apps/docs/src/components/docs/Search.astro
+++ b/apps/docs/src/components/docs/Search.astro
@@ -61,7 +61,7 @@ if (project.trailingSlash === "never") {
 		const shortcut = openBtn?.querySelector("kbd");
 		if (!openBtn || !(shortcut instanceof HTMLElement)) return;
 		const platformKey = shortcut.querySelector("kbd");
-		if (platformKey && /(Mac|iPhone|iPod|iPad)/i.test(navigator.platform)) {
+		if (platformKey && /(Mac|iPhone|iPod|iPad)/i.test(navigator.userAgent)) {
 			platformKey.textContent = "⌘";
 			openBtn.setAttribute("aria-keyshortcuts", "Meta+K");
 		}
@@ -141,7 +141,7 @@ if (project.trailingSlash === "never") {
 				const run = () => {
 					void this.initSearch();
 				};
-				if ("requestIdleCallback" in window) {
+				if (typeof window.requestIdleCallback === "function") {
 					window.requestIdleCallback(run);
 				} else {
 					window.setTimeout(run, 1);
@@ -195,6 +195,7 @@ if (project.trailingSlash === "never") {
 								subResult.url = formatUrl(subResult.url);
 								return subResult;
 							});
+							return result;
 						},
 					});
 				})

--- a/apps/docs/src/env.d.ts
+++ b/apps/docs/src/env.d.ts
@@ -1,0 +1,11 @@
+/// <reference types="astro/client" />
+
+declare module "virtual:starlight/pagefind-config" {
+	export const pagefindUserConfig: Record<string, unknown>;
+}
+
+declare module "@pagefind/default-ui" {
+	export class PagefindUI {
+		constructor(options: Record<string, unknown>);
+	}
+}

--- a/apps/docs/src/styles/global.css
+++ b/apps/docs/src/styles/global.css
@@ -270,6 +270,10 @@ html:has(.node-doc) {
 	--pin-execution: var(--sl-color-white);
 }
 
+html:has(.node-doc) mobile-starlight-toc {
+	display: none;
+}
+
 .node-doc,
 .node-doc *,
 .node-doc *::before,

--- a/apps/website/src/components/download/DownloadPage.astro
+++ b/apps/website/src/components/download/DownloadPage.astro
@@ -26,7 +26,108 @@ const canonical = new URL(Astro.url.pathname, siteUrl).toString();
 const alternateLinks = buildAlternateLinks(siteUrl, Astro.url.pathname);
 
 const ownerRepo = "Rheosoph/flow-like";
-const listUrl = `https://api.github.com/repos/${ownerRepo}/releases`;
+const apiBase = `https://api.github.com/repos/${ownerRepo}`;
+const listUrl = `${apiBase}/releases`;
+const tagsUrl = `${apiBase}/tags`;
+const releaseTagPattern = /^(?:(alpha|beta)-)?v?(\d+)\.(\d+)\.(\d+)$/i;
+const channelRank: Record<string, number> = { stable: 3, beta: 2, alpha: 1 };
+
+const parseReleaseTag = (tag?: string | null) => {
+  const match = tag?.match(releaseTagPattern);
+  if (!match) return null;
+
+  return {
+    channel: (match[1] ?? "stable").toLowerCase(),
+    major: Number(match[2]),
+    minor: Number(match[3]),
+    patch: Number(match[4]),
+  };
+};
+
+const compareReleaseTags = (a: string, b: string) => {
+  const left = parseReleaseTag(a);
+  const right = parseReleaseTag(b);
+  if (left && right) {
+    const versionDiff =
+      left.major - right.major ||
+      left.minor - right.minor ||
+      left.patch - right.patch;
+    if (versionDiff !== 0) return versionDiff;
+
+    return (channelRank[left.channel] ?? 0) - (channelRank[right.channel] ?? 0);
+  }
+
+  if (left) return 1;
+  if (right) return -1;
+  return a.localeCompare(b);
+};
+
+const releaseTag = (release: any) => release?.tag_name ?? release?.name ?? "";
+
+const hasDownloadableAssets = (release: any) =>
+  Array.isArray(release?.assets) &&
+  release.assets.some(
+    (asset: any) =>
+      asset?.browser_download_url &&
+      asset?.name &&
+      !/\.json$/i.test(asset.name) &&
+      !/\.sig$/i.test(asset.name),
+  );
+
+const pickNewestRelease = (releases: any[]) => {
+  const nonDraft = releases.filter((release: any) => !release.draft);
+  const candidates = nonDraft.some(hasDownloadableAssets)
+    ? nonDraft.filter(hasDownloadableAssets)
+    : nonDraft;
+
+  return (
+    candidates.sort((a: any, b: any) => {
+      const tagDiff = compareReleaseTags(releaseTag(b), releaseTag(a));
+      if (tagDiff !== 0) return tagDiff;
+
+      return (
+        Date.parse(b.published_at ?? b.created_at ?? "") -
+        Date.parse(a.published_at ?? a.created_at ?? "")
+      );
+    })[0] ?? null
+  );
+};
+
+const fetchJson = async (url: string, headers: Record<string, string>) => {
+  const res = await fetch(url, { headers });
+  if (!res.ok) return null;
+  return res.json();
+};
+
+const fetchLatestReleaseAllowingPrerelease = async (
+  headers: Record<string, string>,
+) => {
+  const tags = await fetchJson(`${tagsUrl}?per_page=30`, headers);
+  if (Array.isArray(tags)) {
+    const releaseTags = tags
+      .map((tag: any) => tag?.name)
+      .filter((tag: unknown): tag is string => typeof tag === "string")
+      .filter((tag: string) => parseReleaseTag(tag))
+      .sort((a: string, b: string) => compareReleaseTags(b, a));
+
+    for (const tag of releaseTags) {
+      const taggedRelease = await fetchJson(
+        `${listUrl}/tags/${encodeURIComponent(tag)}`,
+        headers,
+      );
+      if (
+        taggedRelease &&
+        !taggedRelease.draft &&
+        hasDownloadableAssets(taggedRelease)
+      ) {
+        return taggedRelease;
+      }
+    }
+  }
+
+  const releases = await fetchJson(`${listUrl}?per_page=10`, headers);
+  return Array.isArray(releases) ? pickNewestRelease(releases) : null;
+};
 
 // --- server-side fetch that also works when only prereleases exist -----------
 let release: any = null;
@@ -40,12 +141,7 @@ try {
     (import.meta as any).env?.PUBLIC_GITHUB_TOKEN;
   if (token) headers.Authorization = `Bearer ${token}`;
 
-  const res = await fetch(`${listUrl}?per_page=5`, { headers });
-  if (res.ok) {
-    const releases = await res.json();
-    const nonDraft = releases.filter((r: any) => !r.draft);
-    release = nonDraft.find((r: any) => !r.prerelease) || nonDraft[0] || null;
-  }
+  release = await fetchLatestReleaseAllowingPrerelease(headers);
 } catch {
   /* client will refetch if needed */
 }
@@ -91,7 +187,7 @@ const i18n = {
 
   <script
     type="module"
-    define:vars={{ preloaded: release, listUrl, ownerRepo, canonical, title, description, i18n }}
+    define:vars={{ preloaded: release, listUrl, tagsUrl, ownerRepo, canonical, title, description, i18n }}
   >
     const $ = (s, r = document) => r.querySelector(s);
 
@@ -128,17 +224,107 @@ const i18n = {
       return "x64";
     };
 
+    const releaseTagPattern = /^(?:(alpha|beta)-)?v?(\d+)\.(\d+)\.(\d+)$/i;
+    const channelRank = { stable: 3, beta: 2, alpha: 1 };
+
+    const parseReleaseTag = (tag) => {
+      const match = tag?.match(releaseTagPattern);
+      if (!match) return null;
+
+      return {
+        channel: (match[1] ?? "stable").toLowerCase(),
+        major: Number(match[2]),
+        minor: Number(match[3]),
+        patch: Number(match[4]),
+      };
+    };
+
+    const compareReleaseTags = (a, b) => {
+      const left = parseReleaseTag(a);
+      const right = parseReleaseTag(b);
+      if (left && right) {
+        const versionDiff =
+          left.major - right.major ||
+          left.minor - right.minor ||
+          left.patch - right.patch;
+        if (versionDiff !== 0) return versionDiff;
+
+        return (channelRank[left.channel] ?? 0) - (channelRank[right.channel] ?? 0);
+      }
+
+      if (left) return 1;
+      if (right) return -1;
+      return a.localeCompare(b);
+    };
+
+    const releaseTag = (release) => release?.tag_name ?? release?.name ?? "";
+
+    const hasDownloadableAssets = (release) =>
+      Array.isArray(release?.assets) &&
+      release.assets.some(
+        (asset) =>
+          asset?.browser_download_url &&
+          asset?.name &&
+          !/\.json$/i.test(asset.name) &&
+          !/\.sig$/i.test(asset.name),
+      );
+
+    const pickNewestRelease = (releases) => {
+      const nonDraft = releases.filter((release) => !release.draft);
+      const candidates = nonDraft.some(hasDownloadableAssets)
+        ? nonDraft.filter(hasDownloadableAssets)
+        : nonDraft;
+
+      return (
+        candidates.sort((a, b) => {
+          const tagDiff = compareReleaseTags(releaseTag(b), releaseTag(a));
+          if (tagDiff !== 0) return tagDiff;
+
+          return (
+            Date.parse(b.published_at ?? b.created_at ?? "") -
+            Date.parse(a.published_at ?? a.created_at ?? "")
+          );
+        })[0] ?? null
+      );
+    };
+
+    const fetchJson = async (url) => {
+      const res = await fetch(url, {
+        headers: { Accept: "application/vnd.github+json" },
+      });
+      if (!res.ok) return null;
+      return res.json();
+    };
+
     const fetchLatestReleaseAllowingPrerelease = async () => {
-      if (state.release) return state.release;
       try {
-        const res = await fetch(`${listUrl}?per_page=5`, {
-          headers: { Accept: "application/vnd.github+json" },
-        });
-        if (!res.ok) return null;
-        const releases = await res.json();
-        const nonDraft = releases.filter((r) => !r.draft);
-        state.release =
-          nonDraft.find((r) => !r.prerelease) || nonDraft[0] || null;
+        const tags = await fetchJson(`${tagsUrl}?per_page=30`);
+        if (Array.isArray(tags)) {
+          const releaseTags = tags
+            .map((tag) => tag?.name)
+            .filter((tag) => typeof tag === "string")
+            .filter((tag) => parseReleaseTag(tag))
+            .sort((a, b) => compareReleaseTags(b, a));
+
+          for (const tag of releaseTags) {
+            const taggedRelease = await fetchJson(
+              `${listUrl}/tags/${encodeURIComponent(tag)}`,
+            );
+            if (
+              taggedRelease &&
+              !taggedRelease.draft &&
+              hasDownloadableAssets(taggedRelease)
+            ) {
+              state.release = taggedRelease;
+              return state.release;
+            }
+          }
+        }
+
+        const releases = await fetchJson(`${listUrl}?per_page=10`);
+        if (Array.isArray(releases)) {
+          state.release = pickNewestRelease(releases) || state.release;
+        }
       } catch {}
       return state.release;
     };

--- a/apps/website/src/components/download/DownloadPage.astro
+++ b/apps/website/src/components/download/DownloadPage.astro
@@ -93,6 +93,13 @@ const pickNewestRelease = (releases: any[]) => {
   );
 };
 
+const pickNewestReleaseTag = (tags: any[]) =>
+  tags
+    .map((tag: any) => tag?.name)
+    .filter((tag: unknown): tag is string => typeof tag === "string")
+    .filter((tag: string) => parseReleaseTag(tag))
+    .sort((a: string, b: string) => compareReleaseTags(b, a))[0] ?? null;
+
 const fetchJson = async (url: string, headers: Record<string, string>) => {
   const res = await fetch(url, { headers });
   if (!res.ok) return null;
@@ -102,31 +109,31 @@ const fetchJson = async (url: string, headers: Record<string, string>) => {
 const fetchLatestReleaseAllowingPrerelease = async (
   headers: Record<string, string>,
 ) => {
-  const tags = await fetchJson(`${tagsUrl}?per_page=30`, headers);
-  if (Array.isArray(tags)) {
-    const releaseTags = tags
-      .map((tag: any) => tag?.name)
-      .filter((tag: unknown): tag is string => typeof tag === "string")
-      .filter((tag: string) => parseReleaseTag(tag))
-      .sort((a: string, b: string) => compareReleaseTags(b, a));
+  const [releases, tags] = await Promise.all([
+    fetchJson(`${listUrl}?per_page=30`, headers),
+    fetchJson(`${tagsUrl}?per_page=10`, headers),
+  ]);
+  const release = Array.isArray(releases) ? pickNewestRelease(releases) : null;
+  const newestTag = Array.isArray(tags) ? pickNewestReleaseTag(tags) : null;
 
-    for (const tag of releaseTags) {
-      const taggedRelease = await fetchJson(
-        `${listUrl}/tags/${encodeURIComponent(tag)}`,
-        headers,
-      );
-      if (
-        taggedRelease &&
-        !taggedRelease.draft &&
-        hasDownloadableAssets(taggedRelease)
-      ) {
-        return taggedRelease;
-      }
+  if (
+    newestTag &&
+    (!release || compareReleaseTags(newestTag, releaseTag(release)) > 0)
+  ) {
+    const taggedRelease = await fetchJson(
+      `${listUrl}/tags/${encodeURIComponent(newestTag)}`,
+      headers,
+    );
+    if (
+      taggedRelease &&
+      !taggedRelease.draft &&
+      hasDownloadableAssets(taggedRelease)
+    ) {
+      return taggedRelease;
     }
   }
 
-  const releases = await fetchJson(`${listUrl}?per_page=10`, headers);
-  return Array.isArray(releases) ? pickNewestRelease(releases) : null;
+  return release;
 };
 
 // --- server-side fetch that also works when only prereleases exist -----------
@@ -288,6 +295,13 @@ const i18n = {
       );
     };
 
+    const pickNewestReleaseTag = (tags) =>
+      tags
+        .map((tag) => tag?.name)
+        .filter((tag) => typeof tag === "string")
+        .filter((tag) => parseReleaseTag(tag))
+        .sort((a, b) => compareReleaseTags(b, a))[0] ?? null;
+
     const fetchJson = async (url) => {
       const res = await fetch(url, {
         headers: { Accept: "application/vnd.github+json" },
@@ -298,33 +312,31 @@ const i18n = {
 
     const fetchLatestReleaseAllowingPrerelease = async () => {
       try {
-        const tags = await fetchJson(`${tagsUrl}?per_page=30`);
-        if (Array.isArray(tags)) {
-          const releaseTags = tags
-            .map((tag) => tag?.name)
-            .filter((tag) => typeof tag === "string")
-            .filter((tag) => parseReleaseTag(tag))
-            .sort((a, b) => compareReleaseTags(b, a));
+        const [releases, tags] = await Promise.all([
+          fetchJson(`${listUrl}?per_page=30`),
+          fetchJson(`${tagsUrl}?per_page=10`),
+        ]);
+        const release = Array.isArray(releases) ? pickNewestRelease(releases) : null;
+        const newestTag = Array.isArray(tags) ? pickNewestReleaseTag(tags) : null;
 
-          for (const tag of releaseTags) {
-            const taggedRelease = await fetchJson(
-              `${listUrl}/tags/${encodeURIComponent(tag)}`,
-            );
-            if (
-              taggedRelease &&
-              !taggedRelease.draft &&
-              hasDownloadableAssets(taggedRelease)
-            ) {
-              state.release = taggedRelease;
-              return state.release;
-            }
+        if (
+          newestTag &&
+          (!release || compareReleaseTags(newestTag, releaseTag(release)) > 0)
+        ) {
+          const taggedRelease = await fetchJson(
+            `${listUrl}/tags/${encodeURIComponent(newestTag)}`,
+          );
+          if (
+            taggedRelease &&
+            !taggedRelease.draft &&
+            hasDownloadableAssets(taggedRelease)
+          ) {
+            state.release = taggedRelease;
+            return state.release;
           }
         }
 
-        const releases = await fetchJson(`${listUrl}?per_page=10`);
-        if (Array.isArray(releases)) {
-          state.release = pickNewestRelease(releases) || state.release;
-        }
+        state.release = release || state.release;
       } catch {}
       return state.release;
     };

--- a/apps/website/src/components/download/Hero.astro
+++ b/apps/website/src/components/download/Hero.astro
@@ -36,7 +36,7 @@ const studioName = "Flow-Like Studio";
 
     <p class="text-lg text-zinc-600 font-light leading-relaxed max-w-md border-l-2 border-zinc-200 pl-6">
       {description} <br/>
-      <span class="text-sm text-zinc-400 mt-2 block">{t("download.hero.version")} {version ?? "..."}</span>
+      <span class="text-sm text-zinc-400 mt-2 block">{t("download.hero.version")} <span id="release-tag">{version ?? "..."}</span></span>
     </p>
 
     <div class="flex flex-wrap gap-4">

--- a/packages/ui/components/flow/flow-node/flow-node-info-overlay.tsx
+++ b/packages/ui/components/flow/flow-node/flow-node-info-overlay.tsx
@@ -2,7 +2,6 @@
 
 import {
 	ActivityIcon,
-	BookOpenIcon,
 	CheckIcon,
 	CircleCheckIcon,
 	CoinsIcon,
@@ -24,6 +23,7 @@ import {
 	useState,
 } from "react";
 import { type IBoard, cn } from "../../../lib";
+import { buildNodeDocsUrl } from "../../../lib/node-docs-url";
 import { NODE_PERMISSION_LABELS } from "../../../lib/permission/node-permission";
 import type { INode } from "../../../lib/schema/flow/node";
 import { type IPin, IPinType } from "../../../lib/schema/flow/pin";
@@ -50,18 +50,6 @@ type FlowNodeInfoOverlayProps = {
 	boardRef: RefObject<IBoard | undefined>;
 	onFocusNode: (nodeId: string) => void;
 };
-
-function buildDocsUrl(node: INode): string {
-	if (node.docs) {
-		return node.docs;
-	}
-	const categoryPath = node.category.toLowerCase().split("/").join("/");
-	const nodeName = node.name
-		.split("_")
-		.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-		.join(" ");
-	return `https://docs.flow-like.com/nodes/${categoryPath}/${nodeName}`;
-}
 
 const HeroSection = memo(
 	({
@@ -226,43 +214,15 @@ const PermissionsSection = memo(({ node }: { node: INode }) => {
 PermissionsSection.displayName = "PermissionsSection";
 
 const DocsPreview = memo(({ url }: { url: string }) => {
-	const [showPreview, setShowPreview] = useState(true);
-	const togglePreview = useCallback(() => setShowPreview((prev) => !prev), []);
-
 	return (
-		<div className="flex flex-col h-full gap-2 md:gap-3">
-			<div className="flex items-center justify-between gap-2 md:gap-3 flex-wrap shrink-0">
-				<div>
-					<h3 className="text-xs md:text-sm font-semibold">Documentation</h3>
-					<p className="text-[10px] md:text-xs text-muted-foreground">
-						Preview docs inline without leaving the board.
-					</p>
-				</div>
-				<Button
-					variant="outline"
-					size="sm"
-					onClick={togglePreview}
-					className="h-8 text-xs md:h-9 md:text-sm"
-				>
-					{showPreview ? "Hide preview" : "Show preview"}
-				</Button>
-			</div>
-			{showPreview ? (
-				<div className="rounded-xl md:rounded-2xl border bg-card overflow-hidden flex-1 min-h-[250px] md:min-h-[300px]">
-					<iframe
-						title="Node docs preview"
-						src={url}
-						className="w-full h-full"
-						loading="lazy"
-						sandbox="allow-same-origin allow-scripts"
-					/>
-				</div>
-			) : (
-				<div className="rounded-xl md:rounded-2xl border border-dashed p-3 md:p-4 text-[10px] md:text-xs text-muted-foreground flex items-center gap-2">
-					<BookOpenIcon className="w-3.5 h-3.5 md:w-4 md:h-4 shrink-0" />
-					Inline docs are loaded on demand to keep the board fast.
-				</div>
-			)}
+		<div className="h-[70vh] min-h-[360px] overflow-hidden rounded-xl border bg-card md:h-full md:min-h-0">
+			<iframe
+				title="Node docs preview"
+				src={url}
+				className="h-full w-full"
+				loading="lazy"
+				sandbox="allow-same-origin allow-scripts"
+			/>
 		</div>
 	);
 });
@@ -713,7 +673,7 @@ export const FlowNodeInfoOverlay = forwardRef<
 	);
 
 	const docsUrl = useMemo(
-		() => (selectedNode ? buildDocsUrl(selectedNode) : ""),
+		() => (selectedNode ? buildNodeDocsUrl(selectedNode) : ""),
 		[selectedNode],
 	);
 
@@ -802,7 +762,7 @@ export const FlowNodeInfoOverlay = forwardRef<
 					)}
 				</div>
 
-				<div className="shrink-0 border-t pt-3 pb-3 px-4 md:pt-4 md:pb-2 md:px-6">
+				<div className="shrink-0 border-t pt-3 pb-3 px-4 md:hidden">
 					<Button variant="outline" size="sm" className="w-full" asChild>
 						<a
 							href={docsUrl}

--- a/packages/ui/components/flow/flow-node/flow-node-info-overlay.tsx
+++ b/packages/ui/components/flow/flow-node/flow-node-info-overlay.tsx
@@ -221,7 +221,7 @@ const DocsPreview = memo(({ url }: { url: string }) => {
 				src={url}
 				className="h-full w-full"
 				loading="lazy"
-				sandbox="allow-same-origin allow-scripts"
+				sandbox="allow-scripts"
 			/>
 		</div>
 	);

--- a/packages/ui/lib/node-docs-url.test.ts
+++ b/packages/ui/lib/node-docs-url.test.ts
@@ -25,6 +25,16 @@ describe("buildNodeDocsUrl", () => {
 		).toBe("https://example.com/custom-node-docs");
 	});
 
+	test("rejects unsafe explicit docs urls", () => {
+		expect(
+			buildNodeDocsUrl(
+				node({
+					docs: "javascript:alert(1)",
+				}),
+			),
+		).toBe("https://docs.flow-like.com/nodes/ai/agents/agent-invoke/");
+	});
+
 	test("matches generated docs slug format for catalog nodes", () => {
 		expect(buildNodeDocsUrl(node({}))).toBe(
 			"https://docs.flow-like.com/nodes/ai/agents/agent-invoke/",
@@ -48,5 +58,16 @@ describe("buildNodeDocsUrl", () => {
 		expect(buildNodeDocsUrl(node({ category: " / ", name: "" }))).toBe(
 			"https://docs.flow-like.com/nodes/uncategorized/node/",
 		);
+	});
+
+	test("falls back safely when runtime node values are missing", () => {
+		expect(
+			buildNodeDocsUrl(
+				node({
+					category: null as unknown as string,
+					name: null as unknown as string,
+				}),
+			),
+		).toBe("https://docs.flow-like.com/nodes/uncategorized/node/");
 	});
 });

--- a/packages/ui/lib/node-docs-url.test.ts
+++ b/packages/ui/lib/node-docs-url.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { buildNodeDocsUrl } from "./node-docs-url";
+import type { INode } from "./schema/flow/node";
+
+function node(overrides: Partial<INode>): INode {
+	return {
+		category: "AI/Agents",
+		description: "",
+		friendly_name: "Invoke Agent",
+		id: "node-id",
+		name: "agent_invoke",
+		pins: {},
+		...overrides,
+	};
+}
+
+describe("buildNodeDocsUrl", () => {
+	test("uses explicit docs urls when provided", () => {
+		expect(
+			buildNodeDocsUrl(
+				node({
+					docs: " https://example.com/custom-node-docs ",
+				}),
+			),
+		).toBe("https://example.com/custom-node-docs");
+	});
+
+	test("matches generated docs slug format for catalog nodes", () => {
+		expect(buildNodeDocsUrl(node({}))).toBe(
+			"https://docs.flow-like.com/nodes/ai/agents/agent-invoke/",
+		);
+	});
+
+	test("slugifies category segments and node names like the docs generator", () => {
+		expect(
+			buildNodeDocsUrl(
+				node({
+					category: "Web / API / Request",
+					name: "http_set_bearer_auth",
+				}),
+			),
+		).toBe(
+			"https://docs.flow-like.com/nodes/web/api/request/http-set-bearer-auth/",
+		);
+	});
+
+	test("falls back to the uncategorized node path for empty values", () => {
+		expect(buildNodeDocsUrl(node({ category: " / ", name: "" }))).toBe(
+			"https://docs.flow-like.com/nodes/uncategorized/node/",
+		);
+	});
+});

--- a/packages/ui/lib/node-docs-url.ts
+++ b/packages/ui/lib/node-docs-url.ts
@@ -1,0 +1,57 @@
+import type { INode } from "./schema/flow/node";
+
+const DOCS_BASE_URL = "https://docs.flow-like.com";
+
+function safeSegment(value: string): string {
+	let out = "";
+	let lastWasDash = false;
+
+	for (const ch of value.trim()) {
+		const code = ch.charCodeAt(0);
+		const isAsciiDigit = code >= 48 && code <= 57;
+		const isAsciiUpper = code >= 65 && code <= 90;
+		const isAsciiLower = code >= 97 && code <= 122;
+
+		if (isAsciiDigit || isAsciiUpper || isAsciiLower) {
+			out += ch.toLowerCase();
+			lastWasDash = false;
+		} else if (ch === " " || ch === "_" || ch === "-" || ch === ".") {
+			if (!lastWasDash && out.length > 0) {
+				out += "-";
+				lastWasDash = true;
+			}
+		} else if (!lastWasDash && out.length > 0) {
+			out += "-";
+			lastWasDash = true;
+		}
+	}
+
+	while (out.endsWith("-")) {
+		out = out.slice(0, -1);
+	}
+
+	return out || "node";
+}
+
+function categorySegments(category: string): string[] {
+	const segments = category
+		.split("/")
+		.map((segment) => segment.trim())
+		.filter(Boolean);
+
+	return segments.length > 0 ? segments : ["Uncategorized"];
+}
+
+export function buildNodeDocsUrl(node: INode): string {
+	const docsUrl = node.docs?.trim();
+	if (docsUrl) {
+		return docsUrl;
+	}
+
+	const categoryPath = categorySegments(node.category)
+		.map(safeSegment)
+		.join("/");
+	const nodeSlug = safeSegment(node.name);
+
+	return `${DOCS_BASE_URL}/nodes/${categoryPath}/${nodeSlug}/`;
+}

--- a/packages/ui/lib/node-docs-url.ts
+++ b/packages/ui/lib/node-docs-url.ts
@@ -2,7 +2,9 @@ import type { INode } from "./schema/flow/node";
 
 const DOCS_BASE_URL = "https://docs.flow-like.com";
 
-function safeSegment(value: string): string {
+function safeSegment(value?: string | null): string {
+	if (!value) return "node";
+
 	let out = "";
 	let lastWasDash = false;
 
@@ -33,7 +35,9 @@ function safeSegment(value: string): string {
 	return out || "node";
 }
 
-function categorySegments(category: string): string[] {
+function categorySegments(category?: string | null): string[] {
+	if (!category) return ["Uncategorized"];
+
 	const segments = category
 		.split("/")
 		.map((segment) => segment.trim())
@@ -42,8 +46,22 @@ function categorySegments(category: string): string[] {
 	return segments.length > 0 ? segments : ["Uncategorized"];
 }
 
+function safeDocsUrl(value?: string | null): string | null {
+	const docsUrl = value?.trim();
+	if (!docsUrl) return null;
+
+	try {
+		const url = new URL(docsUrl);
+		return url.protocol === "http:" || url.protocol === "https:"
+			? url.toString()
+			: null;
+	} catch {
+		return null;
+	}
+}
+
 export function buildNodeDocsUrl(node: INode): string {
-	const docsUrl = node.docs?.trim();
+	const docsUrl = safeDocsUrl(node.docs);
 	if (docsUrl) {
 		return docsUrl;
 	}


### PR DESCRIPTION
This pull request introduces several improvements and refactorings across the documentation site and the UI components. The most significant changes include a robust overhaul of the GitHub release fetching logic for downloads, the addition of a custom search component to the documentation, and UI simplifications for the node info overlay.

**Release fetching and download logic improvements:**

* Refactored the GitHub release fetching logic in `DownloadPage.astro` to more reliably select the latest release, including pre-releases if no stable release is available. This includes new helper functions for parsing and comparing release tags, and now fetches tags and release info in a more robust way. The same logic is duplicated on the client for consistency. [[1]](diffhunk://#diff-7d1c91988c7db095ab2b25817068eb3dbd4b6a89adae22ed3293d6df020b52f5L29-R130) [[2]](diffhunk://#diff-7d1c91988c7db095ab2b25817068eb3dbd4b6a89adae22ed3293d6df020b52f5L43-R144) [[3]](diffhunk://#diff-7d1c91988c7db095ab2b25817068eb3dbd4b6a89adae22ed3293d6df020b52f5L94-R190) [[4]](diffhunk://#diff-7d1c91988c7db095ab2b25817068eb3dbd4b6a89adae22ed3293d6df020b52f5L131-R327)
* Added the `tagsUrl` variable and passed it to the client-side script to support the improved release fetching logic.
* Updated the version display in `Hero.astro` to wrap the version in a `span` with `id="release-tag"` for easier dynamic updates.

**Documentation site enhancements:**

* Added a new custom `Search` component (`Search.astro`) to the documentation site, providing a modal-based search UI with keyboard shortcuts, i18n support, and integration with Pagefind for fast client-side search.
* Registered the new `Search` component in the Astro documentation config for use across the docs site.
* Updated global styles to hide the mobile table of contents when viewing node documentation pages.

**UI component simplifications and improvements:**

* Refactored the `DocsPreview` component in the flow node info overlay to always display the documentation iframe, removing the toggle and preview state for a simpler user experience.
* Replaced the local `buildDocsUrl` function with a shared `buildNodeDocsUrl` utility for generating node documentation URLs, ensuring consistency and maintainability. [[1]](diffhunk://#diff-7e7f564216543083bf252ff90d274221f84a5990b8a073048a4d25680213eaf9R26) [[2]](diffhunk://#diff-7e7f564216543083bf252ff90d274221f84a5990b8a073048a4d25680213eaf9L54-L65) [[3]](diffhunk://#diff-7e7f564216543083bf252ff90d274221f84a5990b8a073048a4d25680213eaf9L716-R676)
* Removed an unused icon import to clean up the code.