### PR TITLE
fix: enhance notification read handling and improve link navigation

### DIFF
--- a/packages/ui/components/pages/notifications-page.tsx
+++ b/packages/ui/components/pages/notifications-page.tsx
@@ -192,14 +192,27 @@ export function NotificationsPageScreen() {
 	);
 
 	const handleMarkAsRead = useCallback(
-		async (id: string) => {
+		async (id: string, refresh = true) => {
 			try {
 				await backend.userState.markNotificationRead(id);
-				await Promise.all([notificationsQuery.refetch(), syncOverview()]);
 			} catch (error) {
 				console.error("Failed to mark notification as read:", error);
 				toast.error("Failed to mark notification as read");
+				return false;
 			}
+
+			if (refresh) {
+				await Promise.allSettled([
+					notificationsQuery.refetch(),
+					syncOverview(),
+				]);
+			} else {
+				void syncOverview().catch((error) => {
+					console.error("Failed to refresh notification overview:", error);
+				});
+			}
+
+			return true;
 		},
 		[backend, notificationsQuery, syncOverview],
 	);
@@ -735,7 +748,7 @@ function InvitationCard({
 type NotificationCardProps = {
 	notification: INotification;
 	index: number;
-	onMarkRead: (id: string) => void;
+	onMarkRead: (id: string, refresh?: boolean) => void;
 	onDelete: (id: string) => void;
 };
 
@@ -748,20 +761,20 @@ function NotificationCard({
 	const router = useRouter();
 
 	const handleLinkClick = useCallback(() => {
-		if (!notification.link) {
+		const link = notification.link;
+		if (!link) {
 			return;
 		}
 
 		if (!notification.read) {
-			void onMarkRead(notification.id);
+			void onMarkRead(notification.id, false);
 		}
 
-		if (notification.link.startsWith("http")) {
-			window.open(notification.link, "_blank", "noopener,noreferrer");
-			return;
+		if (link.startsWith("http")) {
+			window.open(link, "_blank", "noopener,noreferrer");
+		} else {
+			router.push(link);
 		}
-
-		router.push(notification.link);
 	}, [notification, onMarkRead, router]);
 
 	const hasLink = Boolean(notification.link);


### PR DESCRIPTION
This pull request refactors the notification "mark as read" logic and improves how notification links are handled. The main focus is to make the notification refresh behavior more flexible and to clean up link handling when users interact with notifications.

**Notification handling improvements:**

* Updated the `handleMarkAsRead` function to accept an optional `refresh` parameter, allowing notifications to be marked as read without always triggering a full refresh. Now, if `refresh` is false, only the overview is synced; otherwise, both notifications and overview are refreshed. The function also returns a boolean indicating success.
* Updated the `onMarkRead` prop in `NotificationCardProps` and related components to accept the new `refresh` parameter, ensuring consistency across components.

**Notification link handling:**

* Refactored the `handleLinkClick` logic to:
  - Use the new `onMarkRead` signature with `refresh=false` when marking notifications as read from a link click.
  - Open external links in a new tab and internal links using the router, improving clarity and reliability.