### PR TITLE
Fix/652 mobile push deactivates itself

### DIFF
--- a/apps/desktop/app/library/config/layout.tsx
+++ b/apps/desktop/app/library/config/layout.tsx
@@ -89,6 +89,7 @@ import {
 import { toast } from "sonner";
 import { appsDB } from "../../../lib/apps-db";
 import { EVENT_CONFIG } from "../../../lib/event-config";
+import { isIosTauriRuntime } from "../../../lib/platform";
 
 const navigationItems: {
 	href: string;
@@ -313,21 +314,7 @@ export default function Id({
 		[publicationRequests.data],
 	);
 
-	const isIosTauri = useMemo(() => {
-		if (typeof window === "undefined" || typeof navigator === "undefined") {
-			return false;
-		}
-
-		const isTauri =
-			"__TAURI__" in (window as any) ||
-			"__TAURI_IPC__" in (window as any) ||
-			"__TAURI_INTERNALS__" in (window as any);
-		const isIOS =
-			/iPad|iPhone|iPod/.test(navigator.userAgent) ||
-			(navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
-
-		return isTauri && isIOS;
-	}, []);
+	const isIosTauri = useMemo(isIosTauriRuntime, []);
 
 	// Lock page scroll on desktop (md+) so only the right card scrolls
 	useEffect(() => {

--- a/apps/desktop/app/library/config/layout.tsx
+++ b/apps/desktop/app/library/config/layout.tsx
@@ -314,7 +314,10 @@ export default function Id({
 		[publicationRequests.data],
 	);
 
-	const isIosTauri = useMemo(isIosTauriRuntime, []);
+	const [isIosTauri, setIsIosTauri] = useState(false);
+	useEffect(() => {
+		setIsIosTauri(isIosTauriRuntime());
+	}, []);
 
 	// Lock page scroll on desktop (md+) so only the right card scrolls
 	useEffect(() => {

--- a/apps/desktop/app/library/page.tsx
+++ b/apps/desktop/app/library/page.tsx
@@ -20,6 +20,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useAuth } from "react-oidc-context";
 import { toast } from "sonner";
 import { appsDB } from "./../../lib/apps-db";
+import { isMobileDevice as detectMobileDevice } from "./../../lib/platform";
 import ImportEncryptedDialog from "./components/ImportEncryptedDialog";
 
 export default function DesktopLibraryPage() {
@@ -32,20 +33,7 @@ export default function DesktopLibraryPage() {
 		null,
 	);
 
-	const isMobileDevice = useMemo(() => {
-		if (typeof navigator === "undefined") return false;
-		if (
-			/Android|iPhone|iPad|iPod|Opera Mini|IEMobile|WPDesktop/i.test(
-				navigator.userAgent,
-			)
-		)
-			return true;
-		const platform = navigator.platform?.toLowerCase() ?? "";
-		const maxTouchPoints =
-			(navigator as Navigator & { maxTouchPoints?: number }).maxTouchPoints ??
-			0;
-		return /mac/.test(platform) && maxTouchPoints > 1;
-	}, []);
+	const isMobileDevice = useMemo(detectMobileDevice, []);
 
 	const normalizePickerPath = useCallback((input: string): string => {
 		if (!input.startsWith("file://")) return input;

--- a/apps/desktop/app/settings/notifications/page.tsx
+++ b/apps/desktop/app/settings/notifications/page.tsx
@@ -14,7 +14,10 @@ import {
 	useBackend,
 	useHub,
 } from "@flow-like/flow-like-ui";
-import type { IPushTargetStatus } from "@flow-like/flow-like-ui";
+import type {
+	IPushNotificationsConfig,
+	IPushTargetStatus,
+} from "@flow-like/flow-like-ui";
 import {
 	AlertTriangle,
 	Bell,
@@ -80,6 +83,16 @@ function statusBadge(status: IPushTargetStatus | null, localEnabled: boolean) {
 	return { label: "Disabled", variant: "destructive" as const };
 }
 
+function hubConfigLabel(
+	pushConfig: IPushNotificationsConfig | undefined,
+): string {
+	if (!pushConfig) return "Not loaded";
+	if (!pushConfig.enabled) return "Disabled";
+	if (pushConfig.provider !== "fcm") return "Not FCM";
+	if (pushConfig.allow_mobile !== true) return "Mobile off";
+	return "Enabled";
+}
+
 function StatusRow({
 	label,
 	value,
@@ -124,6 +137,22 @@ export default function NotificationsSettingsPage() {
 	const deliveryEnabled =
 		localEnabled &&
 		Boolean(status?.registered && status.push_enabled && !status.invalidated_at);
+	const switchDisabledReason = useMemo(() => {
+		if (saving) return "Saving push settings.";
+		if (loading) return "Checking push status.";
+		if (!isMobile) return "This device was not detected as iOS or Android.";
+		if (!pushConfig) return "Hub config has not loaded from this profile.";
+		if (!pushConfig.enabled) return "Push is disabled in the hub config.";
+		if (pushConfig.provider !== "fcm") return "Mobile push requires the FCM provider.";
+		if (pushConfig.allow_mobile !== true) {
+			return "Mobile push is not enabled in the hub config.";
+		}
+		if (pluginState !== "available") {
+			return "The native remote-push plugin is not available in this app build.";
+		}
+		if (!deviceId) return "No device id is available.";
+		return null;
+	}, [deviceId, isMobile, loading, pluginState, pushConfig, saving]);
 
 	const refreshStatus = useCallback(async () => {
 		setLoading(true);
@@ -153,6 +182,11 @@ export default function NotificationsSettingsPage() {
 			setLoading(false);
 		}
 	}, [backend.userState]);
+
+	const refreshAll = useCallback(async () => {
+		await hub.refetch();
+		await refreshStatus();
+	}, [hub.refetch, refreshStatus]);
 
 	useEffect(() => {
 		void refreshStatus();
@@ -269,16 +303,18 @@ export default function NotificationsSettingsPage() {
 								<Switch
 									checked={deliveryEnabled}
 									disabled={
-										saving ||
-										loading ||
-										!isMobile ||
-										!canUseRemotePush ||
-										pluginState !== "available" ||
-										!deviceId
+										switchDisabledReason !== null
 									}
 									onCheckedChange={setEnabled}
 								/>
 							</div>
+
+							{switchDisabledReason && (
+								<div className="flex gap-3 rounded-md border border-border/70 bg-muted/30 p-3 text-sm text-muted-foreground">
+									<AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+									<span>{switchDisabledReason}</span>
+								</div>
+							)}
 
 							{loadError && (
 								<div className="flex gap-3 rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
@@ -297,7 +333,7 @@ export default function NotificationsSettingsPage() {
 								<StatusTile
 									icon={Server}
 									label="Hub config"
-									value={canUseRemotePush ? "Enabled" : "Unavailable"}
+									value={hubConfigLabel(pushConfig)}
 									ok={canUseRemotePush}
 								/>
 								<StatusTile
@@ -336,7 +372,7 @@ export default function NotificationsSettingsPage() {
 								<CardTitle className="text-xl">Target details</CardTitle>
 								<CardDescription>Server row for this device</CardDescription>
 							</div>
-							<Button variant="outline" size="sm" onClick={refreshStatus}>
+							<Button variant="outline" size="sm" onClick={refreshAll}>
 								<RefreshCw className="h-4 w-4" />
 								Refresh
 							</Button>

--- a/apps/desktop/app/settings/notifications/page.tsx
+++ b/apps/desktop/app/settings/notifications/page.tsx
@@ -1,0 +1,445 @@
+"use client";
+
+import {
+	Badge,
+	Button,
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+	Skeleton,
+	Switch,
+	cn,
+	useBackend,
+	useHub,
+} from "@flow-like/flow-like-ui";
+import type { IPushTargetStatus } from "@flow-like/flow-like-ui";
+import {
+	AlertTriangle,
+	Bell,
+	BellOff,
+	CheckCircle2,
+	RefreshCw,
+	Server,
+	ShieldCheck,
+	Smartphone,
+} from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+import {
+	canUseRemotePushForPlatform,
+	detectPushPlatform,
+	getPushDeviceId,
+	isRemotePushPreferenceEnabled,
+	loadRemotePushPlugin,
+	setRemotePushPreference,
+	type PushTargetPlatform,
+} from "../../../lib/remote-push";
+
+type PluginState = "loading" | "available" | "unavailable";
+type PermissionState = "unknown" | "granted" | "denied" | "unavailable";
+
+function platformLabel(platform: PushTargetPlatform | null): string {
+	switch (platform) {
+		case "IOS":
+			return "iOS";
+		case "ANDROID":
+			return "Android";
+		case "DESKTOP":
+			return "Desktop";
+		default:
+			return "Unknown";
+	}
+}
+
+function formatDate(value?: string | null): string {
+	if (!value) return "Never";
+	const date = new Date(value);
+	if (Number.isNaN(date.getTime())) return value;
+	return new Intl.DateTimeFormat(undefined, {
+		dateStyle: "medium",
+		timeStyle: "short",
+	}).format(date);
+}
+
+function errorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+function statusBadge(status: IPushTargetStatus | null, localEnabled: boolean) {
+	if (!localEnabled) {
+		return { label: "Off on this device", variant: "secondary" as const };
+	}
+	if (!status?.registered) {
+		return { label: "Not registered", variant: "outline" as const };
+	}
+	if (status.push_enabled && !status.invalidated_at) {
+		return { label: "Enabled", variant: "default" as const };
+	}
+	return { label: "Disabled", variant: "destructive" as const };
+}
+
+function StatusRow({
+	label,
+	value,
+	muted,
+}: Readonly<{ label: string; value: React.ReactNode; muted?: boolean }>) {
+	return (
+		<div className="flex min-h-9 items-center justify-between gap-4 border-b border-border/50 py-2 last:border-0">
+			<div className="text-sm text-muted-foreground">{label}</div>
+			<div
+				className={cn(
+					"min-w-0 text-right text-sm font-medium text-foreground",
+					muted && "text-muted-foreground font-normal",
+				)}
+			>
+				{value}
+			</div>
+		</div>
+	);
+}
+
+export default function NotificationsSettingsPage() {
+	const backend = useBackend();
+	const hub = useHub();
+	const pushConfig = hub.hub?.push_notifications;
+	const [platform, setPlatform] = useState<PushTargetPlatform | null>(null);
+	const [pluginState, setPluginState] = useState<PluginState>("loading");
+	const [permissionState, setPermissionState] =
+		useState<PermissionState>("unknown");
+	const [deviceId, setDeviceId] = useState<string | null>(null);
+	const [status, setStatus] = useState<IPushTargetStatus | null>(null);
+	const [localEnabled, setLocalEnabled] = useState(true);
+	const [loading, setLoading] = useState(true);
+	const [saving, setSaving] = useState(false);
+	const [loadError, setLoadError] = useState<string | null>(null);
+
+	const canUseRemotePush = useMemo(
+		() => canUseRemotePushForPlatform(pushConfig, platform),
+		[pushConfig, platform],
+	);
+	const isMobile = platform === "IOS" || platform === "ANDROID";
+	const badge = statusBadge(status, localEnabled);
+	const deliveryEnabled =
+		localEnabled &&
+		Boolean(status?.registered && status.push_enabled && !status.invalidated_at);
+
+	const refreshStatus = useCallback(async () => {
+		setLoading(true);
+		setLoadError(null);
+		try {
+			const nextPlatform = detectPushPlatform();
+			setPlatform(nextPlatform);
+			setLocalEnabled(isRemotePushPreferenceEnabled());
+
+			const [nextDeviceId, remotePushApi] = await Promise.all([
+				getPushDeviceId(),
+				loadRemotePushPlugin(),
+			]);
+			setDeviceId(nextDeviceId);
+			setPluginState(remotePushApi ? "available" : "unavailable");
+			if (!remotePushApi) {
+				setPermissionState("unavailable");
+			}
+
+			const nextStatus =
+				await backend.userState.getPushTargetStatus(nextDeviceId);
+			setStatus(nextStatus);
+		} catch (error) {
+			setLoadError(errorMessage(error));
+			setStatus(null);
+		} finally {
+			setLoading(false);
+		}
+	}, [backend.userState]);
+
+	useEffect(() => {
+		void refreshStatus();
+	}, [refreshStatus]);
+
+	const setEnabled = useCallback(
+		async (enabled: boolean) => {
+			if (!deviceId) return;
+
+			setSaving(true);
+			try {
+				if (enabled) {
+					const nextPlatform = detectPushPlatform();
+					if (!nextPlatform) {
+						throw new Error("Push platform could not be detected.");
+					}
+					if (!canUseRemotePushForPlatform(pushConfig, nextPlatform)) {
+						throw new Error("Remote push is not enabled for this platform.");
+					}
+
+					const remotePushApi = await loadRemotePushPlugin();
+					if (!remotePushApi) {
+						throw new Error("Remote push plugin is not available.");
+					}
+
+					const permission = await remotePushApi.requestPermission();
+					if (!permission.granted) {
+						setPermissionState("denied");
+						throw new Error("Notification permission was denied.");
+					}
+					setPermissionState("granted");
+
+					const token = await remotePushApi.getToken();
+					if (!token) {
+						throw new Error("Remote push returned an empty token.");
+					}
+
+					await backend.userState.registerPushTarget({
+						device_id: deviceId,
+						platform: nextPlatform,
+						token,
+						device_name:
+							typeof navigator !== "undefined"
+								? navigator.userAgent
+								: undefined,
+						channel_id: pushConfig?.channel_id ?? undefined,
+						metadata: {
+							source: "settings",
+							platform: nextPlatform,
+							provider: pushConfig?.provider,
+						},
+					});
+				}
+
+				const nextStatus = await backend.userState.setPushTargetEnabled(
+					deviceId,
+					enabled,
+				);
+				setRemotePushPreference(enabled);
+				setLocalEnabled(enabled);
+				setStatus(nextStatus);
+				toast.success(
+					enabled ? "Push notifications enabled" : "Push notifications disabled",
+				);
+			} catch (error) {
+				toast.error(`Failed to update push notifications: ${errorMessage(error)}`);
+			} finally {
+				setSaving(false);
+			}
+		},
+		[backend.userState, deviceId, pushConfig],
+	);
+
+	return (
+		<div className="h-full min-h-0 overflow-auto">
+			<div className="container mx-auto flex max-w-5xl flex-col gap-6 px-2 pb-4">
+				<div className="flex flex-col gap-1 pt-2">
+					<h1 className="text-3xl font-bold tracking-tight">Notifications</h1>
+					<p className="text-muted-foreground">
+						Mobile push delivery for this device and hub profile
+					</p>
+				</div>
+
+				<div className="grid gap-4 lg:grid-cols-[1.15fr_0.85fr]">
+					<Card>
+						<CardHeader className="gap-3 sm:flex sm:flex-row sm:items-start sm:justify-between">
+							<div className="space-y-1.5">
+								<CardTitle className="flex items-center gap-2 text-xl">
+									{deliveryEnabled ? (
+										<Bell className="h-5 w-5 text-primary" />
+									) : (
+										<BellOff className="h-5 w-5 text-muted-foreground" />
+									)}
+									Push delivery
+								</CardTitle>
+								<CardDescription>
+									{isMobile
+										? "Current native push target state"
+										: "Native mobile push is available on iOS and Android"}
+								</CardDescription>
+							</div>
+							<Badge variant={badge.variant}>{badge.label}</Badge>
+						</CardHeader>
+						<CardContent className="flex flex-col gap-5">
+							<div className="flex items-center justify-between gap-4 rounded-md border border-border/60 bg-muted/20 p-4">
+								<div className="min-w-0">
+									<div className="font-medium">Enable push notifications</div>
+									<div className="text-sm text-muted-foreground">
+										{status?.registered
+											? "Registered target controls server delivery"
+											: "Creates a server target after native permission"}
+									</div>
+								</div>
+								<Switch
+									checked={deliveryEnabled}
+									disabled={
+										saving ||
+										loading ||
+										!isMobile ||
+										!canUseRemotePush ||
+										pluginState !== "available" ||
+										!deviceId
+									}
+									onCheckedChange={setEnabled}
+								/>
+							</div>
+
+							{loadError && (
+								<div className="flex gap-3 rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+									<AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+									<span>{loadError}</span>
+								</div>
+							)}
+
+							<div className="grid gap-3 sm:grid-cols-2">
+								<StatusTile
+									icon={Smartphone}
+									label="Platform"
+									value={platformLabel(platform)}
+									ok={isMobile}
+								/>
+								<StatusTile
+									icon={Server}
+									label="Hub config"
+									value={canUseRemotePush ? "Enabled" : "Unavailable"}
+									ok={canUseRemotePush}
+								/>
+								<StatusTile
+									icon={ShieldCheck}
+									label="Native plugin"
+									value={
+										pluginState === "loading"
+											? "Checking"
+											: pluginState === "available"
+												? "Available"
+												: "Unavailable"
+									}
+									ok={pluginState === "available"}
+								/>
+								<StatusTile
+									icon={CheckCircle2}
+									label="Permission"
+									value={
+										permissionState === "granted"
+											? "Granted"
+											: permissionState === "denied"
+												? "Denied"
+												: permissionState === "unavailable"
+													? "Unavailable"
+													: "Not checked"
+									}
+									ok={permissionState === "granted"}
+								/>
+							</div>
+						</CardContent>
+					</Card>
+
+					<Card>
+						<CardHeader className="gap-3 sm:flex sm:flex-row sm:items-start sm:justify-between">
+							<div className="space-y-1.5">
+								<CardTitle className="text-xl">Target details</CardTitle>
+								<CardDescription>Server row for this device</CardDescription>
+							</div>
+							<Button variant="outline" size="sm" onClick={refreshStatus}>
+								<RefreshCw className="h-4 w-4" />
+								Refresh
+							</Button>
+						</CardHeader>
+						<CardContent>
+							{loading ? (
+								<div className="space-y-3">
+									<Skeleton className="h-8 w-full" />
+									<Skeleton className="h-8 w-full" />
+									<Skeleton className="h-8 w-full" />
+									<Skeleton className="h-8 w-full" />
+								</div>
+							) : (
+								<div className="flex flex-col">
+									<StatusRow
+										label="Device ID"
+										value={
+											deviceId ? (
+												<span className="break-all font-mono text-xs">
+													{deviceId}
+												</span>
+											) : (
+												"Unknown"
+											)
+										}
+										muted={!deviceId}
+									/>
+									<StatusRow
+										label="Registered"
+										value={status?.registered ? "Yes" : "No"}
+										muted={!status?.registered}
+									/>
+									<StatusRow
+										label="Provider"
+										value={status?.provider ?? pushConfig?.provider ?? "None"}
+										muted={!status?.provider && !pushConfig?.provider}
+									/>
+									<StatusRow
+										label="Server enabled"
+										value={status?.push_enabled ? "Yes" : "No"}
+										muted={!status?.push_enabled}
+									/>
+									<StatusRow
+										label="Failure count"
+										value={status?.failure_count ?? 0}
+									/>
+									<StatusRow
+										label="Last registered"
+										value={formatDate(status?.last_registered_at)}
+										muted={!status?.last_registered_at}
+									/>
+									<StatusRow
+										label="Last seen"
+										value={formatDate(status?.last_seen_at)}
+										muted={!status?.last_seen_at}
+									/>
+									<StatusRow
+										label="Invalidated"
+										value={formatDate(status?.invalidated_at)}
+										muted={!status?.invalidated_at}
+									/>
+									<StatusRow
+										label="Reason"
+										value={status?.invalidation_reason ?? "None"}
+										muted={!status?.invalidation_reason}
+									/>
+								</div>
+							)}
+						</CardContent>
+					</Card>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+function StatusTile({
+	icon: Icon,
+	label,
+	value,
+	ok,
+}: Readonly<{
+	icon: typeof Smartphone;
+	label: string;
+	value: string;
+	ok: boolean;
+}>) {
+	return (
+		<div className="flex items-center gap-3 rounded-md border border-border/60 bg-background/60 p-3">
+			<div
+				className={cn(
+					"flex h-9 w-9 shrink-0 items-center justify-center rounded-md",
+					ok
+						? "bg-primary/10 text-primary"
+						: "bg-muted text-muted-foreground",
+				)}
+			>
+				<Icon className="h-4 w-4" />
+			</div>
+			<div className="min-w-0">
+				<div className="text-xs text-muted-foreground">{label}</div>
+				<div className="truncate text-sm font-medium">{value}</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/desktop/app/settings/page.tsx
+++ b/apps/desktop/app/settings/page.tsx
@@ -9,6 +9,7 @@ import {
 import {
 	BarChart3,
 	Brain,
+	Bell,
 	ChevronRight,
 	Cpu,
 	ExternalLink,
@@ -42,6 +43,12 @@ const SETTINGS_SECTIONS: SettingsSection[] = [
 				description: "Name, avatar, interests, and theme",
 				href: "/settings/profiles",
 				icon: User,
+			},
+			{
+				title: "Notifications",
+				description: "Mobile push status and device registration",
+				href: "/settings/notifications",
+				icon: Bell,
 			},
 		],
 	},

--- a/apps/desktop/components/app-sidebar.tsx
+++ b/apps/desktop/components/app-sidebar.tsx
@@ -114,6 +114,7 @@ import { useAuth } from "react-oidc-context";
 import { toast } from "sonner";
 import { fetcher } from "../lib/api";
 import { appsDB } from "../lib/apps-db";
+import { isIosTauriRuntime } from "../lib/platform";
 import { CreateProfileDialog } from "./add-profile";
 import { Shortcuts } from "./shortcuts";
 import { useTauriInvoke } from "./useInvoke";
@@ -239,21 +240,7 @@ function IOSQuickMenuTrigger() {
 	const { isMobile, openMobile, toggleSidebar } = useSidebar();
 	const touchStartRef = useRef<{ x: number; y: number } | null>(null);
 
-	const isIosTauri = useMemo(() => {
-		if (typeof window === "undefined" || typeof navigator === "undefined") {
-			return false;
-		}
-
-		const isTauri =
-			"__TAURI__" in (window as any) ||
-			"__TAURI_IPC__" in (window as any) ||
-			"__TAURI_INTERNALS__" in (window as any);
-		const isIOS =
-			/iPad|iPhone|iPod/.test(navigator.userAgent) ||
-			(navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
-
-		return isTauri && isIOS;
-	}, []);
+	const isIosTauri = useMemo(isIosTauriRuntime, []);
 
 	useEffect(() => {
 		if (!isIosTauri || !isMobile) return;

--- a/apps/desktop/components/app-sidebar.tsx
+++ b/apps/desktop/components/app-sidebar.tsx
@@ -240,7 +240,10 @@ function IOSQuickMenuTrigger() {
 	const { isMobile, openMobile, toggleSidebar } = useSidebar();
 	const touchStartRef = useRef<{ x: number; y: number } | null>(null);
 
-	const isIosTauri = useMemo(isIosTauriRuntime, []);
+	const [isIosTauri, setIsIosTauri] = useState(false);
+	useEffect(() => {
+		setIsIosTauri(isIosTauriRuntime());
+	}, []);
 
 	useEffect(() => {
 		if (!isIosTauri || !isMobile) return;

--- a/apps/desktop/components/global-anchor-component.tsx
+++ b/apps/desktop/components/global-anchor-component.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { createId } from "@paralleldrive/cuid2";
-import { isTauri as isTauriRuntime } from "@tauri-apps/api/core";
 import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { openUrl as shellOpen } from "@tauri-apps/plugin-opener";
 import {
@@ -11,17 +10,9 @@ import {
 	DropdownMenuTrigger,
 } from "@flow-like/flow-like-ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { isIOSDevice, isTauriRuntime } from "../lib/platform";
 
-const isIosLike = () => {
-	if (typeof navigator === "undefined") return false;
-	// iPhone, iPad, iPod; also iPadOS reports MacIntel + touch
-	return (
-		/iPad|iPhone|iPod/.test(navigator.userAgent) ||
-		(navigator.platform === "MacIntel" && (navigator as any).maxTouchPoints > 1)
-	);
-};
-
-const isTauri = () => typeof window !== "undefined" && isTauriRuntime();
+const isTauri = isTauriRuntime;
 
 const isHttpish = (href: string) => /^(https?:|mailto:|tel:)/i.test(href);
 
@@ -96,7 +87,7 @@ const GlobalAnchorHandler = () => {
 		active: false,
 	});
 
-	const IOS = useMemo(isIosLike, []);
+	const IOS = useMemo(isIOSDevice, []);
 	const TAURI = useMemo(isTauri, []);
 
 	const createNewWindow = useCallback(
@@ -440,7 +431,7 @@ const GlobalAnchorHandler = () => {
 										const title = contextMenuData.title;
 
 										// iOS: always open in browser; Desktop: spawn new window for same-origin/_blank, shell for true external
-										if (isIosLike()) {
+										if (isIOSDevice()) {
 											if (isHttpish(href)) {
 												await openInBrowser(href);
 											}

--- a/apps/desktop/components/ios-webview-hardening.tsx
+++ b/apps/desktop/components/ios-webview-hardening.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
+import { isMobileDevice, isTauriRuntime } from "../lib/platform";
 
 const MOBILE_VIEWPORT_CONTENT =
 	"width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover, interactive-widget=resizes-content";
@@ -8,33 +9,6 @@ const MAX_SAFE_TOP_PX = 96;
 const MAX_SAFE_BOTTOM_PX = 64;
 const POLL_MAX_RETRIES = 40;
 const POLL_INTERVAL_MS = 50;
-
-function isTauriRuntime(): boolean {
-	if (typeof window === "undefined") return false;
-	const w = window as Window & {
-		__TAURI__?: unknown;
-		__TAURI_IPC__?: unknown;
-		__TAURI_INTERNALS__?: unknown;
-	};
-	return Boolean(w.__TAURI__ || w.__TAURI_IPC__ || w.__TAURI_INTERNALS__);
-}
-
-function isIOSDevice(): boolean {
-	if (typeof navigator === "undefined") return false;
-	return (
-		/iPad|iPhone|iPod/.test(navigator.userAgent) ||
-		(navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1)
-	);
-}
-
-function isAndroidDevice(): boolean {
-	if (typeof navigator === "undefined") return false;
-	return /Android/i.test(navigator.userAgent);
-}
-
-function isMobileDevice(): boolean {
-	return isIOSDevice() || isAndroidDevice();
-}
 
 function upsertViewportMeta(content: string) {
 	let meta = document.querySelector(

--- a/apps/desktop/components/notification-provider.tsx
+++ b/apps/desktop/components/notification-provider.tsx
@@ -4,11 +4,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { invoke } from "@tauri-apps/api/core";
 import { type Event, type UnlistenFn, listen } from "@tauri-apps/api/event";
 import { useBackend, useHub } from "@flow-like/flow-like-ui";
-import type {
-	IIntercomEvent,
-	INotificationEvent,
-	IPushNotificationsConfig,
-} from "@flow-like/flow-like-ui";
+import type { IIntercomEvent, INotificationEvent } from "@flow-like/flow-like-ui";
 import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "react-oidc-context";
@@ -19,6 +15,18 @@ import {
 	type FlowNotificationBatchDetail,
 } from "../lib/flow-notification-events";
 import { addLocalNotification } from "../lib/notifications-db";
+import {
+	REMOTE_PUSH_PREFERENCE_EVENT,
+	canUseRemotePushForPlatform,
+	detectPushPlatform,
+	getPushDeviceId,
+	isRemotePushPreferenceEnabled,
+	loadRemotePushPlugin,
+	type PushTargetPlatform,
+	type RemotePushApi,
+	type RemotePushListener,
+	type RemotePushPayload,
+} from "../lib/remote-push";
 import type { TauriBackend } from "./tauri-provider";
 
 type NotificationPermission = "granted" | "denied" | "default";
@@ -26,36 +34,6 @@ type NotificationApi = {
 	isPermissionGranted: () => Promise<boolean>;
 	requestPermission: () => Promise<NotificationPermission>;
 	sendNotification: (options: { title: string; body?: string }) => void;
-};
-
-type PushTargetPlatform = "IOS" | "ANDROID" | "DESKTOP";
-
-type RemotePushPayload = {
-	title?: string;
-	body?: string;
-	data: Record<string, unknown>;
-	badge?: number;
-	sound?: string;
-	channelId?: string;
-	category?: string;
-};
-
-type RemotePushListener = {
-	unregister: () => Promise<void> | void;
-};
-
-type RemotePushApi = {
-	getToken: () => Promise<string>;
-	requestPermission: () => Promise<{ granted: boolean }>;
-	onNotificationReceived: (
-		handler: (notification: RemotePushPayload) => void,
-	) => Promise<RemotePushListener>;
-	onNotificationTapped: (
-		handler: (notification: RemotePushPayload) => void,
-	) => Promise<RemotePushListener>;
-	onTokenRefresh: (
-		handler: (token: string) => void,
-	) => Promise<RemotePushListener>;
 };
 
 type RemotePushPluginState = "loading" | "available" | "unavailable";
@@ -73,151 +51,6 @@ async function loadNotificationPlugin(): Promise<NotificationApi | null> {
 	} catch {
 		return null;
 	}
-}
-
-async function loadRemotePushPlugin(): Promise<RemotePushApi | null> {
-	try {
-		const mod = await import("tauri-plugin-remote-push-api");
-		return {
-			getToken: mod.getToken,
-			requestPermission: mod.requestPermission,
-			onNotificationReceived: mod.onNotificationReceived,
-			onNotificationTapped: mod.onNotificationTapped,
-			onTokenRefresh: mod.onTokenRefresh,
-		};
-	} catch {
-		return null;
-	}
-}
-
-const DEVICE_ID_STORAGE_KEY = "flow-like-push-device-id";
-const DEVICE_ID_FILE = "push-device-id.txt";
-
-async function loadPersistentDeviceId(): Promise<string | null> {
-	try {
-		const { readTextFile, BaseDirectory } = await import(
-			"@tauri-apps/plugin-fs"
-		);
-		const id = await readTextFile(DEVICE_ID_FILE, {
-			baseDir: BaseDirectory.AppData,
-		});
-		return id?.trim() || null;
-	} catch {
-		return null;
-	}
-}
-
-async function savePersistentDeviceId(id: string): Promise<void> {
-	try {
-		const { writeTextFile, mkdir, BaseDirectory } = await import(
-			"@tauri-apps/plugin-fs"
-		);
-		await mkdir("", { baseDir: BaseDirectory.AppData, recursive: true }).catch(
-			() => {},
-		);
-		await writeTextFile(DEVICE_ID_FILE, id, {
-			baseDir: BaseDirectory.AppData,
-		});
-	} catch {
-		// FS not available - fall through to localStorage only
-	}
-}
-
-function getPushDeviceIdSync(): string {
-	if (typeof window === "undefined") {
-		return "server-device";
-	}
-
-	const existing = window.localStorage.getItem(DEVICE_ID_STORAGE_KEY);
-	if (existing) {
-		return existing;
-	}
-
-	const created = crypto.randomUUID();
-	window.localStorage.setItem(DEVICE_ID_STORAGE_KEY, created);
-	return created;
-}
-
-async function loadNativeDeviceId(): Promise<string | null> {
-	try {
-		const id = await invoke<string | null>("get_stable_device_id");
-		return typeof id === "string" && id.trim().length > 0 ? id.trim() : null;
-	} catch {
-		return null;
-	}
-}
-
-async function getPushDeviceId(): Promise<string> {
-	if (typeof window === "undefined") {
-		return "server-device";
-	}
-
-	// Native platform-stable id (iOS Keychain / Android ANDROID_ID). Survives
-	// uninstall/reinstall, so the backend reuses the existing PushNotificationTarget
-	// row instead of marking it superseded.
-	const native = await loadNativeDeviceId();
-	if (native) {
-		window.localStorage.setItem(DEVICE_ID_STORAGE_KEY, native);
-		await savePersistentDeviceId(native);
-		return native;
-	}
-
-	// Desktop fallback: persistent FS (AppData survives reinstall on
-	// macOS/Windows/Linux), then localStorage, then a fresh UUID.
-	const persisted = await loadPersistentDeviceId();
-	if (persisted) {
-		window.localStorage.setItem(DEVICE_ID_STORAGE_KEY, persisted);
-		return persisted;
-	}
-
-	const existing = window.localStorage.getItem(DEVICE_ID_STORAGE_KEY);
-	if (existing) {
-		await savePersistentDeviceId(existing);
-		return existing;
-	}
-
-	const created = crypto.randomUUID();
-	window.localStorage.setItem(DEVICE_ID_STORAGE_KEY, created);
-	await savePersistentDeviceId(created);
-	return created;
-}
-
-function detectPushPlatform(): PushTargetPlatform | null {
-	if (typeof navigator === "undefined") {
-		return null;
-	}
-
-	const userAgent = navigator.userAgent.toLowerCase();
-	if (userAgent.includes("android")) {
-		return "ANDROID";
-	}
-	if (
-		userAgent.includes("iphone") ||
-		userAgent.includes("ipad") ||
-		userAgent.includes("ipod")
-	) {
-		return "IOS";
-	}
-	if ("__TAURI_INTERNALS__" in window) {
-		return "DESKTOP";
-	}
-
-	return null;
-}
-
-function canUseRemotePushForPlatform(
-	pushConfig: IPushNotificationsConfig | undefined,
-	platform: PushTargetPlatform | null,
-): boolean {
-	if (!pushConfig?.enabled || pushConfig.provider !== "fcm" || !platform) {
-		return false;
-	}
-
-	if (platform === "DESKTOP") {
-		return pushConfig.allow_desktop === true;
-	}
-
-	return pushConfig.allow_mobile === true;
 }
 
 function dataString(
@@ -320,6 +153,8 @@ export default function NotificationProvider({
 	const [pushDeviceId, setPushDeviceId] = useState<string | null>(null);
 	const [remotePushPluginState, setRemotePushPluginState] =
 		useState<RemotePushPluginState>("loading");
+	const [remotePushPreferenceEnabled, setRemotePushPreferenceEnabled] =
+		useState(isRemotePushPreferenceEnabled);
 	const pushConfig = hub.hub?.push_notifications;
 	const handleTapRef = useRef<(notification: RemotePushPayload) => void>(
 		() => {},
@@ -579,12 +414,34 @@ export default function NotificationProvider({
 	}, []);
 
 	useEffect(() => {
+		if (typeof window === "undefined") {
+			return;
+		}
+
+		const handlePreferenceChange = () => {
+			setRemotePushPreferenceEnabled(isRemotePushPreferenceEnabled());
+		};
+
+		window.addEventListener(
+			REMOTE_PUSH_PREFERENCE_EVENT,
+			handlePreferenceChange,
+		);
+		return () => {
+			window.removeEventListener(
+				REMOTE_PUSH_PREFERENCE_EVENT,
+				handlePreferenceChange,
+			);
+		};
+	}, []);
+
+	useEffect(() => {
 		const platform = detectPushPlatform();
 		if (
 			!isAuthenticated ||
 			!backend?.profile ||
 			!currentUser ||
 			!pushDeviceId ||
+			!remotePushPreferenceEnabled ||
 			remotePushPluginState === "loading"
 		) {
 			return;
@@ -700,6 +557,7 @@ export default function NotificationProvider({
 		pushConfig,
 		appId,
 		pushDeviceId,
+		remotePushPreferenceEnabled,
 		remotePushPluginState,
 	]);
 

--- a/apps/desktop/components/tauri-provider.tsx
+++ b/apps/desktop/components/tauri-provider.tsx
@@ -49,6 +49,7 @@ import { useCallback, useEffect, useRef, useTransition } from "react";
 import type { AuthContextProps } from "react-oidc-context";
 import { appsDB } from "../lib/apps-db";
 import { scheduleIDBCleanup } from "../lib/idb-maintenance";
+import { isIOSDevice } from "../lib/platform";
 import { type OnlineProfile, toLocalProfile } from "../lib/profile-sync";
 import { AiState } from "./tauri-provider/ai-state";
 import { AnalyticsState } from "./tauri-provider/analytics-state";
@@ -142,7 +143,7 @@ export class TauriBackend implements IBackendState {
 	}
 
 	capabilities(): ICapabilities {
-		const isIos = /iPad|iPhone|iPod/.test(navigator.userAgent);
+		const isIos = isIOSDevice();
 
 		return {
 			needsSignIn: isIos,

--- a/apps/desktop/components/tauri-provider/user-state.ts
+++ b/apps/desktop/components/tauri-provider/user-state.ts
@@ -13,7 +13,10 @@ import type {
 } from "@flow-like/flow-like-ui/state/backend-state/types";
 import type {
 	IBillingSession,
+	IPushTargetStatus,
 	IPricingResponse,
+	IRegisterPushTargetRequest,
+	IRegisterPushTargetResponse,
 	ISubscribeRequest,
 	ISubscribeResponse,
 	IUserInfo,
@@ -366,6 +369,68 @@ export class UserState implements IUserState {
 		}
 
 		return remoteResult + localCount;
+	}
+
+	async registerPushTarget(
+		request: IRegisterPushTargetRequest,
+	): Promise<IRegisterPushTargetResponse> {
+		if (
+			!this.backend.profile ||
+			!this.backend.auth ||
+			!this.hasRemoteAccessToken()
+		) {
+			throw new Error("Profile or auth context not available");
+		}
+
+		return fetcher<IRegisterPushTargetResponse>(
+			this.backend.profile,
+			"user/push-targets/register",
+			{
+				method: "POST",
+				body: JSON.stringify(request),
+			},
+			this.backend.auth,
+		);
+	}
+
+	async getPushTargetStatus(deviceId: string): Promise<IPushTargetStatus> {
+		if (
+			!this.backend.profile ||
+			!this.backend.auth ||
+			!this.hasRemoteAccessToken()
+		) {
+			throw new Error("Profile or auth context not available");
+		}
+
+		return fetcher<IPushTargetStatus>(
+			this.backend.profile,
+			`user/push-targets/${encodeURIComponent(deviceId)}`,
+			{ method: "GET" },
+			this.backend.auth,
+		);
+	}
+
+	async setPushTargetEnabled(
+		deviceId: string,
+		enabled: boolean,
+	): Promise<IPushTargetStatus> {
+		if (
+			!this.backend.profile ||
+			!this.backend.auth ||
+			!this.hasRemoteAccessToken()
+		) {
+			throw new Error("Profile or auth context not available");
+		}
+
+		return fetcher<IPushTargetStatus>(
+			this.backend.profile,
+			`user/push-targets/${encodeURIComponent(deviceId)}`,
+			{
+				method: "PATCH",
+				body: JSON.stringify({ push_enabled: enabled }),
+			},
+			this.backend.auth,
+		);
 	}
 
 	async getProfile(): Promise<IProfile> {

--- a/apps/desktop/lib/platform.ts
+++ b/apps/desktop/lib/platform.ts
@@ -1,0 +1,34 @@
+export function isTauriRuntime(): boolean {
+	if (typeof window === "undefined") return false;
+	const tauriWindow = window as Window & {
+		__TAURI__?: unknown;
+		__TAURI_IPC__?: unknown;
+		__TAURI_INTERNALS__?: unknown;
+	};
+	return Boolean(
+		tauriWindow.__TAURI__ ||
+			tauriWindow.__TAURI_IPC__ ||
+			tauriWindow.__TAURI_INTERNALS__,
+	);
+}
+
+export function isIOSDevice(): boolean {
+	if (typeof navigator === "undefined") return false;
+	return (
+		/iPad|iPhone|iPod/.test(navigator.userAgent) ||
+		(navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1)
+	);
+}
+
+export function isAndroidDevice(): boolean {
+	if (typeof navigator === "undefined") return false;
+	return /Android/i.test(navigator.userAgent);
+}
+
+export function isMobileDevice(): boolean {
+	return isIOSDevice() || isAndroidDevice();
+}
+
+export function isIosTauriRuntime(): boolean {
+	return isTauriRuntime() && isIOSDevice();
+}

--- a/apps/desktop/lib/remote-push.ts
+++ b/apps/desktop/lib/remote-push.ts
@@ -40,6 +40,7 @@ export const REMOTE_PUSH_PREFERENCE_EVENT =
 	"flow-like:remote-push-preference-changed";
 
 export async function loadRemotePushPlugin(): Promise<RemotePushApi | null> {
+	if (!isTauriRuntime()) return null;
 	try {
 		const mod = await import("tauri-plugin-remote-push-api");
 		return {
@@ -98,7 +99,7 @@ export async function getPushDeviceId(): Promise<string> {
 		return "server-device";
 	}
 
-	const native = await loadNativeDeviceId();
+	const native = isTauriRuntime() ? await loadNativeDeviceId() : null;
 	if (native) {
 		window.localStorage.setItem(DEVICE_ID_STORAGE_KEY, native);
 		await savePersistentDeviceId(native);

--- a/apps/desktop/lib/remote-push.ts
+++ b/apps/desktop/lib/remote-push.ts
@@ -1,0 +1,184 @@
+import { invoke } from "@tauri-apps/api/core";
+import type { IPushNotificationsConfig } from "@flow-like/flow-like-ui";
+
+export type PushTargetPlatform = "IOS" | "ANDROID" | "DESKTOP";
+
+export type RemotePushPayload = {
+	title?: string;
+	body?: string;
+	data: Record<string, unknown>;
+	badge?: number;
+	sound?: string;
+	channelId?: string;
+	category?: string;
+};
+
+export type RemotePushListener = {
+	unregister: () => Promise<void> | void;
+};
+
+export type RemotePushApi = {
+	getToken: () => Promise<string>;
+	requestPermission: () => Promise<{ granted: boolean }>;
+	onNotificationReceived: (
+		handler: (notification: RemotePushPayload) => void,
+	) => Promise<RemotePushListener>;
+	onNotificationTapped: (
+		handler: (notification: RemotePushPayload) => void,
+	) => Promise<RemotePushListener>;
+	onTokenRefresh: (
+		handler: (token: string) => void,
+	) => Promise<RemotePushListener>;
+};
+
+const DEVICE_ID_STORAGE_KEY = "flow-like-push-device-id";
+const DEVICE_ID_FILE = "push-device-id.txt";
+const REMOTE_PUSH_ENABLED_STORAGE_KEY = "flow-like-remote-push-enabled";
+
+export const REMOTE_PUSH_PREFERENCE_EVENT =
+	"flow-like:remote-push-preference-changed";
+
+export async function loadRemotePushPlugin(): Promise<RemotePushApi | null> {
+	try {
+		const mod = await import("tauri-plugin-remote-push-api");
+		return {
+			getToken: mod.getToken,
+			requestPermission: mod.requestPermission,
+			onNotificationReceived: mod.onNotificationReceived,
+			onNotificationTapped: mod.onNotificationTapped,
+			onTokenRefresh: mod.onTokenRefresh,
+		};
+	} catch {
+		return null;
+	}
+}
+
+async function loadPersistentDeviceId(): Promise<string | null> {
+	try {
+		const { readTextFile, BaseDirectory } = await import(
+			"@tauri-apps/plugin-fs"
+		);
+		const id = await readTextFile(DEVICE_ID_FILE, {
+			baseDir: BaseDirectory.AppData,
+		});
+		return id?.trim() || null;
+	} catch {
+		return null;
+	}
+}
+
+async function savePersistentDeviceId(id: string): Promise<void> {
+	try {
+		const { writeTextFile, mkdir, BaseDirectory } = await import(
+			"@tauri-apps/plugin-fs"
+		);
+		await mkdir("", { baseDir: BaseDirectory.AppData, recursive: true }).catch(
+			() => {},
+		);
+		await writeTextFile(DEVICE_ID_FILE, id, {
+			baseDir: BaseDirectory.AppData,
+		});
+	} catch {
+		// FS is unavailable in browser-like shells; localStorage is still used.
+	}
+}
+
+async function loadNativeDeviceId(): Promise<string | null> {
+	try {
+		const id = await invoke<string | null>("get_stable_device_id");
+		return typeof id === "string" && id.trim().length > 0 ? id.trim() : null;
+	} catch {
+		return null;
+	}
+}
+
+export async function getPushDeviceId(): Promise<string> {
+	if (typeof window === "undefined") {
+		return "server-device";
+	}
+
+	const native = await loadNativeDeviceId();
+	if (native) {
+		window.localStorage.setItem(DEVICE_ID_STORAGE_KEY, native);
+		await savePersistentDeviceId(native);
+		return native;
+	}
+
+	const persisted = await loadPersistentDeviceId();
+	if (persisted) {
+		window.localStorage.setItem(DEVICE_ID_STORAGE_KEY, persisted);
+		return persisted;
+	}
+
+	const existing = window.localStorage.getItem(DEVICE_ID_STORAGE_KEY);
+	if (existing) {
+		await savePersistentDeviceId(existing);
+		return existing;
+	}
+
+	const created = crypto.randomUUID();
+	window.localStorage.setItem(DEVICE_ID_STORAGE_KEY, created);
+	await savePersistentDeviceId(created);
+	return created;
+}
+
+export function detectPushPlatform(): PushTargetPlatform | null {
+	if (typeof navigator === "undefined" || typeof window === "undefined") {
+		return null;
+	}
+
+	const userAgent = navigator.userAgent.toLowerCase();
+	if (userAgent.includes("android")) {
+		return "ANDROID";
+	}
+	if (
+		userAgent.includes("iphone") ||
+		userAgent.includes("ipad") ||
+		userAgent.includes("ipod")
+	) {
+		return "IOS";
+	}
+	if ("__TAURI_INTERNALS__" in window) {
+		return "DESKTOP";
+	}
+
+	return null;
+}
+
+export function canUseRemotePushForPlatform(
+	pushConfig: IPushNotificationsConfig | undefined,
+	platform: PushTargetPlatform | null,
+): boolean {
+	if (!pushConfig?.enabled || pushConfig.provider !== "fcm" || !platform) {
+		return false;
+	}
+
+	if (platform === "DESKTOP") {
+		return pushConfig.allow_desktop === true;
+	}
+
+	return pushConfig.allow_mobile === true;
+}
+
+export function isRemotePushPreferenceEnabled(): boolean {
+	if (typeof window === "undefined") {
+		return true;
+	}
+	return window.localStorage.getItem(REMOTE_PUSH_ENABLED_STORAGE_KEY) !== "false";
+}
+
+export function setRemotePushPreference(enabled: boolean): void {
+	if (typeof window === "undefined") {
+		return;
+	}
+
+	window.localStorage.setItem(
+		REMOTE_PUSH_ENABLED_STORAGE_KEY,
+		enabled ? "true" : "false",
+	);
+	window.dispatchEvent(
+		new CustomEvent(REMOTE_PUSH_PREFERENCE_EVENT, {
+			detail: { enabled },
+		}),
+	);
+}

--- a/apps/desktop/lib/remote-push.ts
+++ b/apps/desktop/lib/remote-push.ts
@@ -1,5 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import type { IPushNotificationsConfig } from "@flow-like/flow-like-ui";
+import { isAndroidDevice, isIOSDevice, isTauriRuntime } from "./platform";
 
 export type PushTargetPlatform = "IOS" | "ANDROID" | "DESKTOP";
 
@@ -123,22 +124,13 @@ export async function getPushDeviceId(): Promise<string> {
 }
 
 export function detectPushPlatform(): PushTargetPlatform | null {
-	if (typeof navigator === "undefined" || typeof window === "undefined") {
-		return null;
-	}
-
-	const userAgent = navigator.userAgent.toLowerCase();
-	if (userAgent.includes("android")) {
+	if (isAndroidDevice()) {
 		return "ANDROID";
 	}
-	if (
-		userAgent.includes("iphone") ||
-		userAgent.includes("ipad") ||
-		userAgent.includes("ipod")
-	) {
+	if (isIOSDevice()) {
 		return "IOS";
 	}
-	if ("__TAURI_INTERNALS__" in window) {
+	if (isTauriRuntime()) {
 		return "DESKTOP";
 	}
 

--- a/packages/api/src/openapi.rs
+++ b/packages/api/src/openapi.rs
@@ -141,6 +141,8 @@ impl Modify for SecurityAddon {
         crate::routes::user::notifications::mark_all_read,
         crate::routes::user::notifications::delete_notification,
         crate::routes::user::push_targets::register_push_target,
+        crate::routes::user::push_targets::get_push_target_status,
+        crate::routes::user::push_targets::update_push_target_status,
         crate::routes::user::push_targets::unregister_push_target,
         crate::routes::user::get_invites::get_invites,
         crate::routes::user::manage_invite::accept_invite,

--- a/packages/api/src/routes/user.rs
+++ b/packages/api/src/routes/user.rs
@@ -100,7 +100,9 @@ pub fn routes() -> Router<AppState> {
         )
         .route(
             "/push-targets/{device_id}",
-            axum::routing::delete(push_targets::unregister_push_target),
+            get(push_targets::get_push_target_status)
+                .patch(push_targets::update_push_target_status)
+                .delete(push_targets::unregister_push_target),
         )
         .route(
             "/notifications/create",

--- a/packages/api/src/routes/user/push_targets.rs
+++ b/packages/api/src/routes/user/push_targets.rs
@@ -24,6 +24,8 @@ use sea_orm::{
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
+const USER_DISABLED_PUSH_REASON: &str = "User disabled push notifications";
+
 #[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum PushTargetPlatformDto {
@@ -47,11 +49,34 @@ pub struct RegisterPushTargetResponse {
     pub id: String,
     pub provider: String,
     pub success: bool,
+    pub push_enabled: bool,
 }
 
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct UnregisterPushTargetResponse {
     pub success: bool,
+}
+
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct PushTargetStatusResponse {
+    pub device_id: String,
+    pub provider: Option<String>,
+    pub registered: bool,
+    pub push_enabled: bool,
+    pub platform: Option<String>,
+    pub device_name: Option<String>,
+    pub channel_id: Option<String>,
+    pub failure_count: Option<i32>,
+    pub last_registered_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub last_seen_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub invalidated_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub invalidation_reason: Option<String>,
+    pub updated_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct UpdatePushTargetRequest {
+    pub push_enabled: bool,
 }
 
 #[derive(Debug, Clone, Deserialize, ToSchema)]
@@ -172,8 +197,11 @@ pub async fn register_push_target(
     .await
     .map_err(|error| ApiError::bad_request(error.to_string()))?;
 
+    let mut push_enabled = true;
     let target_id = if let Some(existing) = existing {
+        push_enabled = should_auto_enable_target(&existing);
         let mut active: push_notification_target::ActiveModel = existing.into();
+        active.device_id = Set(body.device_id.clone());
         active.platform = Set(platform);
         active.token_encrypted = Set(token_encrypted);
         active.endpoint_arn = Set(provider_registration.endpoint_arn.clone());
@@ -181,10 +209,12 @@ pub async fn register_push_target(
         active.channel_id = Set(body.channel_id.clone());
         active.device_name = Set(body.device_name.clone());
         active.metadata = Set(body.metadata.clone());
-        active.push_enabled = Set(true);
+        active.push_enabled = Set(push_enabled);
         active.failure_count = Set(0);
-        active.invalidated_at = Set(None);
-        active.invalidation_reason = Set(None);
+        if push_enabled {
+            active.invalidated_at = Set(None);
+            active.invalidation_reason = Set(None);
+        }
         active.last_registered_at = Set(now);
         active.last_seen_at = Set(now);
         active.updated_at = Set(now);
@@ -221,7 +251,129 @@ pub async fn register_push_target(
         id: target_id,
         provider: provider_name(&provider).to_string(),
         success: true,
+        push_enabled,
     }))
+}
+
+#[utoipa::path(
+    get,
+    path = "/user/push-targets/{device_id}",
+    tag = "user",
+    params(("device_id" = String, Path, description = "Device ID to inspect")),
+    responses(
+        (status = 200, description = "Push target status", body = PushTargetStatusResponse),
+        (status = 401, description = "Unauthorized")
+    ),
+    security(("bearer_auth" = []))
+)]
+#[tracing::instrument(name = "GET /user/push-targets/{device_id}", skip(state, user))]
+pub async fn get_push_target_status(
+    State(state): State<AppState>,
+    Extension(user): Extension<AppUser>,
+    Path(device_id): Path<String>,
+) -> Result<Json<PushTargetStatusResponse>, ApiError> {
+    let sub = user.sub()?;
+    ensure_user_exists(&state, &sub).await?;
+
+    let provider = configured_provider(&state.platform_config.push_notifications);
+    let target = match &provider {
+        Some(provider) => find_push_target_by_device(&state, &sub, &device_id, provider).await?,
+        None => None,
+    };
+
+    Ok(Json(target_status_response(
+        device_id,
+        provider.as_ref(),
+        target,
+    )))
+}
+
+#[utoipa::path(
+    patch,
+    path = "/user/push-targets/{device_id}",
+    tag = "user",
+    params(("device_id" = String, Path, description = "Device ID to update")),
+    request_body = UpdatePushTargetRequest,
+    responses(
+        (status = 200, description = "Push target updated", body = PushTargetStatusResponse),
+        (status = 400, description = "Push notifications are not enabled or provider is not configured"),
+        (status = 401, description = "Unauthorized")
+    ),
+    security(("bearer_auth" = []))
+)]
+#[tracing::instrument(name = "PATCH /user/push-targets/{device_id}", skip(state, user, body))]
+pub async fn update_push_target_status(
+    State(state): State<AppState>,
+    Extension(user): Extension<AppUser>,
+    Path(device_id): Path<String>,
+    Json(body): Json<UpdatePushTargetRequest>,
+) -> Result<Json<PushTargetStatusResponse>, ApiError> {
+    let sub = user.sub()?;
+    ensure_user_exists(&state, &sub).await?;
+
+    let config = &state.platform_config.push_notifications;
+    let provider = configured_provider(config).ok_or_else(|| {
+        ApiError::bad_request("Push notification provider is not configured".to_string())
+    })?;
+
+    if body.push_enabled && !config.enabled {
+        return Err(ApiError::bad_request(
+            "Push notifications are disabled".to_string(),
+        ));
+    }
+
+    let now = chrono::Utc::now().naive_utc();
+    let mut update = push_notification_target::Entity::update_many()
+        .col_expr(
+            push_notification_target::Column::PushEnabled,
+            Expr::value(body.push_enabled),
+        )
+        .col_expr(
+            push_notification_target::Column::LastSeenAt,
+            Expr::value(now),
+        )
+        .col_expr(
+            push_notification_target::Column::UpdatedAt,
+            Expr::value(now),
+        )
+        .filter(push_notification_target::Column::UserId.eq(sub.clone()))
+        .filter(push_notification_target::Column::DeviceId.eq(device_id.clone()))
+        .filter(push_notification_target::Column::Provider.eq(provider.clone()));
+
+    if body.push_enabled {
+        update = update
+            .col_expr(
+                push_notification_target::Column::FailureCount,
+                Expr::value(0),
+            )
+            .col_expr(
+                push_notification_target::Column::InvalidatedAt,
+                Expr::value(None::<chrono::NaiveDateTime>),
+            )
+            .col_expr(
+                push_notification_target::Column::InvalidationReason,
+                Expr::value(None::<String>),
+            );
+    } else {
+        update = update
+            .col_expr(
+                push_notification_target::Column::InvalidatedAt,
+                Expr::value(Some(now)),
+            )
+            .col_expr(
+                push_notification_target::Column::InvalidationReason,
+                Expr::value(Some(USER_DISABLED_PUSH_REASON.to_string())),
+            );
+    }
+
+    update.exec(&state.db).await?;
+
+    let target = find_push_target_by_device(&state, &sub, &device_id, &provider).await?;
+    Ok(Json(target_status_response(
+        device_id,
+        Some(&provider),
+        target,
+    )))
 }
 
 #[utoipa::path(
@@ -279,10 +431,14 @@ fn unregister_reason(reason: Option<&str>) -> String {
     }) {
         Some("permission_revoked") => "User revoked notification permission".to_string(),
         Some("sign_out") => "User signed out on this device".to_string(),
-        Some("user_disabled") => "User disabled push notifications".to_string(),
+        Some("user_disabled") => USER_DISABLED_PUSH_REASON.to_string(),
         Some(value) => format!("Client unregistered push target: {}", value),
         None => "Client unregistered push target".to_string(),
     }
+}
+
+fn should_auto_enable_target(target: &push_notification_target::Model) -> bool {
+    target.invalidation_reason.as_deref() != Some(USER_DISABLED_PUSH_REASON)
 }
 
 fn map_platform(platform: &PushTargetPlatformDto) -> PushNotificationTargetPlatform {
@@ -299,6 +455,71 @@ fn provider_name(provider: &PushNotificationTargetProvider) -> &'static str {
         PushNotificationTargetProvider::AwsSns => "AWS_SNS",
         PushNotificationTargetProvider::AzureNotificationHubs => "AZURE_NOTIFICATION_HUBS",
     }
+}
+
+fn platform_name(platform: &PushNotificationTargetPlatform) -> &'static str {
+    match platform {
+        PushNotificationTargetPlatform::Ios => "IOS",
+        PushNotificationTargetPlatform::Android => "ANDROID",
+        PushNotificationTargetPlatform::Desktop => "DESKTOP",
+    }
+}
+
+fn utc(dt: chrono::NaiveDateTime) -> chrono::DateTime<chrono::Utc> {
+    chrono::DateTime::from_naive_utc_and_offset(dt, chrono::Utc)
+}
+
+fn target_status_response(
+    device_id: String,
+    provider: Option<&PushNotificationTargetProvider>,
+    target: Option<push_notification_target::Model>,
+) -> PushTargetStatusResponse {
+    match target {
+        Some(target) => PushTargetStatusResponse {
+            device_id,
+            provider: Some(provider_name(&target.provider).to_string()),
+            registered: true,
+            push_enabled: target.push_enabled,
+            platform: Some(platform_name(&target.platform).to_string()),
+            device_name: target.device_name,
+            channel_id: target.channel_id,
+            failure_count: Some(target.failure_count),
+            last_registered_at: Some(utc(target.last_registered_at)),
+            last_seen_at: Some(utc(target.last_seen_at)),
+            invalidated_at: target.invalidated_at.map(utc),
+            invalidation_reason: target.invalidation_reason,
+            updated_at: Some(utc(target.updated_at)),
+        },
+        None => PushTargetStatusResponse {
+            device_id,
+            provider: provider.map(provider_name).map(str::to_string),
+            registered: false,
+            push_enabled: false,
+            platform: None,
+            device_name: None,
+            channel_id: None,
+            failure_count: None,
+            last_registered_at: None,
+            last_seen_at: None,
+            invalidated_at: None,
+            invalidation_reason: None,
+            updated_at: None,
+        },
+    }
+}
+
+async fn find_push_target_by_device(
+    state: &AppState,
+    user_id: &str,
+    device_id: &str,
+    provider: &PushNotificationTargetProvider,
+) -> Result<Option<push_notification_target::Model>, sea_orm::DbErr> {
+    push_notification_target::Entity::find()
+        .filter(push_notification_target::Column::UserId.eq(user_id.to_string()))
+        .filter(push_notification_target::Column::DeviceId.eq(device_id.to_string()))
+        .filter(push_notification_target::Column::Provider.eq(provider.clone()))
+        .one(&state.db)
+        .await
 }
 
 async fn find_existing_push_target(
@@ -430,5 +651,33 @@ mod tests {
         let found = find_matching_token_target(vec![other], "ios-token", &encryption_key);
 
         assert!(found.is_none());
+    }
+
+    #[test]
+    fn user_disabled_targets_are_not_auto_enabled_by_registration() {
+        let encryption_key = [4u8; 32];
+        let target = target(
+            "disabled-ios",
+            "ios-token",
+            &encryption_key,
+            false,
+            Some(USER_DISABLED_PUSH_REASON),
+        );
+
+        assert!(!should_auto_enable_target(&target));
+    }
+
+    #[test]
+    fn invalidated_targets_are_auto_enabled_by_registration() {
+        let encryption_key = [5u8; 32];
+        let target = target(
+            "invalidated-ios",
+            "ios-token",
+            &encryption_key,
+            false,
+            Some("15 consecutive invalidation-class failures"),
+        );
+
+        assert!(should_auto_enable_target(&target));
     }
 }

--- a/packages/api/src/routes/user/push_targets.rs
+++ b/packages/api/src/routes/user/push_targets.rs
@@ -366,7 +366,10 @@ pub async fn update_push_target_status(
             );
     }
 
-    update.exec(&state.db).await?;
+    let update_result = update.exec(&state.db).await?;
+    if update_result.rows_affected == 0 {
+        return Err(ApiError::bad_request("Push target not found".to_string()));
+    }
 
     let target = find_push_target_by_device(&state, &sub, &device_id, &provider).await?;
     Ok(Json(target_status_response(

--- a/packages/ui/hooks/use-hub.tsx
+++ b/packages/ui/hooks/use-hub.tsx
@@ -15,21 +15,30 @@ export function useHub() {
 	const [hub, setHub] = useState<IHub | undefined>();
 
 	const fetchHub = useCallback(async () => {
-		if (!profile.data?.hub) return;
+		if (!profile.data?.hub) {
+			setHub(undefined);
+			return;
+		}
 		let hubUrl = profile.data.hub;
 		if (!hubUrl.startsWith("http://") && !hubUrl.startsWith("https://")) {
 			const protocol = (profile.data?.secure ?? true) ? "https" : "http";
 			hubUrl = `${protocol}://${hubUrl}`;
 		}
-		// Strip any trailing slash so we control the suffix exactly. The hub
-		// root handler is `.route("/", ...)` nested under `/api/v1`, which
-		// in axum 0.8 only matches the trailing-slash form.
+		// Strip any trailing slash so we control the suffix exactly. The live
+		// API exposes the hub root at `/api/v1`; `/api/v1/` can 404 behind
+		// CloudFront/Lambda routing.
 		const base = hubUrl.replace(/\/+$/, "");
 		try {
-			const hubData = await fetch(`${base}/api/v1/`, {});
+			const hubData = await fetch(`${base}/api/v1`, {
+				cache: "no-store",
+				headers: {
+					"Cache-Control": "no-cache",
+					Pragma: "no-cache",
+				},
+			});
 			if (!hubData.ok) {
 				console.error(
-					`Hub config fetch returned ${hubData.status} from ${base}/api/v1/`,
+					`Hub config fetch returned ${hubData.status} from ${base}/api/v1`,
 				);
 				return;
 			}
@@ -42,7 +51,7 @@ export function useHub() {
 
 	useEffect(() => {
 		fetchHub();
-	}, [profile.data?.hub]);
+	}, [fetchHub]);
 
 	return { hub, refetch: fetchHub };
 }

--- a/packages/ui/state/backend-state.ts
+++ b/packages/ui/state/backend-state.ts
@@ -141,6 +141,9 @@ export type {
 export * from "./backend-state/db-state";
 export * from "./backend-state/graph-state";
 export type {
+	IPushTargetStatus,
+	IRegisterPushTargetRequest,
+	IRegisterPushTargetResponse,
 	IUserWidgetInfo,
 	IUserTemplateInfo,
 } from "./backend-state/user-state";

--- a/packages/ui/state/backend-state/empty-states/user-state.ts
+++ b/packages/ui/state/backend-state/empty-states/user-state.ts
@@ -12,7 +12,10 @@ import type {
 } from "@flow-like/flow-like-ui/state/backend-state/types";
 import type {
 	IBillingSession,
+	IPushTargetStatus,
 	IPricingResponse,
+	IRegisterPushTargetRequest,
+	IRegisterPushTargetResponse,
 	ISubscribeRequest,
 	ISubscribeResponse,
 	IUserInfo,
@@ -116,6 +119,23 @@ export class EmptyUserState implements IUserState {
 	}
 
 	markAllNotificationsRead(): Promise<number> {
+		throw new Error("Method not implemented.");
+	}
+
+	registerPushTarget(
+		request: IRegisterPushTargetRequest,
+	): Promise<IRegisterPushTargetResponse> {
+		throw new Error("Method not implemented.");
+	}
+
+	getPushTargetStatus(deviceId: string): Promise<IPushTargetStatus> {
+		throw new Error("Method not implemented.");
+	}
+
+	setPushTargetEnabled(
+		deviceId: string,
+		enabled: boolean,
+	): Promise<IPushTargetStatus> {
 		throw new Error("Method not implemented.");
 	}
 

--- a/packages/ui/state/backend-state/user-state.ts
+++ b/packages/ui/state/backend-state/user-state.ts
@@ -78,6 +78,40 @@ export interface IBillingSession {
 	url: string;
 }
 
+export type PushTargetPlatform = "IOS" | "ANDROID" | "DESKTOP";
+
+export interface IRegisterPushTargetRequest {
+	device_id: string;
+	platform: PushTargetPlatform;
+	token: string;
+	device_name?: string;
+	channel_id?: string | null;
+	metadata?: Record<string, unknown>;
+}
+
+export interface IRegisterPushTargetResponse {
+	id: string;
+	provider: string;
+	success: boolean;
+	push_enabled: boolean;
+}
+
+export interface IPushTargetStatus {
+	device_id: string;
+	provider?: string | null;
+	registered: boolean;
+	push_enabled: boolean;
+	platform?: PushTargetPlatform | null;
+	device_name?: string | null;
+	channel_id?: string | null;
+	failure_count?: number | null;
+	last_registered_at?: string | null;
+	last_seen_at?: string | null;
+	invalidated_at?: string | null;
+	invalidation_reason?: string | null;
+	updated_at?: string | null;
+}
+
 /** Widget info returned from the user widgets endpoint */
 export interface IUserWidgetInfo {
 	/** The app ID where the widget is defined */
@@ -124,6 +158,14 @@ export interface IUserState {
 	markNotificationRead(notificationId: string): Promise<void>;
 	deleteNotification(notificationId: string): Promise<void>;
 	markAllNotificationsRead(): Promise<number>;
+	registerPushTarget(
+		request: IRegisterPushTargetRequest,
+	): Promise<IRegisterPushTargetResponse>;
+	getPushTargetStatus(deviceId: string): Promise<IPushTargetStatus>;
+	setPushTargetEnabled(
+		deviceId: string,
+		enabled: boolean,
+	): Promise<IPushTargetStatus>;
 	getProfile(): Promise<IProfile>;
 	getProfiles(): Promise<IProfile[]>;
 	getSettingsProfile(): Promise<ISettingsProfile>;


### PR DESCRIPTION
This pull request refactors platform and device detection logic across the desktop app, centralizing it into a new `platform` utility module. It also introduces new notification settings UI and adds backend methods to support mobile push notification device registration and status. The changes improve maintainability, code reuse, and prepare the app for robust push notification support on mobile and desktop platforms.

**Platform detection refactor:**

- Moved all platform and device detection functions (e.g., `isIosTauriRuntime`, `isIOSDevice`, `isMobileDevice`, `isTauriRuntime`, etc.) into a shared `lib/platform` module, replacing repeated inline logic with shared imports throughout the codebase. This simplifies and unifies device/platform checks across components. [[1]](diffhunk://#diff-d08c42e85a6d29aeec9e70c1610c18375556a53189a6dbdc076d43c20cbc44c3R92) [[2]](diffhunk://#diff-3886dddaa6c4115e69b949b7a0a00d2ba83b8a59d44dba7b0d59a9c681b608edR23) [[3]](diffhunk://#diff-3886dddaa6c4115e69b949b7a0a00d2ba83b8a59d44dba7b0d59a9c681b608edL35-R36) [[4]](diffhunk://#diff-d2dcbe05fe92ffca74205de586138910d8a108ca2b5f3630aa6011f60c9229b5R117) [[5]](diffhunk://#diff-d2dcbe05fe92ffca74205de586138910d8a108ca2b5f3630aa6011f60c9229b5L242-R243) [[6]](diffhunk://#diff-13dd2b9e0dc6bd3616fb5fe59c96b03aee6920d5d738adc919f9439b70c643caR13-R15) [[7]](diffhunk://#diff-13dd2b9e0dc6bd3616fb5fe59c96b03aee6920d5d738adc919f9439b70c643caL99-R90) [[8]](diffhunk://#diff-13dd2b9e0dc6bd3616fb5fe59c96b03aee6920d5d738adc919f9439b70c643caL443-R434) [[9]](diffhunk://#diff-f356b77bd77e3d7e9e2008a0e77c50f0fae0391e377dc72a3e4e76af12af3b40R4) [[10]](diffhunk://#diff-f356b77bd77e3d7e9e2008a0e77c50f0fae0391e377dc72a3e4e76af12af3b40L12-L38) [[11]](diffhunk://#diff-a75bb5979c290f909d17b9101145aa8eeb76700e8c3a68d4247b52618977ac1aR52) [[12]](diffhunk://#diff-a75bb5979c290f909d17b9101145aa8eeb76700e8c3a68d4247b52618977ac1aL145-R146)

**Push notification infrastructure improvements:**

- Refactored remote push notification logic: moved `PushTargetPlatform`, `RemotePushApi`, `RemotePushPayload`, and related helpers into a new `lib/remote-push` module, and updated imports in `notification-provider.tsx` accordingly. [[1]](diffhunk://#diff-b750611573ca46df37f65a70c1a85535981fcd4e352cd1493cc2b706d12fbec8L7-R7) [[2]](diffhunk://#diff-b750611573ca46df37f65a70c1a85535981fcd4e352cd1493cc2b706d12fbec8R18-R29) [[3]](diffhunk://#diff-b750611573ca46df37f65a70c1a85535981fcd4e352cd1493cc2b706d12fbec8L31-L60) [[4]](diffhunk://#diff-b750611573ca46df37f65a70c1a85535981fcd4e352cd1493cc2b706d12fbec8L78-L222)
- Added state and event handling for user push notification preferences, so UI and backend sync when the user enables/disables push notifications. [[1]](diffhunk://#diff-b750611573ca46df37f65a70c1a85535981fcd4e352cd1493cc2b706d12fbec8R156-R157) [[2]](diffhunk://#diff-b750611573ca46df37f65a70c1a85535981fcd4e352cd1493cc2b706d12fbec8R416-R444) [[3]](diffhunk://#diff-b750611573ca46df37f65a70c1a85535981fcd4e352cd1493cc2b706d12fbec8R560)

**User settings and notifications UI:**

- Added a new "Notifications" section to the settings sidebar, with a new icon and description, to allow users to view and manage push notification status and device registration. [[1]](diffhunk://#diff-b0b34a63b1c99b2a6958a34be8ade19aa8c32ebe3df55f97f494b5cd6e5abbd6R12) [[2]](diffhunk://#diff-b0b34a63b1c99b2a6958a34be8ade19aa8c32ebe3df55f97f494b5cd6e5abbd6R47-R52)

**Backend support for push notification device registration:**

- Added new methods to the `UserState` backend class for registering a push notification target, checking push target status, and enabling/disabling push notifications for a device. These methods use the authenticated user's profile and call new backend endpoints. [[1]](diffhunk://#diff-45b3eeb4d30bde3e6db828ae1fbcbb8d46d75b5e60e3a578ed1dedc3bca8ed2bR16-R19) [[2]](diffhunk://#diff-45b3eeb4d30bde3e6db828ae1fbcbb8d46d75b5e60e3a578ed1dedc3bca8ed2bR374-R435)

These changes collectively improve platform detection, centralize notification logic, and lay the groundwork for robust push notification support and management in the app.