### PR TITLE
Feature/612 video nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1418,6 +1418,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "audio-core"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ebbf82d06013f4c41fe71303feb980cddd78496d904d06be627972de51a24"
+
+[[package]]
+name = "audioadapter"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91f87b70b051c5866680ad79f6743a42ccab264c009d1a71f4d33a3872ae60c8"
+dependencies = [
+ "audio-core",
+ "num-traits 0.2.19",
+]
+
+[[package]]
+name = "audioadapter-buffers"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9097d67933fb083d382ce980430afdb758aada60846010aee6be068c06cef0ca"
+dependencies = [
+ "audioadapter",
+ "audioadapter-sample",
+ "num-traits 0.2.19",
+]
+
+[[package]]
+name = "audioadapter-sample"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ab94f2bc04a14e1f49ee5f222f66460e8a1b51627bdfedf34eed394d747938"
+dependencies = [
+ "audio-core",
+ "num-traits 0.2.19",
+]
+
+[[package]]
 name = "auto_enums"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4073,6 +4110,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7290,6 +7340,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "extended"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365"
+
+[[package]]
 name = "fake"
 version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8020,6 +8076,7 @@ version = "0.1.0"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
+ "bytes",
  "flow-like",
  "flow-like-catalog-build-helper",
  "flow-like-catalog-core",
@@ -8041,6 +8098,7 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid 1.23.1",
+ "video-utils-rs",
  "zip 8.5.1",
 ]
 
@@ -11556,11 +11614,24 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console 0.15.11",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+ "web-time",
+]
+
+[[package]]
+name = "indicatif"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
- "console",
+ "console 0.16.3",
  "portable-atomic",
  "unicode-width",
  "unit-prefix",
@@ -12017,13 +12088,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -14231,6 +14301,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "m3u8-rs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f03cd3335fb5f2447755d45cda9c70f76013626a9db44374973791b0926a86c3"
+dependencies = [
+ "chrono",
+ "nom 7.1.3",
+]
+
+[[package]]
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14511,6 +14591,12 @@ dependencies = [
  "rawpointer",
  "thread-tree",
 ]
+
+[[package]]
+name = "matroska-demuxer"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb23384e6bf1431427b45e7db9574146e948ef0cd975018693e6f53eb6d44199"
 
 [[package]]
 name = "maybe-owned"
@@ -14968,6 +15054,20 @@ name = "mutate_once"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13d2233c9842d08cfe13f9eac96e207ca6a2ea10b80259ebe8ad0268be27d2af"
+
+[[package]]
+name = "muxide"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd20c287ed0dab57c8ee6bb2c4dc6b6c5d9634a9625bf5099647136d10b579cc"
+dependencies = [
+ "anyhow",
+ "clap",
+ "indicatif 0.17.11",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "mysql-common-derive"
@@ -15516,6 +15616,7 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits 0.2.19",
+ "serde",
 ]
 
 [[package]]
@@ -15598,6 +15699,12 @@ checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "oasgen"
@@ -19153,6 +19260,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "re_mp4"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62fda65f84bc3fc10f07d2969f2146376d791406dddc357ac42f0bba4dbd33a2"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "num-rational",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "read-fonts"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19915,6 +20036,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rubato"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce96ead1a91f7895704a9f08ea5947dfc8bd7c1f2936a22295b655ec67e5c6ef"
+dependencies = [
+ "audioadapter",
+ "audioadapter-buffers",
+ "num-integer",
+ "num-traits 0.2.19",
+ "visibility",
+ "windowfunctions",
+]
+
+[[package]]
 name = "rumqttc"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -20026,6 +20161,18 @@ dependencies = [
  "serde_json",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "rust_h264"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbedf5e104105e8783a77926f1e212ea37e78fd3b38b2c928938a283d083d6f1"
+
+[[package]]
+name = "rust_h265"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde60f5842f27ed06f1d84844cacd93d1a159f606365b30a5594c771e6b4eb17"
 
 [[package]]
 name = "rustautogui"
@@ -22489,6 +22636,178 @@ dependencies = [
 ]
 
 [[package]]
+name = "symphonia"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5773a4c030a19d9bfaa090f49746ff35c75dfddfa700df7a5939d5e076a57039"
+dependencies = [
+ "lazy_static",
+ "symphonia-bundle-flac",
+ "symphonia-bundle-mp3",
+ "symphonia-codec-aac",
+ "symphonia-codec-adpcm",
+ "symphonia-codec-pcm",
+ "symphonia-codec-vorbis",
+ "symphonia-core",
+ "symphonia-format-isomp4",
+ "symphonia-format-mkv",
+ "symphonia-format-ogg",
+ "symphonia-format-riff",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-bundle-flac"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91565e180aea25d9b80a910c546802526ffd0072d0b8974e3ebe59b686c9976"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-bundle-mp3"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4872dd6bb56bf5eac799e3e957aa1981086c3e613b27e0ac23b176054f7c57ed"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-codec-aac"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c263845aa86881416849c1729a54c7f55164f8b96111dba59de46849e73a790"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-adpcm"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dddc50e2bbea4cfe027441eece77c46b9f319748605ab8f3443350129ddd07f"
+dependencies = [
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-pcm"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e89d716c01541ad3ebe7c91ce4c8d38a7cf266a3f7b2f090b108fb0cb031d95"
+dependencies = [
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-vorbis"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f025837c309cd69ffef572750b4a2257b59552c5399a5e49707cc5b1b85d1c73"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-core"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea00cc4f79b7f6bb7ff87eddc065a1066f3a43fe1875979056672c9ef948c2af"
+dependencies = [
+ "arrayvec",
+ "bitflags 1.3.2",
+ "bytemuck",
+ "lazy_static",
+ "log",
+]
+
+[[package]]
+name = "symphonia-format-isomp4"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "243739585d11f81daf8dac8d9f3d18cc7898f6c09a259675fc364b382c30e0a5"
+dependencies = [
+ "encoding_rs",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-mkv"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "122d786d2c43a49beb6f397551b4a050d8229eaa54c7ddf9ee4b98899b8742d0"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-ogg"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b4955c67c1ed3aa8ae8428d04ca8397fbef6a19b2b051e73b5da8b1435639cb"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-riff"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d7c3df0e7d94efb68401d81906eae73c02b40d5ec1a141962c592d0f11a96f"
+dependencies = [
+ "extended",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-metadata"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36306ff42b9ffe6e5afc99d49e121e0bd62fe79b9db7b9681d48e29fa19e6b16"
+dependencies = [
+ "encoding_rs",
+ "lazy_static",
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-utils-xiph"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27c85ab799a338446b68eec77abf42e1a6f1bb490656e121c6e27bfbab9f16"
+dependencies = [
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -23971,7 +24290,7 @@ dependencies = [
  "derive_builder",
  "esaxx-rs",
  "getrandom 0.3.4",
- "indicatif",
+ "indicatif 0.18.4",
  "itertools 0.14.0",
  "log",
  "macro_rules_attribute",
@@ -25665,6 +25984,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "video-utils-rs"
+version = "0.1.0"
+source = "git+https://github.com/Rheosoph/video-utils-rs.git?rev=4b4e380fd719390dd8598120ebfb50566d234d5c#4b4e380fd719390dd8598120ebfb50566d234d5c"
+dependencies = [
+ "ab_glyph",
+ "bytes",
+ "fast_image_resize",
+ "getrandom 0.2.17",
+ "getrandom 0.3.4",
+ "gif",
+ "h264-reader",
+ "hound",
+ "image",
+ "imageproc",
+ "js-sys",
+ "m3u8-rs",
+ "matroska-demuxer",
+ "muxide",
+ "object_store",
+ "png 0.18.1",
+ "rav1e",
+ "ravif",
+ "re_mp4",
+ "rubato",
+ "rust_h264",
+ "rust_h265",
+ "symphonia",
+ "thiserror 2.0.18",
+ "v_frame",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows 0.62.2",
+ "yuv",
+]
+
+[[package]]
+name = "visibility"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25771,9 +26138,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -25785,9 +26152,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -25795,9 +26162,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -25805,9 +26172,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -25818,9 +26185,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
 ]
@@ -26401,9 +26768,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -26735,6 +27102,15 @@ dependencies = [
  "raw-window-handle",
  "windows-sys 0.59.0",
  "windows-version",
+]
+
+[[package]]
+name = "windowfunctions"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90628d739333b7c5d2ee0b70210b97b8cddc38440c682c96fd9e2c24c2db5f3a"
+dependencies = [
+ "num-traits 0.2.19",
 ]
 
 [[package]]
@@ -27930,6 +28306,15 @@ dependencies = [
  "time",
  "tokio",
  "url",
+]
+
+[[package]]
+name = "yuv"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d85a782d94ee43f078bcfd6fa82d4e6a5b2d1cfbbad168e4df5a9f7b39ef48c"
+dependencies = [
+ "num-traits 0.2.19",
 ]
 
 [[package]]

--- a/packages/catalog/media/Cargo.toml
+++ b/packages/catalog/media/Cargo.toml
@@ -13,6 +13,7 @@ local-tts-accelerate = ["local-tts", "flow-like/local-tts-accelerate"]
 # Execution feature - enables heavy dependencies for node execution
 execute = [
     "flow-like-catalog-core/execute",
+    "dep:video-utils-rs",
     "dep:hayro",
     "dep:rayon",
     "dep:nalgebra",
@@ -34,6 +35,7 @@ ahash.workspace = true
 tracing.workspace = true
 schemars.workspace = true
 futures.workspace = true
+bytes.workspace = true
 serde = { workspace = true, features = ["derive", "rc"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
 uuid.workspace = true
@@ -50,6 +52,7 @@ zip = { version = "8.2.0", default-features = false, features = ["deflate"], opt
 quick-xml = { version = "0.39.2", features = ["serialize"], optional = true }
 lopdf = { version = "0.39.0", optional = true }
 pulldown-cmark = { version = "0.13.1", optional = true }
+video-utils-rs = { git = "https://github.com/Rheosoph/video-utils-rs.git", rev = "4b4e380fd719390dd8598120ebfb50566d234d5c", default-features = false, features = ["portable-core", "platform-codecs", "audio-io", "image-io", "preview", "codec-h264-rust", "codec-h265-rust", "codec-av1-rust", "codec-openh264-ffi", "codec-apple", "codec-android", "codec-windows", "codec-gstreamer", "codec-web"], optional = true }
 
 [build-dependencies]
 flow-like-catalog-build-helper.workspace = true

--- a/packages/catalog/media/src/video.rs
+++ b/packages/catalog/media/src/video.rs
@@ -1,3 +1,5 @@
+pub mod utils;
+
 use std::{collections::HashMap, path::Path, sync::OnceLock, time::Duration};
 
 use flow_like::{

--- a/packages/catalog/media/src/video/utils.rs
+++ b/packages/catalog/media/src/video/utils.rs
@@ -1,0 +1,1214 @@
+#[cfg(feature = "execute")]
+use bytes::Bytes;
+use flow_like::flow::{
+    execution::context::ExecutionContext,
+    node::{Node, NodeLogic, NodeScores},
+    pin::{PinOptions, ValueType},
+    variable::VariableType,
+};
+use flow_like_catalog_core::FlowPath;
+#[cfg(feature = "execute")]
+use flow_like_storage::{Path as ObjectPath, object_store::ObjectStore};
+use flow_like_types::{
+    async_trait,
+    json::{Deserialize, Serialize, json},
+};
+use schemars::JsonSchema;
+#[cfg(feature = "execute")]
+use std::{collections::BTreeSet, sync::Arc};
+#[cfg(feature = "execute")]
+use video_utils_rs::{Decoder, Encoder, VideoDecoder, VideoEncoder};
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct VideoStreamInfo {
+    pub track_id: u32,
+    pub media_type: String,
+    pub codec: String,
+    pub time_base_num: i32,
+    pub time_base_den: i32,
+    pub duration_seconds: Option<f64>,
+    pub width: Option<u32>,
+    pub height: Option<u32>,
+    pub sample_rate: Option<u32>,
+    pub channels: Option<u16>,
+    pub language: Option<String>,
+    pub codec_config_bytes: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct VideoMediaInfo {
+    pub duration_seconds: Option<f64>,
+    pub streams: Vec<VideoStreamInfo>,
+    pub tags: Vec<MediaTag>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct MediaTag {
+    pub key: String,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct RemuxStreamDecision {
+    pub track_id: u32,
+    pub media_type: String,
+    pub codec: String,
+    pub action: String,
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct RemuxCompatibilityReport {
+    pub compatible: bool,
+    pub packet_copy_only: bool,
+    pub requires_transcode: bool,
+    pub has_unsupported_streams: bool,
+    pub source_format: Option<String>,
+    pub target_format: Option<String>,
+    pub streams: Vec<RemuxStreamDecision>,
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct SubtitleCue {
+    pub index: Option<usize>,
+    pub start_ms: i64,
+    pub end_ms: i64,
+    pub text: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct CodecBackendInfo {
+    pub kind: String,
+    pub target: String,
+    pub source: String,
+    pub probe: String,
+    pub hardware_accelerated: bool,
+    pub decodes: Vec<String>,
+    pub encodes: Vec<String>,
+    pub note: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct VideoUtilsFeatureSet {
+    pub packet_ops: bool,
+    pub audio_core: bool,
+    pub audio_io: bool,
+    pub frame_core: bool,
+    pub image_io: bool,
+    pub preview: bool,
+    pub subtitles: bool,
+    pub streaming: bool,
+    pub platform_codecs: bool,
+    pub codec_apple: bool,
+    pub codec_android: bool,
+    pub codec_windows: bool,
+    pub codec_gstreamer: bool,
+    pub codec_web: bool,
+    pub codec_h264_rust: bool,
+    pub codec_h265_rust: bool,
+    pub codec_av1_rust: bool,
+    pub codec_openh264_ffi: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct CodecSupportInfo {
+    pub codec: String,
+    pub media_type: Option<String>,
+    pub implementation: String,
+    pub can_decode: bool,
+    pub can_encode: bool,
+    pub note: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct PlatformCodecProbeInfo {
+    pub codec: String,
+    pub direction: String,
+    pub supported: bool,
+    pub backend: Option<String>,
+    pub detail: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct BackendSelectionInfo {
+    pub codec: String,
+    pub direction: String,
+    pub backend: Option<String>,
+    pub found: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct VideoTransformReport {
+    pub source: String,
+    pub target: String,
+    pub source_format: String,
+    pub target_format: String,
+    pub video_track_id: u32,
+    pub input_packets: usize,
+    pub decoded_frames: usize,
+    pub encoded_video_packets: usize,
+    pub copied_packets: usize,
+    pub bytes_written: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct VideoTranscodeReport {
+    pub source: String,
+    pub target: String,
+    pub source_format: String,
+    pub target_format: String,
+    pub operation: String,
+    pub video_track_id: Option<u32>,
+    pub input_packets: usize,
+    pub output_packets: usize,
+    pub decoded_video_frames: usize,
+    pub encoded_video_packets: usize,
+    pub copied_packets: usize,
+    pub dropped_packets: usize,
+    pub bytes_written: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct SubtitleBurnInReport {
+    pub source: String,
+    pub sidecar: String,
+    pub target: String,
+    pub source_format: String,
+    pub target_format: String,
+    pub video_track_id: u32,
+    pub event_count: usize,
+    pub decoded_frames: usize,
+    pub encoded_video_packets: usize,
+    pub copied_packets: usize,
+    pub bytes_written: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct AudioTransformReport {
+    pub source: String,
+    pub target: String,
+    pub source_format: String,
+    pub target_format: String,
+    pub audio_track_id: u32,
+    pub input_packets: usize,
+    pub decoded_frames: usize,
+    pub encoded_audio_packets: usize,
+    pub bytes_written: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ImageOperationReport {
+    pub source: String,
+    pub target: String,
+    pub input_width: u32,
+    pub input_height: u32,
+    pub output_width: u32,
+    pub output_height: u32,
+    pub output_format: String,
+    pub bytes_written: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct WaveformBucketInfo {
+    pub start_sample: usize,
+    pub end_sample: usize,
+    pub start_seconds: f64,
+    pub end_seconds: f64,
+    pub min: f32,
+    pub max: f32,
+    pub rms: f32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct SilenceRangeInfo {
+    pub start_sample: usize,
+    pub end_sample: usize,
+    pub start_seconds: f64,
+    pub end_seconds: f64,
+    pub duration_seconds: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct AudioAnalysisReport {
+    pub duration_seconds: f64,
+    pub sample_rate: u32,
+    pub channels: u16,
+    pub decoded_frames: usize,
+    pub sample_frames: usize,
+    pub peak_amplitude: f32,
+    pub rms: f32,
+    pub waveform_buckets: usize,
+    pub silence_ranges: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct BitstreamConvertReport {
+    pub source: String,
+    pub target: String,
+    pub codec: String,
+    pub conversion: String,
+    pub track_id: u32,
+    pub packets: usize,
+    pub bytes_written: u64,
+}
+
+fn add_exec_pins(node: &mut Node) {
+    node.add_input_pin("exec_in", "Input", "Trigger", VariableType::Execution);
+    node.add_output_pin("exec_out", "Done", "Continues", VariableType::Execution);
+}
+
+fn add_flow_path_input(node: &mut Node, id: &str, name: &str, description: &str) {
+    node.add_input_pin(id, name, description, VariableType::Struct)
+        .set_schema::<FlowPath>()
+        .set_options(PinOptions::new().set_enforce_schema(true).build());
+}
+
+fn add_flow_path_output(node: &mut Node, id: &str, name: &str, description: &str) {
+    node.add_output_pin(id, name, description, VariableType::Struct)
+        .set_schema::<FlowPath>();
+}
+
+fn add_video_icon_and_scores(node: &mut Node) {
+    node.add_icon("/flow/icons/video.svg");
+    node.set_scores(
+        NodeScores::new()
+            .set_privacy(8)
+            .set_security(7)
+            .set_performance(7)
+            .set_governance(8)
+            .set_reliability(7)
+            .set_cost(10)
+            .build(),
+    );
+}
+
+#[cfg(not(feature = "execute"))]
+fn execute_feature_error() -> flow_like_types::Error {
+    flow_like_types::anyhow!("Requires the 'execute' feature")
+}
+
+#[cfg(feature = "execute")]
+async fn flow_path_object(
+    context: &mut ExecutionContext,
+    flow_path: &FlowPath,
+) -> flow_like_types::Result<(Arc<dyn ObjectStore>, ObjectPath)> {
+    let runtime = flow_path.to_runtime(context).await?;
+    Ok((runtime.store.as_generic(), runtime.path))
+}
+
+#[cfg(feature = "execute")]
+fn flow_path_from_object_path(path: &ObjectPath, template: &FlowPath) -> FlowPath {
+    FlowPath::new(
+        path.to_string(),
+        template.store_ref.clone(),
+        template.cache_store_ref.clone(),
+    )
+}
+
+#[cfg(feature = "execute")]
+fn optional_track_id(value: i64) -> flow_like_types::Result<Option<u32>> {
+    if value <= 0 {
+        return Ok(None);
+    }
+    Ok(Some(u32::try_from(value)?))
+}
+
+#[cfg(feature = "execute")]
+fn subtitle_format(value: &str) -> flow_like_types::Result<video_utils_rs::SubtitleFormat> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "srt" => Ok(video_utils_rs::SubtitleFormat::Srt),
+        "webvtt" | "vtt" => Ok(video_utils_rs::SubtitleFormat::WebVtt),
+        other => Err(flow_like_types::anyhow!(
+            "Unsupported subtitle format: {}",
+            other
+        )),
+    }
+}
+
+#[cfg(feature = "execute")]
+fn subtitle_text(
+    format: video_utils_rs::SubtitleFormat,
+    events: &[video_utils_rs::SubtitleEvent],
+) -> String {
+    match format {
+        video_utils_rs::SubtitleFormat::Srt => video_utils_rs::write_srt(events),
+        video_utils_rs::SubtitleFormat::WebVtt => video_utils_rs::write_webvtt(events),
+    }
+}
+
+#[cfg(feature = "execute")]
+fn clean_optional(value: String) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_owned())
+    }
+}
+
+#[cfg(feature = "execute")]
+fn media_type_name(media_type: video_utils_rs::MediaType) -> String {
+    format!("{media_type:?}").to_ascii_lowercase()
+}
+
+#[cfg(feature = "execute")]
+fn stream_to_info(stream: &video_utils_rs::StreamInfo) -> VideoStreamInfo {
+    VideoStreamInfo {
+        track_id: stream.track_id,
+        media_type: media_type_name(stream.media_type),
+        codec: stream.codec.to_string(),
+        time_base_num: stream.time_base.num,
+        time_base_den: stream.time_base.den,
+        duration_seconds: stream.duration_seconds(),
+        width: stream.width,
+        height: stream.height,
+        sample_rate: stream.sample_rate,
+        channels: stream.channels,
+        language: stream.language.clone(),
+        codec_config_bytes: stream.codec_config.as_ref().map(|config| config.len()),
+    }
+}
+
+#[cfg(feature = "execute")]
+fn media_to_info(media: &video_utils_rs::MediaInfo) -> VideoMediaInfo {
+    VideoMediaInfo {
+        duration_seconds: media.duration_seconds,
+        streams: media.streams.iter().map(stream_to_info).collect(),
+        tags: media
+            .tags
+            .iter()
+            .map(|(key, value)| MediaTag {
+                key: key.clone(),
+                value: value.clone(),
+            })
+            .collect(),
+    }
+}
+
+#[cfg(feature = "execute")]
+fn remux_plan_report(plan: &video_utils_rs::RemuxPlan) -> RemuxCompatibilityReport {
+    let streams = plan
+        .streams
+        .iter()
+        .map(|stream| {
+            let (action, reason) = match &stream.action {
+                video_utils_rs::RemuxAction::PacketCopy => ("packet_copy", None),
+                video_utils_rs::RemuxAction::TranscodeRequired { reason } => {
+                    ("transcode_required", Some(reason.clone()))
+                }
+                video_utils_rs::RemuxAction::Unsupported { reason } => {
+                    ("unsupported", Some(reason.clone()))
+                }
+            };
+            RemuxStreamDecision {
+                track_id: stream.track_id,
+                media_type: media_type_name(stream.media_type),
+                codec: stream.codec.to_string(),
+                action: action.to_owned(),
+                reason,
+            }
+        })
+        .collect();
+
+    RemuxCompatibilityReport {
+        compatible: plan.is_packet_copy_only(),
+        packet_copy_only: plan.is_packet_copy_only(),
+        requires_transcode: plan.requires_transcode(),
+        has_unsupported_streams: plan.has_unsupported_streams(),
+        source_format: Some(plan.source.as_str().to_owned()),
+        target_format: Some(plan.target.as_str().to_owned()),
+        streams,
+        reason: None,
+    }
+}
+
+#[cfg(feature = "execute")]
+fn media_for_packet_subset(
+    source: &video_utils_rs::MediaInfo,
+    packets: &[video_utils_rs::EncodedPacket],
+) -> video_utils_rs::MediaInfo {
+    let track_ids = packets
+        .iter()
+        .map(|packet| packet.track_id)
+        .collect::<BTreeSet<_>>();
+    let mut media = video_utils_rs::MediaInfo {
+        duration_seconds: packets
+            .iter()
+            .map(|packet| packet.time_base.ticks_to_seconds(packet.end_pts()))
+            .max_by(f64::total_cmp),
+        tags: source.tags.clone(),
+        ..Default::default()
+    };
+    for stream in &source.streams {
+        if track_ids.contains(&stream.track_id) {
+            media.push_stream(stream.clone());
+        }
+    }
+    media
+}
+
+#[cfg(feature = "execute")]
+fn select_video_track_id(
+    media: &video_utils_rs::MediaInfo,
+    requested: Option<u32>,
+) -> flow_like_types::Result<u32> {
+    if let Some(track_id) = requested {
+        let stream = media
+            .stream(track_id)
+            .ok_or_else(|| flow_like_types::anyhow!("Requested track {} is missing", track_id))?;
+        if stream.media_type != video_utils_rs::MediaType::Video {
+            return Err(flow_like_types::anyhow!(
+                "Requested track {} is not a video track",
+                track_id
+            ));
+        }
+        return Ok(track_id);
+    }
+
+    media
+        .video_streams()
+        .next()
+        .map(|stream| stream.track_id)
+        .ok_or_else(|| flow_like_types::anyhow!("Source media has no video track"))
+}
+
+#[cfg(feature = "execute")]
+fn cues_from_events(events: &[video_utils_rs::SubtitleEvent]) -> Vec<SubtitleCue> {
+    events
+        .iter()
+        .map(|event| SubtitleCue {
+            index: event.index,
+            start_ms: event.start_ms,
+            end_ms: event.end_ms,
+            text: event.text.clone(),
+        })
+        .collect()
+}
+
+#[cfg(feature = "execute")]
+fn events_from_cues(
+    cues: Vec<SubtitleCue>,
+) -> flow_like_types::Result<Vec<video_utils_rs::SubtitleEvent>> {
+    cues.into_iter()
+        .map(|cue| {
+            let mut event = video_utils_rs::SubtitleEvent::new(cue.start_ms, cue.end_ms, cue.text)?;
+            event.index = cue.index;
+            Ok(event)
+        })
+        .collect()
+}
+
+#[cfg(feature = "execute")]
+fn backend_info() -> Vec<CodecBackendInfo> {
+    video_utils_rs::recommended_backends_for_current_target()
+        .into_iter()
+        .map(|backend| CodecBackendInfo {
+            kind: format!("{:?}", backend.kind),
+            target: format!("{:?}", backend.target),
+            source: format!("{:?}", backend.source),
+            probe: format!("{:?}", backend.probe),
+            hardware_accelerated: backend.hardware_accelerated,
+            decodes: backend.decodes.iter().map(ToString::to_string).collect(),
+            encodes: backend.encodes.iter().map(ToString::to_string).collect(),
+            note: backend.note.to_owned(),
+        })
+        .collect()
+}
+
+#[cfg(feature = "execute")]
+fn feature_set() -> VideoUtilsFeatureSet {
+    let features = video_utils_rs::compiled_features();
+    VideoUtilsFeatureSet {
+        packet_ops: features.packet_ops,
+        audio_core: features.audio_core,
+        audio_io: features.audio_io,
+        frame_core: features.frame_core,
+        image_io: features.image_io,
+        preview: features.preview,
+        subtitles: features.subtitles,
+        streaming: features.streaming,
+        platform_codecs: features.platform_codecs,
+        codec_apple: features.codec_apple,
+        codec_android: features.codec_android,
+        codec_windows: features.codec_windows,
+        codec_gstreamer: features.codec_gstreamer,
+        codec_web: features.codec_web,
+        codec_h264_rust: features.codec_h264_rust,
+        codec_h265_rust: features.codec_h265_rust,
+        codec_av1_rust: features.codec_av1_rust,
+        codec_openh264_ffi: features.codec_openh264_ffi,
+    }
+}
+
+#[cfg(feature = "execute")]
+fn codec_id(value: &str) -> video_utils_rs::CodecId {
+    match value.trim().to_ascii_lowercase().replace('_', "-").as_str() {
+        "h264" | "avc" | "avc1" => video_utils_rs::CodecId::H264,
+        "h265" | "hevc" | "hvc1" | "hev1" => video_utils_rs::CodecId::H265,
+        "av1" | "av01" => video_utils_rs::CodecId::AV1,
+        "vp8" => video_utils_rs::CodecId::VP8,
+        "vp9" => video_utils_rs::CodecId::VP9,
+        "mpeg1" | "mpeg1video" | "mpeg-1-video" => video_utils_rs::CodecId::Mpeg1Video,
+        "mpeg2" | "mpeg2video" | "mpeg-2-video" => video_utils_rs::CodecId::Mpeg2Video,
+        "mpeg4" | "mpeg4-part2" | "mpeg-4-part-2" => video_utils_rs::CodecId::Mpeg4Part2,
+        "prores" => video_utils_rs::CodecId::ProRes,
+        "theora" => video_utils_rs::CodecId::Theora,
+        "dirac" => video_utils_rs::CodecId::Dirac,
+        "rawvideo" | "raw-video" => video_utils_rs::CodecId::RawVideo,
+        "aac" => video_utils_rs::CodecId::Aac,
+        "ac3" => video_utils_rs::CodecId::Ac3,
+        "eac3" => video_utils_rs::CodecId::Eac3,
+        "adpcm" => video_utils_rs::CodecId::Adpcm,
+        "alac" => video_utils_rs::CodecId::Alac,
+        "opus" => video_utils_rs::CodecId::Opus,
+        "flac" => video_utils_rs::CodecId::Flac,
+        "mp1" => video_utils_rs::CodecId::Mp1,
+        "mp2" => video_utils_rs::CodecId::Mp2,
+        "mp3" => video_utils_rs::CodecId::Mp3,
+        "pcm" => video_utils_rs::CodecId::Pcm,
+        "vorbis" => video_utils_rs::CodecId::Vorbis,
+        "speex" => video_utils_rs::CodecId::Speex,
+        "dts" => video_utils_rs::CodecId::Dts,
+        "wma" => video_utils_rs::CodecId::Wma,
+        "wavpack" => video_utils_rs::CodecId::WavPack,
+        "png" => video_utils_rs::CodecId::Png,
+        "jpg" | "jpeg" => video_utils_rs::CodecId::Jpeg,
+        "gif" => video_utils_rs::CodecId::Gif,
+        "webp" => video_utils_rs::CodecId::WebP,
+        "avif" => video_utils_rs::CodecId::Avif,
+        "srt" => video_utils_rs::CodecId::Srt,
+        "webvtt" | "vtt" => video_utils_rs::CodecId::WebVtt,
+        other => video_utils_rs::CodecId::Unknown(other.to_owned()),
+    }
+}
+
+#[cfg(feature = "execute")]
+fn codec_direction(value: &str) -> flow_like_types::Result<video_utils_rs::CodecDirection> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "decode" | "decoder" | "read" => Ok(video_utils_rs::CodecDirection::Decode),
+        "encode" | "encoder" | "write" => Ok(video_utils_rs::CodecDirection::Encode),
+        other => Err(flow_like_types::anyhow!(
+            "Unsupported codec direction: {}",
+            other
+        )),
+    }
+}
+
+#[cfg(feature = "execute")]
+fn platform_probe_info(probe: video_utils_rs::PlatformCodecProbe) -> PlatformCodecProbeInfo {
+    PlatformCodecProbeInfo {
+        codec: probe.codec.to_string(),
+        direction: format!("{:?}", probe.direction).to_ascii_lowercase(),
+        supported: probe.supported,
+        backend: probe.backend.map(|backend| format!("{backend:?}")),
+        detail: probe.detail,
+    }
+}
+
+#[cfg(feature = "execute")]
+fn codec_support_info() -> Vec<CodecSupportInfo> {
+    video_utils_rs::CodecRegistry::builtin()
+        .support()
+        .iter()
+        .map(|support| CodecSupportInfo {
+            codec: support.codec.to_string(),
+            media_type: support
+                .media_type
+                .map(|media_type| media_type_name(media_type)),
+            implementation: format!("{:?}", support.kind),
+            can_decode: support.can_decode,
+            can_encode: support.can_encode,
+            note: support.note.to_owned(),
+        })
+        .collect()
+}
+
+#[cfg(feature = "execute")]
+fn image_format(value: &str) -> flow_like_types::Result<video_utils_rs::ImageStillFormat> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "png" => Ok(video_utils_rs::ImageStillFormat::Png),
+        "jpg" | "jpeg" => Ok(video_utils_rs::ImageStillFormat::Jpeg),
+        "gif" => Ok(video_utils_rs::ImageStillFormat::Gif),
+        "webp" => Ok(video_utils_rs::ImageStillFormat::WebP),
+        "avif" => Ok(video_utils_rs::ImageStillFormat::Avif),
+        other => Err(flow_like_types::anyhow!(
+            "Unsupported image format: {}",
+            other
+        )),
+    }
+}
+
+#[cfg(feature = "execute")]
+fn image_format_for_target(
+    requested: &str,
+    target: &ObjectPath,
+) -> flow_like_types::Result<video_utils_rs::ImageStillFormat> {
+    let requested = requested.trim();
+    if !requested.is_empty() && !requested.eq_ignore_ascii_case("auto") {
+        return image_format(requested);
+    }
+    let extension = target.extension().ok_or_else(|| {
+        flow_like_types::anyhow!("Target path needs an image extension when format is auto")
+    })?;
+    image_format(extension)
+}
+
+#[cfg(feature = "execute")]
+fn image_encoder(format: video_utils_rs::ImageStillFormat) -> video_utils_rs::ImageRgbaEncoder {
+    video_utils_rs::ImageRgbaEncoder::with_format(format)
+}
+
+#[cfg(feature = "execute")]
+fn image_format_name(format: video_utils_rs::ImageStillFormat) -> &'static str {
+    match format {
+        video_utils_rs::ImageStillFormat::Png => "png",
+        video_utils_rs::ImageStillFormat::Jpeg => "jpeg",
+        video_utils_rs::ImageStillFormat::Gif => "gif",
+        video_utils_rs::ImageStillFormat::WebP => "webp",
+        video_utils_rs::ImageStillFormat::Avif => "avif",
+    }
+}
+
+#[cfg(feature = "execute")]
+fn fade_shape(value: &str) -> flow_like_types::Result<video_utils_rs::FadeShape> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "linear" => Ok(video_utils_rs::FadeShape::Linear),
+        "equal_power" | "equal-power" | "power" => Ok(video_utils_rs::FadeShape::EqualPower),
+        other => Err(flow_like_types::anyhow!(
+            "Unsupported fade shape: {}",
+            other
+        )),
+    }
+}
+
+#[cfg(feature = "execute")]
+fn audio_pipeline(
+    gain_factor: f64,
+    gain_db: f64,
+    normalize_peak: f64,
+    fade_in_seconds: f64,
+    fade_out_seconds: f64,
+    fade_shape_name: &str,
+    sample_rate: Option<u32>,
+) -> flow_like_types::Result<video_utils_rs::AudioTransformPipeline> {
+    let mut pipeline = video_utils_rs::AudioTransformPipeline::new();
+    if (gain_factor - 1.0).abs() > f64::EPSILON {
+        pipeline.push(video_utils_rs::AudioTransform::Gain {
+            factor: gain_factor as f32,
+        });
+    }
+    if gain_db.abs() > f64::EPSILON {
+        pipeline.push(video_utils_rs::AudioTransform::GainDb { db: gain_db as f32 });
+    }
+    if normalize_peak > 0.0 {
+        pipeline.push(video_utils_rs::AudioTransform::NormalizePeak {
+            target_peak: normalize_peak as f32,
+        });
+    }
+    if fade_in_seconds > 0.0 || fade_out_seconds > 0.0 {
+        let sample_rate = sample_rate.unwrap_or(48_000);
+        pipeline.push(video_utils_rs::AudioTransform::Fade {
+            fade_in_samples: (fade_in_seconds * sample_rate as f64).round() as usize,
+            fade_out_samples: (fade_out_seconds * sample_rate as f64).round() as usize,
+            shape: fade_shape(fade_shape_name)?,
+        });
+    }
+    Ok(pipeline)
+}
+
+#[cfg(feature = "execute")]
+fn audio_transform_report(
+    report: video_utils_rs::ObjectAudioTransformReport,
+) -> AudioTransformReport {
+    AudioTransformReport {
+        source: report.source.to_string(),
+        target: report.target.to_string(),
+        source_format: report.source_format.as_str().to_owned(),
+        target_format: report.target_format.as_str().to_owned(),
+        audio_track_id: report.audio_track_id,
+        input_packets: report.input_packets,
+        decoded_frames: report.decoded_frames,
+        encoded_audio_packets: report.encoded_audio_packets,
+        bytes_written: report.bytes_written,
+    }
+}
+
+#[cfg(feature = "execute")]
+fn concat_audio_frames(
+    frames: &[video_utils_rs::AudioFrame],
+) -> flow_like_types::Result<video_utils_rs::AudioFrame> {
+    let first = frames
+        .first()
+        .ok_or_else(|| flow_like_types::anyhow!("Audio decoder returned no frames"))?;
+    let sample_rate = first.sample_rate;
+    let channels = first.channels;
+    let mut samples = Vec::new();
+    for frame in frames {
+        if frame.sample_rate != sample_rate || frame.channels != channels {
+            return Err(flow_like_types::anyhow!(
+                "Decoded audio changes format mid-stream"
+            ));
+        }
+        samples.extend_from_slice(&frame.samples_f32_interleaved);
+    }
+    Ok(video_utils_rs::AudioFrame::new(
+        sample_rate,
+        channels,
+        0,
+        samples,
+    )?)
+}
+
+#[cfg(feature = "execute")]
+fn waveform_bucket_info(
+    bucket: video_utils_rs::WaveformBucket,
+    sample_rate: u32,
+) -> WaveformBucketInfo {
+    WaveformBucketInfo {
+        start_sample: bucket.start_sample,
+        end_sample: bucket.end_sample,
+        start_seconds: bucket.start_sample as f64 / sample_rate as f64,
+        end_seconds: bucket.end_sample as f64 / sample_rate as f64,
+        min: bucket.min,
+        max: bucket.max,
+        rms: bucket.rms,
+    }
+}
+
+#[cfg(feature = "execute")]
+fn silence_range_info(range: video_utils_rs::SilenceRange, sample_rate: u32) -> SilenceRangeInfo {
+    let start_seconds = range.start_sample as f64 / sample_rate as f64;
+    let end_seconds = range.end_sample as f64 / sample_rate as f64;
+    SilenceRangeInfo {
+        start_sample: range.start_sample,
+        end_sample: range.end_sample,
+        start_seconds,
+        end_seconds,
+        duration_seconds: end_seconds - start_seconds,
+    }
+}
+
+#[cfg(feature = "execute")]
+async fn decode_audio_file(
+    store: &dyn ObjectStore,
+    path: &ObjectPath,
+) -> flow_like_types::Result<Vec<video_utils_rs::AudioFrame>> {
+    let bytes = video_utils_rs::read_object_bytes(store, path).await?;
+    let mut decoder = path
+        .extension()
+        .map(video_utils_rs::SymphoniaAudioDecoder::with_extension)
+        .unwrap_or_default();
+    Ok(decoder.decode(&bytes)?)
+}
+
+#[cfg(feature = "execute")]
+fn video_frame_pipeline(
+    crop_x: i64,
+    crop_y: i64,
+    crop_width: i64,
+    crop_height: i64,
+    resize_width: i64,
+    resize_height: i64,
+    flip_horizontal: bool,
+    flip_vertical: bool,
+    rotate_degrees: i64,
+    blur_radius: i64,
+    brightness: f64,
+    contrast: f64,
+    saturation: f64,
+) -> flow_like_types::Result<video_utils_rs::FrameTransformPipeline> {
+    let mut pipeline = video_utils_rs::FrameTransformPipeline::new();
+    if crop_width > 0 && crop_height > 0 {
+        pipeline.push(video_utils_rs::FrameTransform::Crop(
+            video_utils_rs::CropRect::new(
+                u32::try_from(crop_x.max(0))?,
+                u32::try_from(crop_y.max(0))?,
+                u32::try_from(crop_width)?,
+                u32::try_from(crop_height)?,
+            ),
+        ));
+    }
+    if resize_width > 0 && resize_height > 0 {
+        pipeline.push(video_utils_rs::FrameTransform::Resize {
+            width: u32::try_from(resize_width)?,
+            height: u32::try_from(resize_height)?,
+        });
+    }
+    if flip_horizontal {
+        pipeline.push(video_utils_rs::FrameTransform::FlipHorizontal);
+    }
+    if flip_vertical {
+        pipeline.push(video_utils_rs::FrameTransform::FlipVertical);
+    }
+    let normalized_rotation = rotate_degrees.rem_euclid(360);
+    match normalized_rotation {
+        0 => {}
+        90 => pipeline.push(video_utils_rs::FrameTransform::Rotate90 { clockwise: true }),
+        270 => pipeline.push(video_utils_rs::FrameTransform::Rotate90 { clockwise: false }),
+        180 => {
+            pipeline.push(video_utils_rs::FrameTransform::Rotate90 { clockwise: true });
+            pipeline.push(video_utils_rs::FrameTransform::Rotate90 { clockwise: true });
+        }
+        _ => {
+            return Err(flow_like_types::anyhow!(
+                "rotate_degrees must be one of 0, 90, 180, or 270"
+            ));
+        }
+    }
+    if blur_radius > 0 {
+        pipeline.push(video_utils_rs::FrameTransform::BoxBlur {
+            radius: u32::try_from(blur_radius)?,
+        });
+    }
+    if brightness.abs() > f64::EPSILON
+        || (contrast - 1.0).abs() > f64::EPSILON
+        || (saturation - 1.0).abs() > f64::EPSILON
+    {
+        pipeline.push(video_utils_rs::FrameTransform::ColorFilter(
+            video_utils_rs::ColorFilter {
+                brightness: brightness as f32,
+                contrast: contrast as f32,
+                saturation: saturation as f32,
+                alpha: 1.0,
+            },
+        ));
+    }
+    Ok(pipeline)
+}
+
+#[cfg(feature = "execute")]
+fn selected_video_stream(
+    media: &video_utils_rs::MediaInfo,
+    track_id: Option<u32>,
+) -> flow_like_types::Result<&video_utils_rs::StreamInfo> {
+    let selected = select_video_track_id(media, track_id)?;
+    media
+        .stream(selected)
+        .ok_or_else(|| flow_like_types::anyhow!("Selected video track {} is missing", selected))
+}
+
+#[cfg(feature = "execute")]
+fn packet_frame_duration(packets: &[video_utils_rs::EncodedPacket], track_id: u32) -> i64 {
+    packets
+        .iter()
+        .find(|packet| packet.track_id == track_id && packet.duration > 0)
+        .map(|packet| packet.duration)
+        .or_else(|| {
+            let mut pts = packets
+                .iter()
+                .filter(|packet| packet.track_id == track_id)
+                .map(|packet| packet.pts)
+                .collect::<Vec<_>>();
+            pts.sort_unstable();
+            pts.windows(2)
+                .find_map(|window| (window[1] > window[0]).then_some(window[1] - window[0]))
+        })
+        .unwrap_or(1)
+}
+
+#[cfg(feature = "execute")]
+fn platform_video_decoder(
+    stream: &video_utils_rs::StreamInfo,
+) -> flow_like_types::Result<video_utils_rs::PlatformVideoDecoder> {
+    let width = stream
+        .width
+        .ok_or_else(|| flow_like_types::anyhow!("Source video stream has no width"))?;
+    let height = stream
+        .height
+        .ok_or_else(|| flow_like_types::anyhow!("Source video stream has no height"))?;
+    let mut config =
+        video_utils_rs::PlatformVideoDecoderConfig::new(stream.codec.clone(), width, height);
+    if let Some(codec_config) = &stream.codec_config {
+        config = config.with_extra_data(codec_config.to_vec());
+    }
+    Ok(video_utils_rs::PlatformVideoDecoder::new(config)?)
+}
+
+#[cfg(feature = "execute")]
+fn platform_video_encoder(
+    codec: video_utils_rs::CodecId,
+    width: u32,
+    height: u32,
+    time_base: video_utils_rs::TimeBase,
+    frame_duration: i64,
+    bitrate: i64,
+) -> flow_like_types::Result<video_utils_rs::PlatformVideoEncoder> {
+    let mut config = video_utils_rs::PlatformVideoEncoderConfig::new(
+        codec,
+        width,
+        height,
+        time_base,
+        frame_duration,
+    );
+    if bitrate > 0 {
+        config = config.with_bitrate(u32::try_from(bitrate)?);
+    }
+    Ok(video_utils_rs::PlatformVideoEncoder::new(config)?)
+}
+
+#[cfg(feature = "execute")]
+struct VideoProcessResult {
+    media: video_utils_rs::MediaInfo,
+    packets: Vec<video_utils_rs::EncodedPacket>,
+    video_track_id: u32,
+    input_packets: usize,
+    decoded_frames: usize,
+    encoded_video_packets: usize,
+    copied_packets: usize,
+    dropped_packets: usize,
+}
+
+#[cfg(feature = "execute")]
+fn process_video_transform(
+    demuxed: &video_utils_rs::DemuxedMedia,
+    video_track_id: u32,
+    preserve_non_video: bool,
+    pipeline: &video_utils_rs::FrameTransformPipeline,
+    decoder: &mut dyn VideoDecoder,
+    encoder: &mut dyn VideoEncoder,
+    output_codec_config: Option<Bytes>,
+) -> flow_like_types::Result<VideoProcessResult> {
+    let output_codec = encoder.codec_id();
+    let mut output_media = demuxed.media.clone();
+    let mut output_packets = Vec::<video_utils_rs::EncodedPacket>::new();
+    let mut decoded_frames = 0usize;
+    let mut encoded_video_packets = 0usize;
+    let mut copied_packets = 0usize;
+    let mut dropped_packets = 0usize;
+    let mut output_dimensions = None::<(u32, u32)>;
+    let mut output_time_base = None;
+
+    for packet in &demuxed.packets {
+        if packet.track_id != video_track_id {
+            if preserve_non_video {
+                output_packets.push(packet.clone());
+                copied_packets += 1;
+            } else {
+                dropped_packets += 1;
+            }
+            continue;
+        }
+
+        for frame in decoder.decode_packet(packet)? {
+            decoded_frames += 1;
+            let transformed = pipeline.apply(&frame)?;
+            output_dimensions = Some((transformed.width, transformed.height));
+            let encoded = encoder.encode_frame(&transformed, packet.pts)?;
+            if let Some(packet) = encoded.first() {
+                output_time_base = Some(packet.time_base);
+            }
+            encoded_video_packets += encoded.len();
+            output_packets.extend(encoded);
+        }
+    }
+
+    for frame in decoder.flush()? {
+        decoded_frames += 1;
+        let transformed = pipeline.apply(&frame)?;
+        output_dimensions = Some((transformed.width, transformed.height));
+        let encoded = encoder.encode_frame(&transformed, 0)?;
+        if let Some(packet) = encoded.first() {
+            output_time_base = Some(packet.time_base);
+        }
+        encoded_video_packets += encoded.len();
+        output_packets.extend(encoded);
+    }
+    let finished = encoder.finish()?;
+    if let Some(packet) = finished.first() {
+        output_time_base = Some(packet.time_base);
+    }
+    encoded_video_packets += finished.len();
+    output_packets.extend(finished);
+
+    update_video_stream(
+        &mut output_media,
+        video_track_id,
+        output_codec,
+        output_dimensions,
+        output_time_base,
+        output_codec_config,
+        preserve_non_video,
+    )?;
+    sort_packets(&mut output_packets);
+
+    Ok(VideoProcessResult {
+        media: output_media,
+        packets: output_packets,
+        video_track_id,
+        input_packets: demuxed.packets.len(),
+        decoded_frames,
+        encoded_video_packets,
+        copied_packets,
+        dropped_packets,
+    })
+}
+
+#[cfg(feature = "execute")]
+fn process_subtitle_burn(
+    demuxed: &video_utils_rs::DemuxedMedia,
+    video_track_id: u32,
+    preserve_non_video: bool,
+    events: &[video_utils_rs::SubtitleEvent],
+    style: &video_utils_rs::SubtitleStyle,
+    decoder: &mut dyn VideoDecoder,
+    encoder: &mut dyn VideoEncoder,
+    output_codec_config: Option<Bytes>,
+) -> flow_like_types::Result<VideoProcessResult> {
+    let output_codec = encoder.codec_id();
+    let mut output_media = demuxed.media.clone();
+    let mut output_packets = Vec::<video_utils_rs::EncodedPacket>::new();
+    let mut decoded_frames = 0usize;
+    let mut encoded_video_packets = 0usize;
+    let mut copied_packets = 0usize;
+    let mut dropped_packets = 0usize;
+    let mut output_dimensions = None::<(u32, u32)>;
+    let mut output_time_base = None;
+
+    for packet in &demuxed.packets {
+        if packet.track_id != video_track_id {
+            if preserve_non_video {
+                output_packets.push(packet.clone());
+                copied_packets += 1;
+            } else {
+                dropped_packets += 1;
+            }
+            continue;
+        }
+
+        for mut frame in decoder.decode_packet(packet)? {
+            decoded_frames += 1;
+            let time_ms = packet
+                .time_base
+                .rescale(packet.pts, video_utils_rs::TimeBase::milliseconds());
+            video_utils_rs::burn_subtitles_onto_frame(&mut frame, events, time_ms, style)?;
+            output_dimensions = Some((frame.width, frame.height));
+            let encoded = encoder.encode_frame(&frame, packet.pts)?;
+            if let Some(packet) = encoded.first() {
+                output_time_base = Some(packet.time_base);
+            }
+            encoded_video_packets += encoded.len();
+            output_packets.extend(encoded);
+        }
+    }
+
+    for mut frame in decoder.flush()? {
+        decoded_frames += 1;
+        video_utils_rs::burn_subtitles_onto_frame(&mut frame, events, 0, style)?;
+        output_dimensions = Some((frame.width, frame.height));
+        let encoded = encoder.encode_frame(&frame, 0)?;
+        if let Some(packet) = encoded.first() {
+            output_time_base = Some(packet.time_base);
+        }
+        encoded_video_packets += encoded.len();
+        output_packets.extend(encoded);
+    }
+    let finished = encoder.finish()?;
+    if let Some(packet) = finished.first() {
+        output_time_base = Some(packet.time_base);
+    }
+    encoded_video_packets += finished.len();
+    output_packets.extend(finished);
+
+    update_video_stream(
+        &mut output_media,
+        video_track_id,
+        output_codec,
+        output_dimensions,
+        output_time_base,
+        output_codec_config,
+        preserve_non_video,
+    )?;
+    sort_packets(&mut output_packets);
+
+    Ok(VideoProcessResult {
+        media: output_media,
+        packets: output_packets,
+        video_track_id,
+        input_packets: demuxed.packets.len(),
+        decoded_frames,
+        encoded_video_packets,
+        copied_packets,
+        dropped_packets,
+    })
+}
+
+#[cfg(feature = "execute")]
+fn update_video_stream(
+    media: &mut video_utils_rs::MediaInfo,
+    video_track_id: u32,
+    codec: video_utils_rs::CodecId,
+    dimensions: Option<(u32, u32)>,
+    time_base: Option<video_utils_rs::TimeBase>,
+    codec_config: Option<Bytes>,
+    preserve_non_video: bool,
+) -> flow_like_types::Result<()> {
+    if !preserve_non_video {
+        media
+            .streams
+            .retain(|stream| stream.track_id == video_track_id);
+    }
+    let stream = media
+        .streams
+        .iter_mut()
+        .find(|stream| stream.track_id == video_track_id)
+        .ok_or_else(|| flow_like_types::anyhow!("Selected video track is missing from media"))?;
+    let codec_changed = stream.codec != codec;
+    stream.codec = codec;
+    if let Some((width, height)) = dimensions {
+        stream.width = Some(width);
+        stream.height = Some(height);
+    }
+    if let Some(time_base) = time_base {
+        stream.time_base = time_base;
+    }
+    if let Some(codec_config) = codec_config {
+        stream.codec_config = Some(codec_config);
+    } else if codec_changed {
+        stream.codec_config = None;
+    }
+    Ok(())
+}
+
+#[cfg(feature = "execute")]
+fn sort_packets(packets: &mut [video_utils_rs::EncodedPacket]) {
+    packets.sort_by(|left, right| {
+        let left_ts = left.time_base.ticks_to_seconds(left.decode_order_ts());
+        let right_ts = right.time_base.ticks_to_seconds(right.decode_order_ts());
+        left_ts
+            .total_cmp(&right_ts)
+            .then_with(|| left.track_id.cmp(&right.track_id))
+            .then_with(|| left.pts.cmp(&right.pts))
+    });
+}
+
+pub mod add_subtitle_track;
+pub mod analyze_audio;
+pub mod audio_to_wav;
+pub mod bitstream_convert;
+pub mod burn_subtitles;
+pub mod check_remux_compatibility;
+pub mod concat;
+pub mod contact_sheet;
+pub mod convert_image_format;
+pub mod detect_container;
+pub mod detect_silence;
+pub mod encode_av1;
+pub mod extract_subtitle_track;
+pub mod extract_thumbnail;
+pub mod extract_track;
+pub mod normalize_timestamps;
+pub mod package_hls_vod;
+pub mod parse_subtitles;
+pub mod pick_codec_backend;
+pub mod probe_codec_backends;
+pub mod probe_media_info;
+pub mod probe_platform_codec;
+pub mod remux;
+pub mod shift_subtitle_file;
+pub mod transcode_video;
+pub mod transform_audio;
+pub mod transform_image;
+pub mod transform_video;
+pub mod trim_keyframes;
+pub mod write_subtitles;

--- a/packages/catalog/media/src/video/utils.rs
+++ b/packages/catalog/media/src/video/utils.rs
@@ -27,6 +27,10 @@ pub struct VideoStreamInfo {
     pub time_base_num: i32,
     pub time_base_den: i32,
     pub duration_seconds: Option<f64>,
+    pub fps: Option<f64>,
+    pub frame_count: Option<u64>,
+    pub packet_count: Option<u64>,
+    pub average_frame_duration_seconds: Option<f64>,
     pub width: Option<u32>,
     pub height: Option<u32>,
     pub sample_rate: Option<u32>,
@@ -46,6 +50,15 @@ pub struct VideoMediaInfo {
 pub struct MediaTag {
     pub key: String,
     pub value: String,
+}
+
+#[cfg(feature = "execute")]
+#[derive(Debug, Clone, Copy, Default)]
+struct StreamTimingStats {
+    fps: Option<f64>,
+    frame_count: Option<u64>,
+    packet_count: Option<u64>,
+    average_frame_duration_seconds: Option<f64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -210,6 +223,74 @@ pub struct ImageOperationReport {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct VideoRemuxReport {
+    pub source: String,
+    pub target: String,
+    pub operation: String,
+    pub bytes_written: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct SubtitleTrackMuxReport {
+    pub source: String,
+    pub sidecar: String,
+    pub target: String,
+    pub event_count: usize,
+    pub subtitle_packets: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct SubtitleTrackExtractReport {
+    pub source: String,
+    pub target: String,
+    pub subtitle_track_id: u32,
+    pub event_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct VideoFrameExtractionReport {
+    pub source: String,
+    pub target: String,
+    pub video_track_id: u32,
+    pub frame_index: usize,
+    pub decoded_frames: usize,
+    pub input_width: u32,
+    pub input_height: u32,
+    pub output_width: u32,
+    pub output_height: u32,
+    pub output_format: String,
+    pub bytes_written: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ContactSheetReport {
+    pub source: String,
+    pub target: String,
+    pub video_track_id: u32,
+    pub frame_count: usize,
+    pub input_width: u32,
+    pub input_height: u32,
+    pub output_width: u32,
+    pub output_height: u32,
+    pub output_format: String,
+    pub bytes_written: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct HlsVodPackageReport {
+    pub init_segment: Option<FlowPath>,
+    pub segment_count: usize,
+    pub bytes_written: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ContainerDetectionInfo {
+    pub format: String,
+    pub display_name: String,
+    pub extensions: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct WaveformBucketInfo {
     pub start_sample: usize,
     pub end_sample: usize,
@@ -354,6 +435,14 @@ fn media_type_name(media_type: video_utils_rs::MediaType) -> String {
 
 #[cfg(feature = "execute")]
 fn stream_to_info(stream: &video_utils_rs::StreamInfo) -> VideoStreamInfo {
+    stream_to_info_with_stats(stream, StreamTimingStats::default())
+}
+
+#[cfg(feature = "execute")]
+fn stream_to_info_with_stats(
+    stream: &video_utils_rs::StreamInfo,
+    stats: StreamTimingStats,
+) -> VideoStreamInfo {
     VideoStreamInfo {
         track_id: stream.track_id,
         media_type: media_type_name(stream.media_type),
@@ -361,6 +450,10 @@ fn stream_to_info(stream: &video_utils_rs::StreamInfo) -> VideoStreamInfo {
         time_base_num: stream.time_base.num,
         time_base_den: stream.time_base.den,
         duration_seconds: stream.duration_seconds(),
+        fps: stats.fps,
+        frame_count: stats.frame_count,
+        packet_count: stats.packet_count,
+        average_frame_duration_seconds: stats.average_frame_duration_seconds,
         width: stream.width,
         height: stream.height,
         sample_rate: stream.sample_rate,
@@ -371,10 +464,105 @@ fn stream_to_info(stream: &video_utils_rs::StreamInfo) -> VideoStreamInfo {
 }
 
 #[cfg(feature = "execute")]
+fn stream_timing_stats(
+    stream: &video_utils_rs::StreamInfo,
+    packets: &[video_utils_rs::EncodedPacket],
+) -> StreamTimingStats {
+    let mut packet_count = 0_u64;
+    let mut first_packet_duration_seconds = None;
+    let mut first_pts_seconds = None;
+    let mut last_end_seconds = None;
+
+    for packet in packets
+        .iter()
+        .filter(|packet| packet.track_id == stream.track_id)
+    {
+        packet_count += 1;
+
+        let start_seconds = packet.time_base.ticks_to_seconds(packet.pts);
+        let end_seconds = packet.time_base.ticks_to_seconds(packet.end_pts());
+
+        first_pts_seconds = Some(
+            first_pts_seconds
+                .map(|current: f64| current.min(start_seconds))
+                .unwrap_or(start_seconds),
+        );
+        last_end_seconds = Some(
+            last_end_seconds
+                .map(|current: f64| current.max(end_seconds))
+                .unwrap_or(end_seconds),
+        );
+
+        if packet.duration > 0 && first_packet_duration_seconds.is_none() {
+            let duration_seconds = packet.duration_seconds();
+            if duration_seconds.is_finite() && duration_seconds > 0.0 {
+                first_packet_duration_seconds = Some(duration_seconds);
+            }
+        }
+    }
+
+    let packet_count = Some(packet_count);
+    if stream.media_type != video_utils_rs::MediaType::Video {
+        return StreamTimingStats {
+            packet_count,
+            ..Default::default()
+        };
+    }
+
+    let frame_count = packet_count.filter(|count| *count > 0);
+    let span_seconds = first_pts_seconds
+        .zip(last_end_seconds)
+        .map(|(first, last)| last - first)
+        .filter(|duration| duration.is_finite() && *duration > 0.0);
+    let duration_seconds = stream
+        .duration_seconds()
+        .filter(|duration| duration.is_finite() && *duration > 0.0)
+        .or(span_seconds);
+
+    let fps = frame_count.and_then(|count| {
+        duration_seconds
+            .map(|duration| count as f64 / duration)
+            .or_else(|| first_packet_duration_seconds.map(|duration| 1.0 / duration))
+            .filter(|fps| fps.is_finite() && *fps > 0.0)
+    });
+    let average_frame_duration_seconds = fps.map(|fps| 1.0 / fps);
+
+    StreamTimingStats {
+        fps,
+        frame_count,
+        packet_count,
+        average_frame_duration_seconds,
+    }
+}
+
+#[cfg(feature = "execute")]
 fn media_to_info(media: &video_utils_rs::MediaInfo) -> VideoMediaInfo {
     VideoMediaInfo {
         duration_seconds: media.duration_seconds,
         streams: media.streams.iter().map(stream_to_info).collect(),
+        tags: media
+            .tags
+            .iter()
+            .map(|(key, value)| MediaTag {
+                key: key.clone(),
+                value: value.clone(),
+            })
+            .collect(),
+    }
+}
+
+#[cfg(feature = "execute")]
+fn media_to_info_with_packets(
+    media: &video_utils_rs::MediaInfo,
+    packets: &[video_utils_rs::EncodedPacket],
+) -> VideoMediaInfo {
+    VideoMediaInfo {
+        duration_seconds: media.duration_seconds,
+        streams: media
+            .streams
+            .iter()
+            .map(|stream| stream_to_info_with_stats(stream, stream_timing_stats(stream, packets)))
+            .collect(),
         tags: media
             .tags
             .iter()
@@ -1212,3 +1400,46 @@ pub mod transform_image;
 pub mod transform_video;
 pub mod trim_keyframes;
 pub mod write_subtitles;
+
+#[cfg(all(test, feature = "execute"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stream_timing_stats_estimates_fps_from_packets() {
+        let time_base = video_utils_rs::TimeBase::new(1, 30).unwrap();
+        let stream = video_utils_rs::StreamInfo {
+            track_id: 1,
+            media_type: video_utils_rs::MediaType::Video,
+            codec: video_utils_rs::CodecId::RawVideo,
+            time_base,
+            duration: Some(90),
+            width: Some(1920),
+            height: Some(1080),
+            sample_rate: None,
+            channels: None,
+            language: None,
+            codec_config: None,
+            tags: Default::default(),
+        };
+        let packets = (0..90)
+            .map(|pts| {
+                video_utils_rs::EncodedPacket::new(
+                    1,
+                    video_utils_rs::CodecId::RawVideo,
+                    pts,
+                    1,
+                    time_base,
+                    Vec::<u8>::new(),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let stats = stream_timing_stats(&stream, &packets);
+
+        assert_eq!(stats.frame_count, Some(90));
+        assert_eq!(stats.packet_count, Some(90));
+        assert_eq!(stats.fps, Some(30.0));
+        assert_eq!(stats.average_frame_duration_seconds, Some(1.0 / 30.0));
+    }
+}

--- a/packages/catalog/media/src/video/utils/add_subtitle_track.rs
+++ b/packages/catalog/media/src/video/utils/add_subtitle_track.rs
@@ -1,0 +1,113 @@
+use super::*;
+
+#[crate::register_node]
+#[derive(Default)]
+pub struct AddSubtitleTrackNode;
+
+impl AddSubtitleTrackNode {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl NodeLogic for AddSubtitleTrackNode {
+    fn get_node(&self) -> Node {
+        let mut node = Node::new(
+            "video_add_subtitle_track",
+            "Add Subtitle Track",
+            "Mux an SRT or WebVTT sidecar into a Matroska subtitle track",
+            "Subtitles",
+        );
+        node.add_icon("/flow/icons/text.svg");
+        add_exec_pins(&mut node);
+        add_flow_path_input(&mut node, "source", "Source", "Source media FlowPath");
+        add_flow_path_input(&mut node, "sidecar", "Sidecar", "Subtitle sidecar FlowPath");
+        add_flow_path_input(&mut node, "target", "Target", "Target Matroska FlowPath");
+        node.add_input_pin(
+            "format",
+            "Format",
+            "Subtitle sidecar format",
+            VariableType::String,
+        )
+        .set_options(
+            PinOptions::new()
+                .set_valid_values(vec!["srt".to_owned(), "webvtt".to_owned()])
+                .build(),
+        )
+        .set_default_value(Some(json!("srt")));
+        node.add_input_pin(
+            "track_id",
+            "Track ID",
+            "Subtitle track id to create",
+            VariableType::Integer,
+        )
+        .set_default_value(Some(json!(100)));
+        node.add_input_pin(
+            "language",
+            "Language",
+            "Optional language tag",
+            VariableType::String,
+        )
+        .set_default_value(Some(json!("")));
+        add_flow_path_output(&mut node, "result", "Result", "Written media FlowPath");
+        node.add_output_pin(
+            "event_count",
+            "Event Count",
+            "Parsed subtitle event count",
+            VariableType::Integer,
+        );
+        node.add_output_pin(
+            "subtitle_packets",
+            "Subtitle Packets",
+            "Subtitle packets muxed",
+            VariableType::Integer,
+        );
+        node
+    }
+
+    #[cfg(feature = "execute")]
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        context.deactivate_exec_pin("exec_out").await?;
+        let source: FlowPath = context.evaluate_pin("source").await?;
+        let sidecar: FlowPath = context.evaluate_pin("sidecar").await?;
+        let target: FlowPath = context.evaluate_pin("target").await?;
+        let format: String = context.evaluate_pin("format").await?;
+        let track_id: i64 = context.evaluate_pin("track_id").await?;
+        let language: String = context.evaluate_pin("language").await?;
+        let format = subtitle_format(&format)?;
+        let track_id = u32::try_from(track_id)?;
+        let (source_store, source_location) = flow_path_object(context, &source).await?;
+        let (sidecar_store, sidecar_location) = flow_path_object(context, &sidecar).await?;
+        let (target_store, target_location) = flow_path_object(context, &target).await?;
+        let mut job = video_utils_rs::ObjectSubtitleTrackJob::new(track_id, format);
+        if let Some(language) = clean_optional(language) {
+            job = job.with_language(language);
+        }
+        let report = video_utils_rs::add_subtitle_sidecar_to_object_between_stores(
+            source_store.as_ref(),
+            &source_location,
+            sidecar_store.as_ref(),
+            &sidecar_location,
+            target_store.as_ref(),
+            &target_location,
+            &job,
+        )
+        .await?;
+
+        context.set_pin_value("result", json!(target)).await?;
+        context
+            .set_pin_value("event_count", json!(report.event_count as i64))
+            .await?;
+        context
+            .set_pin_value("subtitle_packets", json!(report.subtitle_packets as i64))
+            .await?;
+        context.activate_exec_pin("exec_out").await?;
+        Ok(())
+    }
+
+    #[cfg(not(feature = "execute"))]
+    async fn run(&self, _context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        Err(execute_feature_error())
+    }
+}

--- a/packages/catalog/media/src/video/utils/add_subtitle_track.rs
+++ b/packages/catalog/media/src/video/utils/add_subtitle_track.rs
@@ -52,17 +52,12 @@ impl NodeLogic for AddSubtitleTrackNode {
         .set_default_value(Some(json!("")));
         add_flow_path_output(&mut node, "result", "Result", "Written media FlowPath");
         node.add_output_pin(
-            "event_count",
-            "Event Count",
-            "Parsed subtitle event count",
-            VariableType::Integer,
-        );
-        node.add_output_pin(
-            "subtitle_packets",
-            "Subtitle Packets",
-            "Subtitle packets muxed",
-            VariableType::Integer,
-        );
+            "report",
+            "Report",
+            "Subtitle mux report",
+            VariableType::Struct,
+        )
+        .set_schema::<SubtitleTrackMuxReport>();
         node
     }
 
@@ -84,7 +79,7 @@ impl NodeLogic for AddSubtitleTrackNode {
         if let Some(language) = clean_optional(language) {
             job = job.with_language(language);
         }
-        let report = video_utils_rs::add_subtitle_sidecar_to_object_between_stores(
+        let subtitle_report = video_utils_rs::add_subtitle_sidecar_to_object_between_stores(
             source_store.as_ref(),
             &source_location,
             sidecar_store.as_ref(),
@@ -94,14 +89,16 @@ impl NodeLogic for AddSubtitleTrackNode {
             &job,
         )
         .await?;
+        let report = SubtitleTrackMuxReport {
+            source: source_location.to_string(),
+            sidecar: sidecar_location.to_string(),
+            target: target_location.to_string(),
+            event_count: subtitle_report.event_count,
+            subtitle_packets: subtitle_report.subtitle_packets,
+        };
 
         context.set_pin_value("result", json!(target)).await?;
-        context
-            .set_pin_value("event_count", json!(report.event_count as i64))
-            .await?;
-        context
-            .set_pin_value("subtitle_packets", json!(report.subtitle_packets as i64))
-            .await?;
+        context.set_pin_value("report", json!(report)).await?;
         context.activate_exec_pin("exec_out").await?;
         Ok(())
     }

--- a/packages/catalog/media/src/video/utils/analyze_audio.rs
+++ b/packages/catalog/media/src/video/utils/analyze_audio.rs
@@ -88,7 +88,8 @@ impl NodeLogic for AnalyzeAudioNode {
         let frames = decode_audio_file(store.as_ref(), &location).await?;
         let decoded_frames = frames.len();
         let audio = concat_audio_frames(&frames)?;
-        let waveform = video_utils_rs::waveform_peaks(&audio, waveform_buckets.max(1) as usize)?
+        let waveform_bucket_count = usize::try_from(waveform_buckets.max(1))?;
+        let waveform = video_utils_rs::waveform_peaks(&audio, waveform_bucket_count)?
             .into_iter()
             .map(|bucket| waveform_bucket_info(bucket, audio.sample_rate))
             .collect::<Vec<_>>();

--- a/packages/catalog/media/src/video/utils/analyze_audio.rs
+++ b/packages/catalog/media/src/video/utils/analyze_audio.rs
@@ -1,0 +1,134 @@
+use super::*;
+
+#[crate::register_node]
+#[derive(Default)]
+pub struct AnalyzeAudioNode;
+
+impl AnalyzeAudioNode {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl NodeLogic for AnalyzeAudioNode {
+    fn get_node(&self) -> Node {
+        let mut node = Node::new(
+            "video_analyze_audio",
+            "Analyze Audio",
+            "Decode audio and report waveform, peak/RMS, and silence ranges",
+            "Audio",
+        );
+        add_video_icon_and_scores(&mut node);
+        add_exec_pins(&mut node);
+        add_flow_path_input(&mut node, "source", "Source", "Source audio/media FlowPath");
+        node.add_input_pin(
+            "waveform_buckets",
+            "Waveform Buckets",
+            "Number of waveform buckets",
+            VariableType::Integer,
+        )
+        .set_default_value(Some(json!(64)));
+        node.add_input_pin(
+            "silence_threshold_db",
+            "Silence dB",
+            "RMS threshold in dB",
+            VariableType::Float,
+        )
+        .set_default_value(Some(json!(-60.0)));
+        node.add_input_pin(
+            "window_ms",
+            "Window ms",
+            "Silence analysis window",
+            VariableType::Integer,
+        )
+        .set_default_value(Some(json!(20)));
+        node.add_input_pin(
+            "min_silence_ms",
+            "Min Silence ms",
+            "Minimum silence duration",
+            VariableType::Integer,
+        )
+        .set_default_value(Some(json!(500)));
+        node.add_output_pin(
+            "report",
+            "Report",
+            "Audio analysis report",
+            VariableType::Struct,
+        )
+        .set_schema::<AudioAnalysisReport>();
+        node.add_output_pin(
+            "waveform",
+            "Waveform",
+            "Waveform buckets",
+            VariableType::Struct,
+        )
+        .set_schema::<WaveformBucketInfo>()
+        .set_value_type(ValueType::Array);
+        node.add_output_pin(
+            "silence",
+            "Silence",
+            "Detected silence ranges",
+            VariableType::Struct,
+        )
+        .set_schema::<SilenceRangeInfo>()
+        .set_value_type(ValueType::Array);
+        node
+    }
+
+    #[cfg(feature = "execute")]
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        context.deactivate_exec_pin("exec_out").await?;
+        let source: FlowPath = context.evaluate_pin("source").await?;
+        let waveform_buckets: i64 = context.evaluate_pin("waveform_buckets").await?;
+        let silence_threshold_db: f64 = context.evaluate_pin("silence_threshold_db").await?;
+        let window_ms: i64 = context.evaluate_pin("window_ms").await?;
+        let min_silence_ms: i64 = context.evaluate_pin("min_silence_ms").await?;
+        let (store, location) = flow_path_object(context, &source).await?;
+        let frames = decode_audio_file(store.as_ref(), &location).await?;
+        let decoded_frames = frames.len();
+        let audio = concat_audio_frames(&frames)?;
+        let waveform = video_utils_rs::waveform_peaks(&audio, waveform_buckets.max(1) as usize)?
+            .into_iter()
+            .map(|bucket| waveform_bucket_info(bucket, audio.sample_rate))
+            .collect::<Vec<_>>();
+        let window_samples = ((window_ms.max(1) as f64 / 1000.0) * audio.sample_rate as f64)
+            .round()
+            .max(1.0) as usize;
+        let min_duration_samples = ((min_silence_ms.max(1) as f64 / 1000.0)
+            * audio.sample_rate as f64)
+            .round()
+            .max(1.0) as usize;
+        let silence = video_utils_rs::detect_silence(
+            &audio,
+            silence_threshold_db as f32,
+            window_samples,
+            min_duration_samples,
+        )?
+        .into_iter()
+        .map(|range| silence_range_info(range, audio.sample_rate))
+        .collect::<Vec<_>>();
+        let report = AudioAnalysisReport {
+            duration_seconds: audio.duration_seconds(),
+            sample_rate: audio.sample_rate,
+            channels: audio.channels,
+            decoded_frames,
+            sample_frames: audio.sample_frames(),
+            peak_amplitude: audio.peak_amplitude(),
+            rms: audio.rms(),
+            waveform_buckets: waveform.len(),
+            silence_ranges: silence.len(),
+        };
+
+        context.set_pin_value("report", json!(report)).await?;
+        context.set_pin_value("waveform", json!(waveform)).await?;
+        context.set_pin_value("silence", json!(silence)).await?;
+        context.activate_exec_pin("exec_out").await?;
+        Ok(())
+    }
+
+    #[cfg(not(feature = "execute"))]
+    async fn run(&self, _context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        Err(execute_feature_error())
+    }
+}

--- a/packages/catalog/media/src/video/utils/audio_to_wav.rs
+++ b/packages/catalog/media/src/video/utils/audio_to_wav.rs
@@ -38,12 +38,6 @@ impl NodeLogic for AudioToWavNode {
             VariableType::Struct,
         )
         .set_schema::<AudioTransformReport>();
-        node.add_output_pin(
-            "bytes_written",
-            "Bytes Written",
-            "Bytes written to the target",
-            VariableType::Integer,
-        );
         node
     }
 
@@ -72,9 +66,6 @@ impl NodeLogic for AudioToWavNode {
         let report = audio_transform_report(report);
 
         context.set_pin_value("result", json!(target)).await?;
-        context
-            .set_pin_value("bytes_written", json!(report.bytes_written as i64))
-            .await?;
         context.set_pin_value("report", json!(report)).await?;
         context.activate_exec_pin("exec_out").await?;
         Ok(())

--- a/packages/catalog/media/src/video/utils/audio_to_wav.rs
+++ b/packages/catalog/media/src/video/utils/audio_to_wav.rs
@@ -1,0 +1,87 @@
+use super::*;
+
+#[crate::register_node]
+#[derive(Default)]
+pub struct AudioToWavNode;
+
+impl AudioToWavNode {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl NodeLogic for AudioToWavNode {
+    fn get_node(&self) -> Node {
+        let mut node = Node::new(
+            "video_audio_to_wav",
+            "Audio To WAV",
+            "Decode an audio/media object and write WAV PCM output",
+            "Audio",
+        );
+        add_video_icon_and_scores(&mut node);
+        add_exec_pins(&mut node);
+        add_flow_path_input(&mut node, "source", "Source", "Source audio/media FlowPath");
+        add_flow_path_input(&mut node, "target", "Target", "Target WAV FlowPath");
+        node.add_input_pin(
+            "audio_track_id",
+            "Audio Track",
+            "Audio track id, or 0 for default",
+            VariableType::Integer,
+        )
+        .set_default_value(Some(json!(0)));
+        add_flow_path_output(&mut node, "result", "Result", "Written WAV FlowPath");
+        node.add_output_pin(
+            "report",
+            "Report",
+            "Audio conversion report",
+            VariableType::Struct,
+        )
+        .set_schema::<AudioTransformReport>();
+        node.add_output_pin(
+            "bytes_written",
+            "Bytes Written",
+            "Bytes written to the target",
+            VariableType::Integer,
+        );
+        node
+    }
+
+    #[cfg(feature = "execute")]
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        context.deactivate_exec_pin("exec_out").await?;
+        let source: FlowPath = context.evaluate_pin("source").await?;
+        let target: FlowPath = context.evaluate_pin("target").await?;
+        let audio_track_id: i64 = context.evaluate_pin("audio_track_id").await?;
+        let (source_store, source_location) = flow_path_object(context, &source).await?;
+        let (target_store, target_location) = flow_path_object(context, &target).await?;
+        let mut job = video_utils_rs::ObjectAudioTransformJob::new(
+            video_utils_rs::AudioTransformPipeline::new(),
+        );
+        if let Some(track_id) = optional_track_id(audio_track_id)? {
+            job = job.with_audio_track(track_id);
+        }
+        let report = video_utils_rs::transform_object_audio_file_to_wav_between_stores(
+            source_store.as_ref(),
+            &source_location,
+            target_store.as_ref(),
+            &target_location,
+            &job,
+        )
+        .await?;
+        let report = audio_transform_report(report);
+
+        context.set_pin_value("result", json!(target)).await?;
+        context
+            .set_pin_value("bytes_written", json!(report.bytes_written as i64))
+            .await?;
+        context.set_pin_value("report", json!(report)).await?;
+        context.activate_exec_pin("exec_out").await?;
+        Ok(())
+    }
+
+    #[cfg(not(feature = "execute"))]
+    async fn run(&self, _context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        Err(execute_feature_error())
+    }
+}

--- a/packages/catalog/media/src/video/utils/bitstream_convert.rs
+++ b/packages/catalog/media/src/video/utils/bitstream_convert.rs
@@ -40,12 +40,6 @@ impl NodeLogic for BitstreamConvertNode {
             VariableType::Struct,
         )
         .set_schema::<BitstreamConvertReport>();
-        node.add_output_pin(
-            "bytes_written",
-            "Bytes Written",
-            "Bytes written to the target",
-            VariableType::Integer,
-        );
         node
     }
 
@@ -155,9 +149,6 @@ impl NodeLogic for BitstreamConvertNode {
         };
 
         context.set_pin_value("result", json!(target)).await?;
-        context
-            .set_pin_value("bytes_written", json!(bytes_written as i64))
-            .await?;
         context.set_pin_value("report", json!(report)).await?;
         context.activate_exec_pin("exec_out").await?;
         Ok(())

--- a/packages/catalog/media/src/video/utils/bitstream_convert.rs
+++ b/packages/catalog/media/src/video/utils/bitstream_convert.rs
@@ -1,0 +1,170 @@
+use super::*;
+
+#[crate::register_node]
+#[derive(Default)]
+pub struct BitstreamConvertNode;
+
+impl BitstreamConvertNode {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl NodeLogic for BitstreamConvertNode {
+    fn get_node(&self) -> Node {
+        let mut node = Node::new(
+            "video_bitstream_convert",
+            "Bitstream Convert",
+            "Convert H.264/H.265/AAC packet bitstream framing into an elementary output file",
+            "Video/Packets",
+        );
+        add_video_icon_and_scores(&mut node);
+        add_exec_pins(&mut node);
+        add_flow_path_input(&mut node, "source", "Source", "Source media FlowPath");
+        add_flow_path_input(&mut node, "target", "Target", "Target elementary FlowPath");
+        node.add_input_pin("conversion", "Conversion", "h264_annex_b, h264_length_prefixed, h265_annex_b, h265_length_prefixed, aac_adts, or aac_raw", VariableType::String)
+            .set_default_value(Some(json!("h264_annex_b")));
+        node.add_input_pin(
+            "track_id",
+            "Track",
+            "Track id, or 0 to select by conversion codec",
+            VariableType::Integer,
+        )
+        .set_default_value(Some(json!(0)));
+        add_flow_path_output(&mut node, "result", "Result", "Written elementary FlowPath");
+        node.add_output_pin(
+            "report",
+            "Report",
+            "Bitstream conversion report",
+            VariableType::Struct,
+        )
+        .set_schema::<BitstreamConvertReport>();
+        node.add_output_pin(
+            "bytes_written",
+            "Bytes Written",
+            "Bytes written to the target",
+            VariableType::Integer,
+        );
+        node
+    }
+
+    #[cfg(feature = "execute")]
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        context.deactivate_exec_pin("exec_out").await?;
+        let source: FlowPath = context.evaluate_pin("source").await?;
+        let target: FlowPath = context.evaluate_pin("target").await?;
+        let conversion: String = context.evaluate_pin("conversion").await?;
+        let track_id: i64 = context.evaluate_pin("track_id").await?;
+        let conversion = conversion.trim().to_ascii_lowercase();
+        let expected_codec = match conversion.as_str() {
+            "h264_annex_b" | "h264_length_prefixed" => video_utils_rs::CodecId::H264,
+            "h265_annex_b" | "h265_length_prefixed" => video_utils_rs::CodecId::H265,
+            "aac_adts" | "aac_raw" => video_utils_rs::CodecId::Aac,
+            other => {
+                return Err(flow_like_types::anyhow!(
+                    "Unsupported bitstream conversion: {}",
+                    other
+                ));
+            }
+        };
+        let (source_store, source_location) = flow_path_object(context, &source).await?;
+        let (target_store, target_location) = flow_path_object(context, &target).await?;
+        let demuxed = video_utils_rs::demux_object(source_store.as_ref(), &source_location).await?;
+        let selected_track = if let Some(track_id) = optional_track_id(track_id)? {
+            track_id
+        } else {
+            demuxed
+                .media
+                .streams
+                .iter()
+                .find(|stream| stream.codec == expected_codec)
+                .map(|stream| stream.track_id)
+                .ok_or_else(|| flow_like_types::anyhow!("No {} track found", expected_codec))?
+        };
+        let stream = demuxed
+            .media
+            .stream(selected_track)
+            .ok_or_else(|| flow_like_types::anyhow!("Track {} is missing", selected_track))?;
+        if stream.codec != expected_codec {
+            return Err(flow_like_types::anyhow!(
+                "Track {} has codec {}, expected {}",
+                selected_track,
+                stream.codec,
+                expected_codec
+            ));
+        }
+
+        let mut output = Vec::<u8>::new();
+        let mut packet_count = 0usize;
+        for packet in demuxed
+            .packets
+            .iter()
+            .filter(|packet| packet.track_id == selected_track)
+        {
+            let converted = match conversion.as_str() {
+                "h264_annex_b" => video_utils_rs::bitstream::h264::h264_packet_to_annex_b(
+                    packet,
+                    stream.codec_config.as_ref(),
+                )?,
+                "h264_length_prefixed" => {
+                    let config = stream.codec_config.as_ref().ok_or_else(|| {
+                        flow_like_types::anyhow!(
+                            "H.264 length-prefixed conversion requires avcC codec config"
+                        )
+                    })?;
+                    video_utils_rs::bitstream::h264::h264_packet_to_length_prefixed(packet, config)?
+                }
+                "h265_annex_b" => video_utils_rs::bitstream::h265::h265_packet_to_annex_b(
+                    packet,
+                    stream.codec_config.as_ref(),
+                )?,
+                "h265_length_prefixed" => {
+                    let config = stream.codec_config.as_ref().ok_or_else(|| {
+                        flow_like_types::anyhow!(
+                            "H.265 length-prefixed conversion requires hvcC codec config"
+                        )
+                    })?;
+                    video_utils_rs::bitstream::h265::h265_packet_to_length_prefixed(packet, config)?
+                }
+                "aac_adts" => video_utils_rs::bitstream::aac::aac_packet_to_adts(
+                    packet,
+                    stream.codec_config.as_ref(),
+                )?,
+                "aac_raw" => video_utils_rs::bitstream::aac::aac_packet_to_raw(packet)?,
+                _ => unreachable!(),
+            };
+            output.extend_from_slice(&converted);
+            packet_count += 1;
+        }
+        let bytes_written = output.len() as u64;
+        video_utils_rs::write_object_bytes(
+            target_store.as_ref(),
+            &target_location,
+            Bytes::from(output),
+        )
+        .await?;
+        let report = BitstreamConvertReport {
+            source: source_location.to_string(),
+            target: target_location.to_string(),
+            codec: expected_codec.to_string(),
+            conversion,
+            track_id: selected_track,
+            packets: packet_count,
+            bytes_written,
+        };
+
+        context.set_pin_value("result", json!(target)).await?;
+        context
+            .set_pin_value("bytes_written", json!(bytes_written as i64))
+            .await?;
+        context.set_pin_value("report", json!(report)).await?;
+        context.activate_exec_pin("exec_out").await?;
+        Ok(())
+    }
+
+    #[cfg(not(feature = "execute"))]
+    async fn run(&self, _context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        Err(execute_feature_error())
+    }
+}

--- a/packages/catalog/media/src/video/utils/burn_subtitles.rs
+++ b/packages/catalog/media/src/video/utils/burn_subtitles.rs
@@ -1,0 +1,190 @@
+use super::*;
+
+#[crate::register_node]
+#[derive(Default)]
+pub struct BurnSubtitlesNode;
+
+impl BurnSubtitlesNode {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl NodeLogic for BurnSubtitlesNode {
+    fn get_node(&self) -> Node {
+        let mut node = Node::new(
+            "video_burn_subtitles",
+            "Burn Subtitles Into Video",
+            "Render an SRT/WebVTT sidecar into video frames and mux the result",
+            "Subtitles",
+        );
+        add_video_icon_and_scores(&mut node);
+        add_exec_pins(&mut node);
+        add_flow_path_input(&mut node, "source", "Source", "Source media FlowPath");
+        add_flow_path_input(&mut node, "sidecar", "Sidecar", "Subtitle sidecar FlowPath");
+        add_flow_path_input(&mut node, "target", "Target", "Target media FlowPath");
+        node.add_input_pin("format", "Format", "srt or webvtt", VariableType::String)
+            .set_default_value(Some(json!("srt")));
+        node.add_input_pin(
+            "output_codec",
+            "Output Codec",
+            "Video codec to encode",
+            VariableType::String,
+        )
+        .set_default_value(Some(json!("h264")));
+        node.add_input_pin(
+            "video_track_id",
+            "Video Track",
+            "Video track id, or 0 for default",
+            VariableType::Integer,
+        )
+        .set_default_value(Some(json!(0)));
+        node.add_input_pin(
+            "preserve_non_video",
+            "Preserve Non-Video",
+            "Copy non-video packets when possible",
+            VariableType::Boolean,
+        )
+        .set_default_value(Some(json!(true)));
+        node.add_input_pin(
+            "bitrate",
+            "Bitrate",
+            "Target bitrate in bits per second, or 0 for backend default",
+            VariableType::Integer,
+        )
+        .set_default_value(Some(json!(0)));
+        node.add_input_pin(
+            "scale",
+            "Scale",
+            "Subtitle render scale",
+            VariableType::Integer,
+        )
+        .set_default_value(Some(json!(2)));
+        node.add_input_pin(
+            "margin_bottom",
+            "Margin Bottom",
+            "Subtitle bottom margin in pixels",
+            VariableType::Integer,
+        )
+        .set_default_value(Some(json!(24)));
+        add_flow_path_output(&mut node, "result", "Result", "Written media FlowPath");
+        node.add_output_pin(
+            "report",
+            "Report",
+            "Subtitle burn-in report",
+            VariableType::Struct,
+        )
+        .set_schema::<SubtitleBurnInReport>();
+        node.add_output_pin(
+            "event_count",
+            "Events",
+            "Parsed subtitle event count",
+            VariableType::Integer,
+        );
+        node.add_output_pin(
+            "bytes_written",
+            "Bytes Written",
+            "Bytes written to the target",
+            VariableType::Integer,
+        );
+        node
+    }
+
+    #[cfg(feature = "execute")]
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        context.deactivate_exec_pin("exec_out").await?;
+        let source: FlowPath = context.evaluate_pin("source").await?;
+        let sidecar: FlowPath = context.evaluate_pin("sidecar").await?;
+        let target: FlowPath = context.evaluate_pin("target").await?;
+        let format: String = context.evaluate_pin("format").await?;
+        let output_codec: String = context.evaluate_pin("output_codec").await?;
+        let video_track_id: i64 = context.evaluate_pin("video_track_id").await?;
+        let preserve_non_video: bool = context.evaluate_pin("preserve_non_video").await?;
+        let bitrate: i64 = context.evaluate_pin("bitrate").await?;
+        let scale: i64 = context.evaluate_pin("scale").await?;
+        let margin_bottom: i64 = context.evaluate_pin("margin_bottom").await?;
+        let (source_store, source_location) = flow_path_object(context, &source).await?;
+        let (sidecar_store, sidecar_location) = flow_path_object(context, &sidecar).await?;
+        let (target_store, target_location) = flow_path_object(context, &target).await?;
+        let demuxed = video_utils_rs::demux_object(source_store.as_ref(), &source_location).await?;
+        let requested_track = optional_track_id(video_track_id)?;
+        let stream = selected_video_stream(&demuxed.media, requested_track)?;
+        let track_id = stream.track_id;
+        let width = stream
+            .width
+            .ok_or_else(|| flow_like_types::anyhow!("Source video stream has no width"))?;
+        let height = stream
+            .height
+            .ok_or_else(|| flow_like_types::anyhow!("Source video stream has no height"))?;
+        let frame_duration = packet_frame_duration(&demuxed.packets, track_id);
+        let format = subtitle_format(&format)?;
+        let sidecar_bytes =
+            video_utils_rs::read_object_bytes(sidecar_store.as_ref(), &sidecar_location).await?;
+        let sidecar_text = String::from_utf8(sidecar_bytes.to_vec()).map_err(|err| {
+            flow_like_types::anyhow!("Subtitle sidecar is not valid UTF-8: {}", err)
+        })?;
+        let events = video_utils_rs::parse_subtitles(format, &sidecar_text)?;
+        let mut style = video_utils_rs::ObjectSubtitleBurnInJob::new(format).style;
+        style.scale = u32::try_from(scale.max(1))?;
+        style.margin_bottom = u32::try_from(margin_bottom.max(0))?;
+        let processed = {
+            let mut decoder = platform_video_decoder(stream)?;
+            let mut encoder = platform_video_encoder(
+                codec_id(&output_codec),
+                width,
+                height,
+                stream.time_base,
+                frame_duration,
+                bitrate,
+            )?;
+            let output_codec_config = encoder.codec_config().map(Bytes::from);
+            process_subtitle_burn(
+                &demuxed,
+                track_id,
+                preserve_non_video,
+                &events,
+                &style,
+                &mut decoder,
+                &mut encoder,
+                output_codec_config,
+            )?
+        };
+        let mux_report = video_utils_rs::mux_object(
+            target_store.as_ref(),
+            &target_location,
+            &processed.media,
+            &processed.packets,
+        )
+        .await?;
+        let report = SubtitleBurnInReport {
+            source: source_location.to_string(),
+            sidecar: sidecar_location.to_string(),
+            target: target_location.to_string(),
+            source_format: demuxed.format.as_str().to_owned(),
+            target_format: mux_report.target_format.as_str().to_owned(),
+            video_track_id: processed.video_track_id,
+            event_count: events.len(),
+            decoded_frames: processed.decoded_frames,
+            encoded_video_packets: processed.encoded_video_packets,
+            copied_packets: processed.copied_packets,
+            bytes_written: mux_report.bytes_written,
+        };
+
+        context.set_pin_value("result", json!(target)).await?;
+        context
+            .set_pin_value("event_count", json!(report.event_count as i64))
+            .await?;
+        context
+            .set_pin_value("bytes_written", json!(report.bytes_written as i64))
+            .await?;
+        context.set_pin_value("report", json!(report)).await?;
+        context.activate_exec_pin("exec_out").await?;
+        Ok(())
+    }
+
+    #[cfg(not(feature = "execute"))]
+    async fn run(&self, _context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        Err(execute_feature_error())
+    }
+}

--- a/packages/catalog/media/src/video/utils/burn_subtitles.rs
+++ b/packages/catalog/media/src/video/utils/burn_subtitles.rs
@@ -76,18 +76,6 @@ impl NodeLogic for BurnSubtitlesNode {
             VariableType::Struct,
         )
         .set_schema::<SubtitleBurnInReport>();
-        node.add_output_pin(
-            "event_count",
-            "Events",
-            "Parsed subtitle event count",
-            VariableType::Integer,
-        );
-        node.add_output_pin(
-            "bytes_written",
-            "Bytes Written",
-            "Bytes written to the target",
-            VariableType::Integer,
-        );
         node
     }
 
@@ -172,12 +160,6 @@ impl NodeLogic for BurnSubtitlesNode {
         };
 
         context.set_pin_value("result", json!(target)).await?;
-        context
-            .set_pin_value("event_count", json!(report.event_count as i64))
-            .await?;
-        context
-            .set_pin_value("bytes_written", json!(report.bytes_written as i64))
-            .await?;
         context.set_pin_value("report", json!(report)).await?;
         context.activate_exec_pin("exec_out").await?;
         Ok(())

--- a/packages/catalog/media/src/video/utils/check_remux_compatibility.rs
+++ b/packages/catalog/media/src/video/utils/check_remux_compatibility.rs
@@ -1,0 +1,96 @@
+use super::*;
+
+#[crate::register_node]
+#[derive(Default)]
+pub struct CheckRemuxCompatibilityNode;
+
+impl CheckRemuxCompatibilityNode {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl NodeLogic for CheckRemuxCompatibilityNode {
+    fn get_node(&self) -> Node {
+        let mut node = Node::new(
+            "video_check_remux_compatibility",
+            "Check Remux Compatibility",
+            "Check whether source streams can be packet-copied into a target container",
+            "Video/Planning",
+        );
+        add_video_icon_and_scores(&mut node);
+        add_exec_pins(&mut node);
+        add_flow_path_input(&mut node, "source", "Source", "Source media FlowPath");
+        add_flow_path_input(
+            &mut node,
+            "target",
+            "Target",
+            "Target FlowPath with desired extension",
+        );
+        node.add_output_pin(
+            "compatible",
+            "Compatible",
+            "True when every stream can be packet-copied",
+            VariableType::Boolean,
+        );
+        node.add_output_pin(
+            "requires_transcode",
+            "Requires Transcode",
+            "True when one or more streams need transcoding",
+            VariableType::Boolean,
+        );
+        node.add_output_pin(
+            "report",
+            "Report",
+            "Detailed remux compatibility report",
+            VariableType::Struct,
+        )
+        .set_schema::<RemuxCompatibilityReport>();
+        node
+    }
+
+    #[cfg(feature = "execute")]
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        context.deactivate_exec_pin("exec_out").await?;
+        let source: FlowPath = context.evaluate_pin("source").await?;
+        let target: FlowPath = context.evaluate_pin("target").await?;
+        let (source_store, source_location) = flow_path_object(context, &source).await?;
+        let (_, target_location) = flow_path_object(context, &target).await?;
+
+        let report = match video_utils_rs::plan_object_remux_from_probe(
+            source_store.as_ref(),
+            &source_location,
+            &target_location,
+        )
+        .await
+        {
+            Ok(plan) => remux_plan_report(&plan),
+            Err(err) => RemuxCompatibilityReport {
+                compatible: false,
+                packet_copy_only: false,
+                requires_transcode: false,
+                has_unsupported_streams: true,
+                source_format: None,
+                target_format: None,
+                streams: Vec::new(),
+                reason: Some(err.to_string()),
+            },
+        };
+
+        context
+            .set_pin_value("compatible", json!(report.compatible))
+            .await?;
+        context
+            .set_pin_value("requires_transcode", json!(report.requires_transcode))
+            .await?;
+        context.set_pin_value("report", json!(report)).await?;
+        context.activate_exec_pin("exec_out").await?;
+        Ok(())
+    }
+
+    #[cfg(not(feature = "execute"))]
+    async fn run(&self, _context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        Err(execute_feature_error())
+    }
+}

--- a/packages/catalog/media/src/video/utils/check_remux_compatibility.rs
+++ b/packages/catalog/media/src/video/utils/check_remux_compatibility.rs
@@ -29,18 +29,6 @@ impl NodeLogic for CheckRemuxCompatibilityNode {
             "Target FlowPath with desired extension",
         );
         node.add_output_pin(
-            "compatible",
-            "Compatible",
-            "True when every stream can be packet-copied",
-            VariableType::Boolean,
-        );
-        node.add_output_pin(
-            "requires_transcode",
-            "Requires Transcode",
-            "True when one or more streams need transcoding",
-            VariableType::Boolean,
-        );
-        node.add_output_pin(
             "report",
             "Report",
             "Detailed remux compatibility report",
@@ -78,12 +66,6 @@ impl NodeLogic for CheckRemuxCompatibilityNode {
             },
         };
 
-        context
-            .set_pin_value("compatible", json!(report.compatible))
-            .await?;
-        context
-            .set_pin_value("requires_transcode", json!(report.requires_transcode))
-            .await?;
         context.set_pin_value("report", json!(report)).await?;
         context.activate_exec_pin("exec_out").await?;
         Ok(())

--- a/packages/catalog/media/src/video/utils/concat.rs
+++ b/packages/catalog/media/src/video/utils/concat.rs
@@ -1,0 +1,85 @@
+use super::*;
+
+#[crate::register_node]
+#[derive(Default)]
+pub struct ConcatMediaNode;
+
+impl ConcatMediaNode {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl NodeLogic for ConcatMediaNode {
+    fn get_node(&self) -> Node {
+        let mut node = Node::new(
+            "video_concat",
+            "Concatenate Videos",
+            "Concatenate packet-copy-compatible media files",
+            "Video/Editing",
+        );
+        add_video_icon_and_scores(&mut node);
+        add_exec_pins(&mut node);
+        node.add_input_pin(
+            "sources",
+            "Sources",
+            "Media FlowPaths in concatenation order",
+            VariableType::Struct,
+        )
+        .set_schema::<FlowPath>()
+        .set_value_type(ValueType::Array);
+        add_flow_path_input(&mut node, "target", "Target", "Target media FlowPath");
+        add_flow_path_output(&mut node, "result", "Result", "Written media FlowPath");
+        node.add_output_pin(
+            "packet_count",
+            "Packet Count",
+            "Packets written",
+            VariableType::Integer,
+        );
+        node
+    }
+
+    #[cfg(feature = "execute")]
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        context.deactivate_exec_pin("exec_out").await?;
+        let sources: Vec<FlowPath> = context.evaluate_pin("sources").await?;
+        let target: FlowPath = context.evaluate_pin("target").await?;
+        if sources.is_empty() {
+            return Err(flow_like_types::anyhow!(
+                "At least one source media file is required"
+            ));
+        }
+
+        let mut demuxed_media = Vec::with_capacity(sources.len());
+        for source in &sources {
+            let (store, location) = flow_path_object(context, source).await?;
+            demuxed_media.push(video_utils_rs::demux_object(store.as_ref(), &location).await?);
+        }
+        let packet_groups = demuxed_media
+            .iter()
+            .map(|demuxed| demuxed.packets.as_slice())
+            .collect::<Vec<_>>();
+        let packets = video_utils_rs::concat_copy(&packet_groups)?;
+        let media = demuxed_media
+            .first()
+            .map(|demuxed| demuxed.media.clone())
+            .ok_or_else(|| flow_like_types::anyhow!("No media was demuxed"))?;
+        let (target_store, target_location) = flow_path_object(context, &target).await?;
+        let report =
+            video_utils_rs::mux_object(target_store.as_ref(), &target_location, &media, &packets)
+                .await?;
+
+        context.set_pin_value("result", json!(target)).await?;
+        context
+            .set_pin_value("packet_count", json!(report.packet_count as i64))
+            .await?;
+        context.activate_exec_pin("exec_out").await?;
+        Ok(())
+    }
+
+    #[cfg(not(feature = "execute"))]
+    async fn run(&self, _context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        Err(execute_feature_error())
+    }
+}

--- a/packages/catalog/media/src/video/utils/contact_sheet.rs
+++ b/packages/catalog/media/src/video/utils/contact_sheet.rs
@@ -84,19 +84,7 @@ impl NodeLogic for ContactSheetNode {
             "Contact sheet image report",
             VariableType::Struct,
         )
-        .set_schema::<ImageOperationReport>();
-        node.add_output_pin(
-            "frames",
-            "Frames",
-            "Frames written into the sheet",
-            VariableType::Integer,
-        );
-        node.add_output_pin(
-            "bytes_written",
-            "Bytes Written",
-            "Bytes written to the target",
-            VariableType::Integer,
-        );
+        .set_schema::<ContactSheetReport>();
         node
     }
 
@@ -126,7 +114,7 @@ impl NodeLogic for ContactSheetNode {
         let input_width = stream.width.unwrap_or(0);
         let input_height = stream.height.unwrap_or(0);
         let output_format = image_format_for_target(&format, &target_location)?;
-        let (output, report, frame_count) = {
+        let (output, report) = {
             let mut decoder = platform_video_decoder(stream)?;
             let mut decoded_index = 0usize;
             let mut frames = Vec::new();
@@ -177,9 +165,11 @@ impl NodeLogic for ContactSheetNode {
             }
             let mut encoder = image_encoder(output_format);
             let output = encoder.encode(&sheet)?;
-            let report = ImageOperationReport {
+            let report = ContactSheetReport {
                 source: source_location.to_string(),
                 target: target_location.to_string(),
+                video_track_id: selected_track,
+                frame_count: frames.len(),
                 input_width,
                 input_height,
                 output_width: sheet.width,
@@ -187,9 +177,8 @@ impl NodeLogic for ContactSheetNode {
                 output_format: image_format_name(output_format).to_owned(),
                 bytes_written: output.len() as u64,
             };
-            (output, report, frames.len())
+            (output, report)
         };
-        let bytes_written = output.len() as u64;
         video_utils_rs::write_object_bytes(
             target_store.as_ref(),
             &target_location,
@@ -198,12 +187,6 @@ impl NodeLogic for ContactSheetNode {
         .await?;
 
         context.set_pin_value("result", json!(target)).await?;
-        context
-            .set_pin_value("frames", json!(frame_count as i64))
-            .await?;
-        context
-            .set_pin_value("bytes_written", json!(bytes_written as i64))
-            .await?;
         context.set_pin_value("report", json!(report)).await?;
         context.activate_exec_pin("exec_out").await?;
         Ok(())

--- a/packages/catalog/media/src/video/utils/contact_sheet.rs
+++ b/packages/catalog/media/src/video/utils/contact_sheet.rs
@@ -1,0 +1,216 @@
+use super::*;
+
+#[crate::register_node]
+#[derive(Default)]
+pub struct ContactSheetNode;
+
+impl ContactSheetNode {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl NodeLogic for ContactSheetNode {
+    fn get_node(&self) -> Node {
+        let mut node = Node::new(
+            "video_contact_sheet",
+            "Contact Sheet",
+            "Sample decoded frames and write a preview grid image",
+            "Video/Preview",
+        );
+        add_video_icon_and_scores(&mut node);
+        add_exec_pins(&mut node);
+        add_flow_path_input(&mut node, "source", "Source", "Source media FlowPath");
+        add_flow_path_input(&mut node, "target", "Target", "Target image FlowPath");
+        node.add_input_pin(
+            "max_frames",
+            "Max Frames",
+            "Maximum frames in the sheet",
+            VariableType::Integer,
+        )
+        .set_default_value(Some(json!(12)));
+        node.add_input_pin(
+            "every_n_frames",
+            "Every N Frames",
+            "Sampling interval in decoded frames",
+            VariableType::Integer,
+        )
+        .set_default_value(Some(json!(30)));
+        node.add_input_pin(
+            "columns",
+            "Columns",
+            "Grid column count",
+            VariableType::Integer,
+        )
+        .set_default_value(Some(json!(4)));
+        node.add_input_pin(
+            "cell_width",
+            "Cell Width",
+            "Cell width in pixels",
+            VariableType::Integer,
+        )
+        .set_default_value(Some(json!(160)));
+        node.add_input_pin(
+            "cell_height",
+            "Cell Height",
+            "Cell height in pixels",
+            VariableType::Integer,
+        )
+        .set_default_value(Some(json!(90)));
+        node.add_input_pin(
+            "video_track_id",
+            "Video Track",
+            "Video track id, or 0 for default",
+            VariableType::Integer,
+        )
+        .set_default_value(Some(json!(0)));
+        node.add_input_pin(
+            "format",
+            "Format",
+            "Output image format, or auto from target extension",
+            VariableType::String,
+        )
+        .set_default_value(Some(json!("auto")));
+        add_flow_path_output(
+            &mut node,
+            "result",
+            "Result",
+            "Written contact sheet FlowPath",
+        );
+        node.add_output_pin(
+            "report",
+            "Report",
+            "Contact sheet image report",
+            VariableType::Struct,
+        )
+        .set_schema::<ImageOperationReport>();
+        node.add_output_pin(
+            "frames",
+            "Frames",
+            "Frames written into the sheet",
+            VariableType::Integer,
+        );
+        node.add_output_pin(
+            "bytes_written",
+            "Bytes Written",
+            "Bytes written to the target",
+            VariableType::Integer,
+        );
+        node
+    }
+
+    #[cfg(feature = "execute")]
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        context.deactivate_exec_pin("exec_out").await?;
+        let source: FlowPath = context.evaluate_pin("source").await?;
+        let target: FlowPath = context.evaluate_pin("target").await?;
+        let max_frames: i64 = context.evaluate_pin("max_frames").await?;
+        let every_n_frames: i64 = context.evaluate_pin("every_n_frames").await?;
+        let columns: i64 = context.evaluate_pin("columns").await?;
+        let cell_width: i64 = context.evaluate_pin("cell_width").await?;
+        let cell_height: i64 = context.evaluate_pin("cell_height").await?;
+        let video_track_id: i64 = context.evaluate_pin("video_track_id").await?;
+        let format: String = context.evaluate_pin("format").await?;
+        let max_frames = usize::try_from(max_frames.max(1))?;
+        let every_n_frames = usize::try_from(every_n_frames.max(1))?;
+        let columns = u32::try_from(columns.max(1))?;
+        let cell_width = u32::try_from(cell_width.max(1))?;
+        let cell_height = u32::try_from(cell_height.max(1))?;
+        let (source_store, source_location) = flow_path_object(context, &source).await?;
+        let (target_store, target_location) = flow_path_object(context, &target).await?;
+        let demuxed = video_utils_rs::demux_object(source_store.as_ref(), &source_location).await?;
+        let requested_track = optional_track_id(video_track_id)?;
+        let stream = selected_video_stream(&demuxed.media, requested_track)?;
+        let selected_track = stream.track_id;
+        let input_width = stream.width.unwrap_or(0);
+        let input_height = stream.height.unwrap_or(0);
+        let output_format = image_format_for_target(&format, &target_location)?;
+        let (output, report, frame_count) = {
+            let mut decoder = platform_video_decoder(stream)?;
+            let mut decoded_index = 0usize;
+            let mut frames = Vec::new();
+            for packet in demuxed
+                .packets
+                .iter()
+                .filter(|packet| packet.track_id == selected_track)
+            {
+                for frame in decoder.decode_packet(packet)? {
+                    if decoded_index.is_multiple_of(every_n_frames) {
+                        frames.push(frame);
+                        if frames.len() >= max_frames {
+                            break;
+                        }
+                    }
+                    decoded_index += 1;
+                }
+                if frames.len() >= max_frames {
+                    break;
+                }
+            }
+            if frames.len() < max_frames {
+                for frame in decoder.flush()? {
+                    if decoded_index.is_multiple_of(every_n_frames) {
+                        frames.push(frame);
+                        if frames.len() >= max_frames {
+                            break;
+                        }
+                    }
+                    decoded_index += 1;
+                }
+            }
+            if frames.is_empty() {
+                return Err(flow_like_types::anyhow!("No video frames were decoded"));
+            }
+
+            let rows = ((frames.len() as u32) + columns - 1) / columns;
+            let mut sheet = video_utils_rs::RgbaFrame::solid(
+                columns * cell_width,
+                rows * cell_height,
+                [0, 0, 0, 255],
+            );
+            for (index, frame) in frames.iter().enumerate() {
+                let resized = frame.resize_nearest(cell_width, cell_height)?;
+                let x = (index as u32 % columns) * cell_width;
+                let y = (index as u32 / columns) * cell_height;
+                sheet.overlay(&resized, x as i32, y as i32);
+            }
+            let mut encoder = image_encoder(output_format);
+            let output = encoder.encode(&sheet)?;
+            let report = ImageOperationReport {
+                source: source_location.to_string(),
+                target: target_location.to_string(),
+                input_width,
+                input_height,
+                output_width: sheet.width,
+                output_height: sheet.height,
+                output_format: image_format_name(output_format).to_owned(),
+                bytes_written: output.len() as u64,
+            };
+            (output, report, frames.len())
+        };
+        let bytes_written = output.len() as u64;
+        video_utils_rs::write_object_bytes(
+            target_store.as_ref(),
+            &target_location,
+            Bytes::from(output),
+        )
+        .await?;
+
+        context.set_pin_value("result", json!(target)).await?;
+        context
+            .set_pin_value("frames", json!(frame_count as i64))
+            .await?;
+        context
+            .set_pin_value("bytes_written", json!(bytes_written as i64))
+            .await?;
+        context.set_pin_value("report", json!(report)).await?;
+        context.activate_exec_pin("exec_out").await?;
+        Ok(())
+    }
+
+    #[cfg(not(feature = "execute"))]
+    async fn run(&self, _context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        Err(execute_feature_error())
+    }
+}

--- a/packages/catalog/media/src/video/utils/convert_image_format.rs
+++ b/packages/catalog/media/src/video/utils/convert_image_format.rs
@@ -1,0 +1,96 @@
+use super::*;
+
+#[crate::register_node]
+#[derive(Default)]
+pub struct ConvertImageFormatNode;
+
+impl ConvertImageFormatNode {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl NodeLogic for ConvertImageFormatNode {
+    fn get_node(&self) -> Node {
+        let mut node = Node::new(
+            "video_convert_image_format",
+            "Convert Image Format",
+            "Decode a still image and write it as PNG, JPEG, GIF, WebP, or AVIF",
+            "Image",
+        );
+        add_video_icon_and_scores(&mut node);
+        add_exec_pins(&mut node);
+        add_flow_path_input(&mut node, "source", "Source", "Source image FlowPath");
+        add_flow_path_input(&mut node, "target", "Target", "Target image FlowPath");
+        node.add_input_pin(
+            "format",
+            "Format",
+            "Output image format, or auto from target extension",
+            VariableType::String,
+        )
+        .set_default_value(Some(json!("auto")));
+        add_flow_path_output(&mut node, "result", "Result", "Written image FlowPath");
+        node.add_output_pin(
+            "report",
+            "Report",
+            "Image conversion report",
+            VariableType::Struct,
+        )
+        .set_schema::<ImageOperationReport>();
+        node.add_output_pin(
+            "bytes_written",
+            "Bytes Written",
+            "Bytes written to the target",
+            VariableType::Integer,
+        );
+        node
+    }
+
+    #[cfg(feature = "execute")]
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        context.deactivate_exec_pin("exec_out").await?;
+        let source: FlowPath = context.evaluate_pin("source").await?;
+        let target: FlowPath = context.evaluate_pin("target").await?;
+        let format: String = context.evaluate_pin("format").await?;
+        let (source_store, source_location) = flow_path_object(context, &source).await?;
+        let (target_store, target_location) = flow_path_object(context, &target).await?;
+        let bytes =
+            video_utils_rs::read_object_bytes(source_store.as_ref(), &source_location).await?;
+        let mut decoder = video_utils_rs::ImageRgbaDecoder::new();
+        let frame = decoder.decode(&bytes)?;
+        let output_format = image_format_for_target(&format, &target_location)?;
+        let mut encoder = image_encoder(output_format);
+        let output = encoder.encode(&frame)?;
+        let bytes_written = output.len() as u64;
+        video_utils_rs::write_object_bytes(
+            target_store.as_ref(),
+            &target_location,
+            Bytes::from(output),
+        )
+        .await?;
+
+        let report = ImageOperationReport {
+            source: source_location.to_string(),
+            target: target_location.to_string(),
+            input_width: frame.width,
+            input_height: frame.height,
+            output_width: frame.width,
+            output_height: frame.height,
+            output_format: image_format_name(output_format).to_owned(),
+            bytes_written,
+        };
+        context.set_pin_value("result", json!(target)).await?;
+        context
+            .set_pin_value("bytes_written", json!(bytes_written as i64))
+            .await?;
+        context.set_pin_value("report", json!(report)).await?;
+        context.activate_exec_pin("exec_out").await?;
+        Ok(())
+    }
+
+    #[cfg(not(feature = "execute"))]
+    async fn run(&self, _context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        Err(execute_feature_error())
+    }
+}

--- a/packages/catalog/media/src/video/utils/convert_image_format.rs
+++ b/packages/catalog/media/src/video/utils/convert_image_format.rs
@@ -38,12 +38,6 @@ impl NodeLogic for ConvertImageFormatNode {
             VariableType::Struct,
         )
         .set_schema::<ImageOperationReport>();
-        node.add_output_pin(
-            "bytes_written",
-            "Bytes Written",
-            "Bytes written to the target",
-            VariableType::Integer,
-        );
         node
     }
 
@@ -81,9 +75,6 @@ impl NodeLogic for ConvertImageFormatNode {
             bytes_written,
         };
         context.set_pin_value("result", json!(target)).await?;
-        context
-            .set_pin_value("bytes_written", json!(bytes_written as i64))
-            .await?;
         context.set_pin_value("report", json!(report)).await?;
         context.activate_exec_pin("exec_out").await?;
         Ok(())

--- a/packages/catalog/media/src/video/utils/detect_container.rs
+++ b/packages/catalog/media/src/video/utils/detect_container.rs
@@ -1,0 +1,72 @@
+use super::*;
+
+#[crate::register_node]
+#[derive(Default)]
+pub struct DetectVideoContainerNode;
+
+impl DetectVideoContainerNode {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl NodeLogic for DetectVideoContainerNode {
+    fn get_node(&self) -> Node {
+        let mut node = Node::new(
+            "video_detect_container",
+            "Detect Video Container",
+            "Detect the media container for a FlowPath object",
+            "Video/Inspect",
+        );
+        add_video_icon_and_scores(&mut node);
+        add_exec_pins(&mut node);
+        add_flow_path_input(&mut node, "source", "Source", "Media FlowPath to inspect");
+        node.add_output_pin(
+            "format",
+            "Format",
+            "Stable container identifier",
+            VariableType::String,
+        );
+        node.add_output_pin(
+            "display_name",
+            "Display Name",
+            "Human readable container name",
+            VariableType::String,
+        );
+        node.add_output_pin(
+            "extensions",
+            "Extensions",
+            "Common file extensions",
+            VariableType::String,
+        )
+        .set_value_type(ValueType::Array);
+        node
+    }
+
+    #[cfg(feature = "execute")]
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        context.deactivate_exec_pin("exec_out").await?;
+        let source: FlowPath = context.evaluate_pin("source").await?;
+        let (store, location) = flow_path_object(context, &source).await?;
+        let format =
+            video_utils_rs::detect_object_container_format(store.as_ref(), &location).await?;
+
+        context
+            .set_pin_value("format", json!(format.as_str()))
+            .await?;
+        context
+            .set_pin_value("display_name", json!(format.display_name()))
+            .await?;
+        context
+            .set_pin_value("extensions", json!(format.extensions()))
+            .await?;
+        context.activate_exec_pin("exec_out").await?;
+        Ok(())
+    }
+
+    #[cfg(not(feature = "execute"))]
+    async fn run(&self, _context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        Err(execute_feature_error())
+    }
+}

--- a/packages/catalog/media/src/video/utils/detect_container.rs
+++ b/packages/catalog/media/src/video/utils/detect_container.rs
@@ -23,24 +23,12 @@ impl NodeLogic for DetectVideoContainerNode {
         add_exec_pins(&mut node);
         add_flow_path_input(&mut node, "source", "Source", "Media FlowPath to inspect");
         node.add_output_pin(
-            "format",
-            "Format",
-            "Stable container identifier",
-            VariableType::String,
-        );
-        node.add_output_pin(
-            "display_name",
-            "Display Name",
-            "Human readable container name",
-            VariableType::String,
-        );
-        node.add_output_pin(
-            "extensions",
-            "Extensions",
-            "Common file extensions",
-            VariableType::String,
+            "container",
+            "Container",
+            "Detected media container",
+            VariableType::Struct,
         )
-        .set_value_type(ValueType::Array);
+        .set_schema::<ContainerDetectionInfo>();
         node
     }
 
@@ -51,16 +39,17 @@ impl NodeLogic for DetectVideoContainerNode {
         let (store, location) = flow_path_object(context, &source).await?;
         let format =
             video_utils_rs::detect_object_container_format(store.as_ref(), &location).await?;
+        let container = ContainerDetectionInfo {
+            format: format.as_str().to_owned(),
+            display_name: format.display_name().to_owned(),
+            extensions: format
+                .extensions()
+                .iter()
+                .map(|extension| (*extension).to_owned())
+                .collect(),
+        };
 
-        context
-            .set_pin_value("format", json!(format.as_str()))
-            .await?;
-        context
-            .set_pin_value("display_name", json!(format.display_name()))
-            .await?;
-        context
-            .set_pin_value("extensions", json!(format.extensions()))
-            .await?;
+        context.set_pin_value("container", json!(container)).await?;
         context.activate_exec_pin("exec_out").await?;
         Ok(())
     }

--- a/packages/catalog/media/src/video/utils/detect_silence.rs
+++ b/packages/catalog/media/src/video/utils/detect_silence.rs
@@ -1,0 +1,102 @@
+use super::*;
+
+#[crate::register_node]
+#[derive(Default)]
+pub struct DetectSilenceNode;
+
+impl DetectSilenceNode {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl NodeLogic for DetectSilenceNode {
+    fn get_node(&self) -> Node {
+        let mut node = Node::new(
+            "video_detect_silence",
+            "Detect Silence",
+            "Decode audio and return silence intervals",
+            "Audio",
+        );
+        add_video_icon_and_scores(&mut node);
+        add_exec_pins(&mut node);
+        add_flow_path_input(&mut node, "source", "Source", "Source audio/media FlowPath");
+        node.add_input_pin(
+            "silence_threshold_db",
+            "Silence dB",
+            "RMS threshold in dB",
+            VariableType::Float,
+        )
+        .set_default_value(Some(json!(-60.0)));
+        node.add_input_pin(
+            "window_ms",
+            "Window ms",
+            "Silence analysis window",
+            VariableType::Integer,
+        )
+        .set_default_value(Some(json!(20)));
+        node.add_input_pin(
+            "min_silence_ms",
+            "Min Silence ms",
+            "Minimum silence duration",
+            VariableType::Integer,
+        )
+        .set_default_value(Some(json!(500)));
+        node.add_output_pin(
+            "silence",
+            "Silence",
+            "Detected silence ranges",
+            VariableType::Struct,
+        )
+        .set_schema::<SilenceRangeInfo>()
+        .set_value_type(ValueType::Array);
+        node.add_output_pin(
+            "count",
+            "Count",
+            "Detected silence range count",
+            VariableType::Integer,
+        );
+        node
+    }
+
+    #[cfg(feature = "execute")]
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        context.deactivate_exec_pin("exec_out").await?;
+        let source: FlowPath = context.evaluate_pin("source").await?;
+        let silence_threshold_db: f64 = context.evaluate_pin("silence_threshold_db").await?;
+        let window_ms: i64 = context.evaluate_pin("window_ms").await?;
+        let min_silence_ms: i64 = context.evaluate_pin("min_silence_ms").await?;
+        let (store, location) = flow_path_object(context, &source).await?;
+        let frames = decode_audio_file(store.as_ref(), &location).await?;
+        let audio = concat_audio_frames(&frames)?;
+        let window_samples = ((window_ms.max(1) as f64 / 1000.0) * audio.sample_rate as f64)
+            .round()
+            .max(1.0) as usize;
+        let min_duration_samples = ((min_silence_ms.max(1) as f64 / 1000.0)
+            * audio.sample_rate as f64)
+            .round()
+            .max(1.0) as usize;
+        let silence = video_utils_rs::detect_silence(
+            &audio,
+            silence_threshold_db as f32,
+            window_samples,
+            min_duration_samples,
+        )?
+        .into_iter()
+        .map(|range| silence_range_info(range, audio.sample_rate))
+        .collect::<Vec<_>>();
+
+        context
+            .set_pin_value("count", json!(silence.len() as i64))
+            .await?;
+        context.set_pin_value("silence", json!(silence)).await?;
+        context.activate_exec_pin("exec_out").await?;
+        Ok(())
+    }
+
+    #[cfg(not(feature = "execute"))]
+    async fn run(&self, _context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        Err(execute_feature_error())
+    }
+}

--- a/packages/catalog/media/src/video/utils/encode_av1.rs
+++ b/packages/catalog/media/src/video/utils/encode_av1.rs
@@ -73,12 +73,6 @@ impl NodeLogic for EncodeAv1Node {
             VariableType::Struct,
         )
         .set_schema::<VideoTransformReport>();
-        node.add_output_pin(
-            "bytes_written",
-            "Bytes Written",
-            "Bytes written to the target",
-            VariableType::Integer,
-        );
         node
     }
 
@@ -153,9 +147,6 @@ impl NodeLogic for EncodeAv1Node {
         };
 
         context.set_pin_value("result", json!(target)).await?;
-        context
-            .set_pin_value("bytes_written", json!(report.bytes_written as i64))
-            .await?;
         context.set_pin_value("report", json!(report)).await?;
         context.activate_exec_pin("exec_out").await?;
         Ok(())

--- a/packages/catalog/media/src/video/utils/encode_av1.rs
+++ b/packages/catalog/media/src/video/utils/encode_av1.rs
@@ -1,0 +1,168 @@
+use super::*;
+
+#[crate::register_node]
+#[derive(Default)]
+pub struct EncodeAv1Node;
+
+impl EncodeAv1Node {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl NodeLogic for EncodeAv1Node {
+    fn get_node(&self) -> Node {
+        let mut node = Node::new(
+            "video_encode_av1",
+            "Encode AV1",
+            "Decode a selected video stream and encode it to AV1 with the Rust rav1e backend",
+            "Video/Transcode",
+        );
+        add_video_icon_and_scores(&mut node);
+        add_exec_pins(&mut node);
+        add_flow_path_input(&mut node, "source", "Source", "Source media FlowPath");
+        add_flow_path_input(&mut node, "target", "Target", "Target AV1 media FlowPath");
+        node.add_input_pin(
+            "video_track_id",
+            "Video Track",
+            "Video track id, or 0 for default",
+            VariableType::Integer,
+        )
+        .set_default_value(Some(json!(0)));
+        node.add_input_pin(
+            "preserve_non_video",
+            "Preserve Non-Video",
+            "Copy non-video packets when possible",
+            VariableType::Boolean,
+        )
+        .set_default_value(Some(json!(true)));
+        node.add_input_pin(
+            "speed",
+            "Speed",
+            "rav1e speed preset 0..10",
+            VariableType::Integer,
+        )
+        .set_default_value(Some(json!(10)));
+        node.add_input_pin(
+            "quantizer",
+            "Quantizer",
+            "rav1e quantizer 0..255",
+            VariableType::Integer,
+        )
+        .set_default_value(Some(json!(120)));
+        node.add_input_pin(
+            "max_key_frame_interval",
+            "Key Interval",
+            "Maximum keyframe interval",
+            VariableType::Integer,
+        )
+        .set_default_value(Some(json!(120)));
+        node.add_input_pin(
+            "threads",
+            "Threads",
+            "Worker threads, or 0 for rav1e default",
+            VariableType::Integer,
+        )
+        .set_default_value(Some(json!(0)));
+        add_flow_path_output(&mut node, "result", "Result", "Written AV1 media FlowPath");
+        node.add_output_pin(
+            "report",
+            "Report",
+            "AV1 encode report",
+            VariableType::Struct,
+        )
+        .set_schema::<VideoTransformReport>();
+        node.add_output_pin(
+            "bytes_written",
+            "Bytes Written",
+            "Bytes written to the target",
+            VariableType::Integer,
+        );
+        node
+    }
+
+    #[cfg(feature = "execute")]
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        context.deactivate_exec_pin("exec_out").await?;
+        let source: FlowPath = context.evaluate_pin("source").await?;
+        let target: FlowPath = context.evaluate_pin("target").await?;
+        let video_track_id: i64 = context.evaluate_pin("video_track_id").await?;
+        let preserve_non_video: bool = context.evaluate_pin("preserve_non_video").await?;
+        let speed: i64 = context.evaluate_pin("speed").await?;
+        let quantizer: i64 = context.evaluate_pin("quantizer").await?;
+        let max_key_frame_interval: i64 = context.evaluate_pin("max_key_frame_interval").await?;
+        let threads: i64 = context.evaluate_pin("threads").await?;
+        let (source_store, source_location) = flow_path_object(context, &source).await?;
+        let (target_store, target_location) = flow_path_object(context, &target).await?;
+        let demuxed = video_utils_rs::demux_object(source_store.as_ref(), &source_location).await?;
+        let requested_track = optional_track_id(video_track_id)?;
+        let stream = selected_video_stream(&demuxed.media, requested_track)?;
+        let track_id = stream.track_id;
+        let width = stream
+            .width
+            .ok_or_else(|| flow_like_types::anyhow!("Source video stream has no width"))?;
+        let height = stream
+            .height
+            .ok_or_else(|| flow_like_types::anyhow!("Source video stream has no height"))?;
+        let frame_duration = packet_frame_duration(&demuxed.packets, track_id);
+        let options = video_utils_rs::Rav1eAv1EncoderOptions::new()
+            .with_speed(u8::try_from(speed.clamp(0, 10))?)
+            .with_quantizer(usize::try_from(quantizer.clamp(0, 255))?)
+            .with_max_key_frame_interval(u64::try_from(max_key_frame_interval.max(0))?)
+            .with_threads(usize::try_from(threads.max(0))?);
+        let processed = {
+            let mut decoder = platform_video_decoder(stream)?;
+            let mut encoder = video_utils_rs::Rav1eAv1Encoder::with_options(
+                track_id,
+                width,
+                height,
+                stream.time_base,
+                frame_duration,
+                options,
+            )?;
+            let output_codec_config = Some(encoder.codec_config());
+            process_video_transform(
+                &demuxed,
+                track_id,
+                preserve_non_video,
+                &video_utils_rs::FrameTransformPipeline::new(),
+                &mut decoder,
+                &mut encoder,
+                output_codec_config,
+            )?
+        };
+        let mux_report = video_utils_rs::mux_object(
+            target_store.as_ref(),
+            &target_location,
+            &processed.media,
+            &processed.packets,
+        )
+        .await?;
+        let report = VideoTransformReport {
+            source: source_location.to_string(),
+            target: target_location.to_string(),
+            source_format: demuxed.format.as_str().to_owned(),
+            target_format: mux_report.target_format.as_str().to_owned(),
+            video_track_id: processed.video_track_id,
+            input_packets: processed.input_packets,
+            decoded_frames: processed.decoded_frames,
+            encoded_video_packets: processed.encoded_video_packets,
+            copied_packets: processed.copied_packets,
+            bytes_written: mux_report.bytes_written,
+        };
+
+        context.set_pin_value("result", json!(target)).await?;
+        context
+            .set_pin_value("bytes_written", json!(report.bytes_written as i64))
+            .await?;
+        context.set_pin_value("report", json!(report)).await?;
+        context.activate_exec_pin("exec_out").await?;
+        Ok(())
+    }
+
+    #[cfg(not(feature = "execute"))]
+    async fn run(&self, _context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        Err(execute_feature_error())
+    }
+}

--- a/packages/catalog/media/src/video/utils/extract_subtitle_track.rs
+++ b/packages/catalog/media/src/video/utils/extract_subtitle_track.rs
@@ -1,0 +1,96 @@
+use super::*;
+
+#[crate::register_node]
+#[derive(Default)]
+pub struct ExtractSubtitleTrackNode;
+
+impl ExtractSubtitleTrackNode {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl NodeLogic for ExtractSubtitleTrackNode {
+    fn get_node(&self) -> Node {
+        let mut node = Node::new(
+            "video_extract_subtitle_track",
+            "Extract Subtitle Track",
+            "Extract a subtitle track to an SRT or WebVTT sidecar",
+            "Subtitles",
+        );
+        node.add_icon("/flow/icons/text.svg");
+        add_exec_pins(&mut node);
+        add_flow_path_input(&mut node, "source", "Source", "Source media FlowPath");
+        add_flow_path_input(&mut node, "target", "Target", "Target sidecar FlowPath");
+        node.add_input_pin(
+            "format",
+            "Format",
+            "Output subtitle format",
+            VariableType::String,
+        )
+        .set_options(
+            PinOptions::new()
+                .set_valid_values(vec!["srt".to_owned(), "webvtt".to_owned()])
+                .build(),
+        )
+        .set_default_value(Some(json!("srt")));
+        node.add_input_pin(
+            "track_id",
+            "Track ID",
+            "Subtitle track id; 0 uses first subtitle track",
+            VariableType::Integer,
+        )
+        .set_default_value(Some(json!(0)));
+        add_flow_path_output(&mut node, "result", "Result", "Written sidecar FlowPath");
+        node.add_output_pin(
+            "event_count",
+            "Event Count",
+            "Extracted subtitle event count",
+            VariableType::Integer,
+        );
+        node.add_output_pin(
+            "subtitle_track_id",
+            "Subtitle Track",
+            "Extracted subtitle track id",
+            VariableType::Integer,
+        );
+        node
+    }
+
+    #[cfg(feature = "execute")]
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        context.deactivate_exec_pin("exec_out").await?;
+        let source: FlowPath = context.evaluate_pin("source").await?;
+        let target: FlowPath = context.evaluate_pin("target").await?;
+        let format: String = context.evaluate_pin("format").await?;
+        let track_id: i64 = context.evaluate_pin("track_id").await?;
+        let format = subtitle_format(&format)?;
+        let (source_store, source_location) = flow_path_object(context, &source).await?;
+        let (target_store, target_location) = flow_path_object(context, &target).await?;
+        let report = video_utils_rs::extract_subtitle_track_to_sidecar_between_stores(
+            source_store.as_ref(),
+            &source_location,
+            target_store.as_ref(),
+            &target_location,
+            optional_track_id(track_id)?,
+            format,
+        )
+        .await?;
+
+        context.set_pin_value("result", json!(target)).await?;
+        context
+            .set_pin_value("event_count", json!(report.event_count as i64))
+            .await?;
+        context
+            .set_pin_value("subtitle_track_id", json!(report.subtitle_track_id as i64))
+            .await?;
+        context.activate_exec_pin("exec_out").await?;
+        Ok(())
+    }
+
+    #[cfg(not(feature = "execute"))]
+    async fn run(&self, _context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        Err(execute_feature_error())
+    }
+}

--- a/packages/catalog/media/src/video/utils/extract_subtitle_track.rs
+++ b/packages/catalog/media/src/video/utils/extract_subtitle_track.rs
@@ -44,17 +44,12 @@ impl NodeLogic for ExtractSubtitleTrackNode {
         .set_default_value(Some(json!(0)));
         add_flow_path_output(&mut node, "result", "Result", "Written sidecar FlowPath");
         node.add_output_pin(
-            "event_count",
-            "Event Count",
-            "Extracted subtitle event count",
-            VariableType::Integer,
-        );
-        node.add_output_pin(
-            "subtitle_track_id",
-            "Subtitle Track",
-            "Extracted subtitle track id",
-            VariableType::Integer,
-        );
+            "report",
+            "Report",
+            "Subtitle extraction report",
+            VariableType::Struct,
+        )
+        .set_schema::<SubtitleTrackExtractReport>();
         node
     }
 
@@ -68,7 +63,7 @@ impl NodeLogic for ExtractSubtitleTrackNode {
         let format = subtitle_format(&format)?;
         let (source_store, source_location) = flow_path_object(context, &source).await?;
         let (target_store, target_location) = flow_path_object(context, &target).await?;
-        let report = video_utils_rs::extract_subtitle_track_to_sidecar_between_stores(
+        let subtitle_report = video_utils_rs::extract_subtitle_track_to_sidecar_between_stores(
             source_store.as_ref(),
             &source_location,
             target_store.as_ref(),
@@ -77,14 +72,15 @@ impl NodeLogic for ExtractSubtitleTrackNode {
             format,
         )
         .await?;
+        let report = SubtitleTrackExtractReport {
+            source: source_location.to_string(),
+            target: target_location.to_string(),
+            subtitle_track_id: subtitle_report.subtitle_track_id,
+            event_count: subtitle_report.event_count,
+        };
 
         context.set_pin_value("result", json!(target)).await?;
-        context
-            .set_pin_value("event_count", json!(report.event_count as i64))
-            .await?;
-        context
-            .set_pin_value("subtitle_track_id", json!(report.subtitle_track_id as i64))
-            .await?;
+        context.set_pin_value("report", json!(report)).await?;
         context.activate_exec_pin("exec_out").await?;
         Ok(())
     }

--- a/packages/catalog/media/src/video/utils/extract_thumbnail.rs
+++ b/packages/catalog/media/src/video/utils/extract_thumbnail.rs
@@ -1,0 +1,174 @@
+use super::*;
+
+#[crate::register_node]
+#[derive(Default)]
+pub struct ExtractThumbnailNode;
+
+impl ExtractThumbnailNode {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl NodeLogic for ExtractThumbnailNode {
+    fn get_node(&self) -> Node {
+        let mut node = Node::new(
+            "video_extract_thumbnail",
+            "Extract Thumbnail",
+            "Decode a video frame and write it as a still image",
+            "Video/Preview",
+        );
+        add_video_icon_and_scores(&mut node);
+        add_exec_pins(&mut node);
+        add_flow_path_input(&mut node, "source", "Source", "Source media FlowPath");
+        add_flow_path_input(&mut node, "target", "Target", "Target image FlowPath");
+        node.add_input_pin(
+            "frame_index",
+            "Frame Index",
+            "Decoded frame index to export",
+            VariableType::Integer,
+        )
+        .set_default_value(Some(json!(0)));
+        node.add_input_pin(
+            "video_track_id",
+            "Video Track",
+            "Video track id, or 0 for default",
+            VariableType::Integer,
+        )
+        .set_default_value(Some(json!(0)));
+        node.add_input_pin(
+            "format",
+            "Format",
+            "Output image format, or auto from target extension",
+            VariableType::String,
+        )
+        .set_default_value(Some(json!("auto")));
+        node.add_input_pin(
+            "width",
+            "Width",
+            "Output width, or 0 to keep decoded width",
+            VariableType::Integer,
+        )
+        .set_default_value(Some(json!(0)));
+        node.add_input_pin(
+            "height",
+            "Height",
+            "Output height, or 0 to keep decoded height",
+            VariableType::Integer,
+        )
+        .set_default_value(Some(json!(0)));
+        add_flow_path_output(&mut node, "result", "Result", "Written image FlowPath");
+        node.add_output_pin("report", "Report", "Thumbnail report", VariableType::Struct)
+            .set_schema::<ImageOperationReport>();
+        node.add_output_pin(
+            "decoded_frames",
+            "Decoded Frames",
+            "Frames decoded before export",
+            VariableType::Integer,
+        );
+        node.add_output_pin(
+            "bytes_written",
+            "Bytes Written",
+            "Bytes written to the target",
+            VariableType::Integer,
+        );
+        node
+    }
+
+    #[cfg(feature = "execute")]
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        context.deactivate_exec_pin("exec_out").await?;
+        let source: FlowPath = context.evaluate_pin("source").await?;
+        let target: FlowPath = context.evaluate_pin("target").await?;
+        let frame_index: i64 = context.evaluate_pin("frame_index").await?;
+        let video_track_id: i64 = context.evaluate_pin("video_track_id").await?;
+        let format: String = context.evaluate_pin("format").await?;
+        let width: i64 = context.evaluate_pin("width").await?;
+        let height: i64 = context.evaluate_pin("height").await?;
+        let frame_index = usize::try_from(frame_index.max(0))?;
+        let (source_store, source_location) = flow_path_object(context, &source).await?;
+        let (target_store, target_location) = flow_path_object(context, &target).await?;
+        let demuxed = video_utils_rs::demux_object(source_store.as_ref(), &source_location).await?;
+        let requested_track = optional_track_id(video_track_id)?;
+        let stream = selected_video_stream(&demuxed.media, requested_track)?;
+        let selected_track = stream.track_id;
+        let output_format = image_format_for_target(&format, &target_location)?;
+        let (output, report, decoded_count) = {
+            let mut decoder = platform_video_decoder(stream)?;
+            let mut decoded_count = 0usize;
+            let mut selected = None;
+            for packet in demuxed
+                .packets
+                .iter()
+                .filter(|packet| packet.track_id == selected_track)
+            {
+                for frame in decoder.decode_packet(packet)? {
+                    if decoded_count == frame_index {
+                        selected = Some(frame);
+                        break;
+                    }
+                    decoded_count += 1;
+                }
+                if selected.is_some() {
+                    break;
+                }
+            }
+            if selected.is_none() {
+                for frame in decoder.flush()? {
+                    if decoded_count == frame_index {
+                        selected = Some(frame);
+                        break;
+                    }
+                    decoded_count += 1;
+                }
+            }
+            let frame = selected.ok_or_else(|| {
+                flow_like_types::anyhow!("Frame index {} was not decoded", frame_index)
+            })?;
+            let input_width = frame.width;
+            let input_height = frame.height;
+            let output_frame = if width > 0 && height > 0 {
+                frame.resize_nearest(u32::try_from(width)?, u32::try_from(height)?)?
+            } else {
+                frame
+            };
+            let mut encoder = image_encoder(output_format);
+            let output = encoder.encode(&output_frame)?;
+            let report = ImageOperationReport {
+                source: source_location.to_string(),
+                target: target_location.to_string(),
+                input_width,
+                input_height,
+                output_width: output_frame.width,
+                output_height: output_frame.height,
+                output_format: image_format_name(output_format).to_owned(),
+                bytes_written: output.len() as u64,
+            };
+            (output, report, decoded_count)
+        };
+        let bytes_written = output.len() as u64;
+        video_utils_rs::write_object_bytes(
+            target_store.as_ref(),
+            &target_location,
+            Bytes::from(output),
+        )
+        .await?;
+
+        context.set_pin_value("result", json!(target)).await?;
+        context
+            .set_pin_value("decoded_frames", json!((decoded_count + 1) as i64))
+            .await?;
+        context
+            .set_pin_value("bytes_written", json!(bytes_written as i64))
+            .await?;
+        context.set_pin_value("report", json!(report)).await?;
+        context.activate_exec_pin("exec_out").await?;
+        Ok(())
+    }
+
+    #[cfg(not(feature = "execute"))]
+    async fn run(&self, _context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        Err(execute_feature_error())
+    }
+}

--- a/packages/catalog/media/src/video/utils/extract_thumbnail.rs
+++ b/packages/catalog/media/src/video/utils/extract_thumbnail.rs
@@ -60,19 +60,7 @@ impl NodeLogic for ExtractThumbnailNode {
         .set_default_value(Some(json!(0)));
         add_flow_path_output(&mut node, "result", "Result", "Written image FlowPath");
         node.add_output_pin("report", "Report", "Thumbnail report", VariableType::Struct)
-            .set_schema::<ImageOperationReport>();
-        node.add_output_pin(
-            "decoded_frames",
-            "Decoded Frames",
-            "Frames decoded before export",
-            VariableType::Integer,
-        );
-        node.add_output_pin(
-            "bytes_written",
-            "Bytes Written",
-            "Bytes written to the target",
-            VariableType::Integer,
-        );
+            .set_schema::<VideoFrameExtractionReport>();
         node
     }
 
@@ -94,7 +82,7 @@ impl NodeLogic for ExtractThumbnailNode {
         let stream = selected_video_stream(&demuxed.media, requested_track)?;
         let selected_track = stream.track_id;
         let output_format = image_format_for_target(&format, &target_location)?;
-        let (output, report, decoded_count) = {
+        let (output, report) = {
             let mut decoder = platform_video_decoder(stream)?;
             let mut decoded_count = 0usize;
             let mut selected = None;
@@ -135,9 +123,12 @@ impl NodeLogic for ExtractThumbnailNode {
             };
             let mut encoder = image_encoder(output_format);
             let output = encoder.encode(&output_frame)?;
-            let report = ImageOperationReport {
+            let report = VideoFrameExtractionReport {
                 source: source_location.to_string(),
                 target: target_location.to_string(),
+                video_track_id: selected_track,
+                frame_index,
+                decoded_frames: decoded_count + 1,
                 input_width,
                 input_height,
                 output_width: output_frame.width,
@@ -145,9 +136,8 @@ impl NodeLogic for ExtractThumbnailNode {
                 output_format: image_format_name(output_format).to_owned(),
                 bytes_written: output.len() as u64,
             };
-            (output, report, decoded_count)
+            (output, report)
         };
-        let bytes_written = output.len() as u64;
         video_utils_rs::write_object_bytes(
             target_store.as_ref(),
             &target_location,
@@ -156,12 +146,6 @@ impl NodeLogic for ExtractThumbnailNode {
         .await?;
 
         context.set_pin_value("result", json!(target)).await?;
-        context
-            .set_pin_value("decoded_frames", json!((decoded_count + 1) as i64))
-            .await?;
-        context
-            .set_pin_value("bytes_written", json!(bytes_written as i64))
-            .await?;
         context.set_pin_value("report", json!(report)).await?;
         context.activate_exec_pin("exec_out").await?;
         Ok(())

--- a/packages/catalog/media/src/video/utils/extract_track.rs
+++ b/packages/catalog/media/src/video/utils/extract_track.rs
@@ -1,0 +1,96 @@
+use super::*;
+
+#[crate::register_node]
+#[derive(Default)]
+pub struct ExtractTrackNode;
+
+impl ExtractTrackNode {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl NodeLogic for ExtractTrackNode {
+    fn get_node(&self) -> Node {
+        let mut node = Node::new(
+            "video_extract_track",
+            "Extract Track",
+            "Write one encoded media track into a new container",
+            "Video/Tracks",
+        );
+        add_video_icon_and_scores(&mut node);
+        add_exec_pins(&mut node);
+        add_flow_path_input(&mut node, "source", "Source", "Source media FlowPath");
+        add_flow_path_input(&mut node, "target", "Target", "Target media FlowPath");
+        node.add_input_pin(
+            "track_id",
+            "Track ID",
+            "Track to keep",
+            VariableType::Integer,
+        )
+        .set_default_value(Some(json!(1)));
+        add_flow_path_output(&mut node, "result", "Result", "Written media FlowPath");
+        node.add_output_pin(
+            "packet_count",
+            "Packet Count",
+            "Packets written",
+            VariableType::Integer,
+        );
+        node.add_output_pin(
+            "stream",
+            "Stream",
+            "Extracted stream metadata",
+            VariableType::Struct,
+        )
+        .set_schema::<VideoStreamInfo>();
+        node
+    }
+
+    #[cfg(feature = "execute")]
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        context.deactivate_exec_pin("exec_out").await?;
+        let source: FlowPath = context.evaluate_pin("source").await?;
+        let target: FlowPath = context.evaluate_pin("target").await?;
+        let track_id: i64 = context.evaluate_pin("track_id").await?;
+        let track_id = u32::try_from(track_id)?;
+        let (source_store, source_location) = flow_path_object(context, &source).await?;
+        let (target_store, target_location) = flow_path_object(context, &target).await?;
+
+        let demuxed = video_utils_rs::demux_object(source_store.as_ref(), &source_location).await?;
+        let stream = demuxed
+            .media
+            .stream(track_id)
+            .ok_or_else(|| flow_like_types::anyhow!("Track {} is missing", track_id))?;
+        let packets = video_utils_rs::filter_track(&demuxed.packets, track_id);
+        if packets.is_empty() {
+            return Err(flow_like_types::anyhow!(
+                "Track {} has no encoded packets",
+                track_id
+            ));
+        }
+        let mut media = video_utils_rs::MediaInfo {
+            duration_seconds: stream.duration_seconds(),
+            tags: demuxed.media.tags.clone(),
+            ..Default::default()
+        };
+        media.push_stream(stream.clone());
+        let stream_info = stream_to_info(stream);
+        let report =
+            video_utils_rs::mux_object(target_store.as_ref(), &target_location, &media, &packets)
+                .await?;
+
+        context.set_pin_value("result", json!(target)).await?;
+        context
+            .set_pin_value("packet_count", json!(report.packet_count as i64))
+            .await?;
+        context.set_pin_value("stream", json!(stream_info)).await?;
+        context.activate_exec_pin("exec_out").await?;
+        Ok(())
+    }
+
+    #[cfg(not(feature = "execute"))]
+    async fn run(&self, _context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        Err(execute_feature_error())
+    }
+}

--- a/packages/catalog/media/src/video/utils/normalize_timestamps.rs
+++ b/packages/catalog/media/src/video/utils/normalize_timestamps.rs
@@ -1,0 +1,66 @@
+use super::*;
+
+#[crate::register_node]
+#[derive(Default)]
+pub struct NormalizePacketTimestampsNode;
+
+impl NormalizePacketTimestampsNode {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl NodeLogic for NormalizePacketTimestampsNode {
+    fn get_node(&self) -> Node {
+        let mut node = Node::new(
+            "video_normalize_timestamps",
+            "Normalize Timestamps",
+            "Rebase packet timestamps so each track starts at zero or later",
+            "Video/Packets",
+        );
+        add_video_icon_and_scores(&mut node);
+        add_exec_pins(&mut node);
+        add_flow_path_input(&mut node, "source", "Source", "Source media FlowPath");
+        add_flow_path_input(&mut node, "target", "Target", "Target media FlowPath");
+        add_flow_path_output(&mut node, "result", "Result", "Written media FlowPath");
+        node.add_output_pin(
+            "packet_count",
+            "Packet Count",
+            "Packets written",
+            VariableType::Integer,
+        );
+        node
+    }
+
+    #[cfg(feature = "execute")]
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        context.deactivate_exec_pin("exec_out").await?;
+        let source: FlowPath = context.evaluate_pin("source").await?;
+        let target: FlowPath = context.evaluate_pin("target").await?;
+        let (source_store, source_location) = flow_path_object(context, &source).await?;
+        let (target_store, target_location) = flow_path_object(context, &target).await?;
+        let demuxed = video_utils_rs::demux_object(source_store.as_ref(), &source_location).await?;
+        let mut packets = demuxed.packets;
+        video_utils_rs::normalize_timestamps(&mut packets)?;
+        let report = video_utils_rs::mux_object(
+            target_store.as_ref(),
+            &target_location,
+            &demuxed.media,
+            &packets,
+        )
+        .await?;
+
+        context.set_pin_value("result", json!(target)).await?;
+        context
+            .set_pin_value("packet_count", json!(report.packet_count as i64))
+            .await?;
+        context.activate_exec_pin("exec_out").await?;
+        Ok(())
+    }
+
+    #[cfg(not(feature = "execute"))]
+    async fn run(&self, _context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        Err(execute_feature_error())
+    }
+}

--- a/packages/catalog/media/src/video/utils/package_hls_vod.rs
+++ b/packages/catalog/media/src/video/utils/package_hls_vod.rs
@@ -1,0 +1,198 @@
+use super::*;
+
+#[crate::register_node]
+#[derive(Default)]
+pub struct PackageHlsVodNode;
+
+impl PackageHlsVodNode {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl NodeLogic for PackageHlsVodNode {
+    fn get_node(&self) -> Node {
+        let mut node = Node::new(
+            "video_package_hls_vod",
+            "Package HLS VOD",
+            "Write an HLS media playlist plus MPEG-TS or fMP4 segments",
+            "Streaming",
+        );
+        add_video_icon_and_scores(&mut node);
+        add_exec_pins(&mut node);
+        add_flow_path_input(&mut node, "source", "Source", "Source media FlowPath");
+        add_flow_path_input(&mut node, "playlist", "Playlist", "Target .m3u8 FlowPath");
+        node.add_input_pin(
+            "target_duration_seconds",
+            "Target Duration",
+            "Target segment duration in seconds",
+            VariableType::Float,
+        )
+        .set_default_value(Some(json!(6.0)));
+        node.add_input_pin(
+            "segment_format",
+            "Segment Format",
+            "Segment container format",
+            VariableType::String,
+        )
+        .set_options(
+            PinOptions::new()
+                .set_valid_values(vec!["mpeg_ts".to_owned(), "fmp4".to_owned()])
+                .build(),
+        )
+        .set_default_value(Some(json!("mpeg_ts")));
+        node.add_input_pin(
+            "segment_track_id",
+            "Segment Track",
+            "Track used for segment boundaries; 0 chooses first video/audio",
+            VariableType::Integer,
+        )
+        .set_default_value(Some(json!(0)));
+        node.add_input_pin(
+            "copy_all_tracks",
+            "Copy All Tracks",
+            "Include every stream in each segment",
+            VariableType::Boolean,
+        )
+        .set_default_value(Some(json!(true)));
+        node.add_input_pin(
+            "segment_prefix",
+            "Segment Prefix",
+            "Optional segment object-key prefix",
+            VariableType::String,
+        )
+        .set_default_value(Some(json!("")));
+        node.add_input_pin(
+            "init_segment_name",
+            "Init Segment",
+            "Optional fMP4 init segment name",
+            VariableType::String,
+        )
+        .set_default_value(Some(json!("")));
+        node.add_input_pin(
+            "uri_prefix",
+            "URI Prefix",
+            "Optional URI prefix written into playlist",
+            VariableType::String,
+        )
+        .set_default_value(Some(json!("")));
+        add_flow_path_output(
+            &mut node,
+            "playlist_out",
+            "Playlist",
+            "Written playlist FlowPath",
+        );
+        node.add_output_pin(
+            "segments",
+            "Segments",
+            "Written segment FlowPaths",
+            VariableType::Struct,
+        )
+        .set_schema::<FlowPath>()
+        .set_value_type(ValueType::Array);
+        node.add_output_pin(
+            "init_segment",
+            "Init Segment",
+            "Written fMP4 init segment FlowPath when present",
+            VariableType::Struct,
+        )
+        .set_schema::<FlowPath>();
+        node.add_output_pin(
+            "segment_count",
+            "Segment Count",
+            "Number of media segments",
+            VariableType::Integer,
+        );
+        node.add_output_pin(
+            "bytes_written",
+            "Bytes Written",
+            "Total bytes written",
+            VariableType::Integer,
+        );
+        node
+    }
+
+    #[cfg(feature = "execute")]
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        context.deactivate_exec_pin("exec_out").await?;
+        let source: FlowPath = context.evaluate_pin("source").await?;
+        let playlist: FlowPath = context.evaluate_pin("playlist").await?;
+        let target_duration_seconds: f64 = context.evaluate_pin("target_duration_seconds").await?;
+        let segment_format: String = context.evaluate_pin("segment_format").await?;
+        let segment_track_id: i64 = context.evaluate_pin("segment_track_id").await?;
+        let copy_all_tracks: bool = context.evaluate_pin("copy_all_tracks").await?;
+        let segment_prefix: String = context.evaluate_pin("segment_prefix").await?;
+        let init_segment_name: String = context.evaluate_pin("init_segment_name").await?;
+        let uri_prefix: String = context.evaluate_pin("uri_prefix").await?;
+        let (source_store, source_location) = flow_path_object(context, &source).await?;
+        let (playlist_store, playlist_location) = flow_path_object(context, &playlist).await?;
+
+        let mut job = video_utils_rs::ObjectHlsVodJob::new()
+            .with_target_duration(target_duration_seconds)
+            .copy_all_tracks(copy_all_tracks);
+        if let Some(track_id) = optional_track_id(segment_track_id)? {
+            job = job.with_segment_track(track_id);
+        }
+        job = match segment_format.trim().to_ascii_lowercase().as_str() {
+            "mpeg_ts" | "ts" => {
+                job.with_segment_format(video_utils_rs::HlsSegmentContainer::MpegTs)
+            }
+            "fmp4" | "mp4" => job.with_segment_format(video_utils_rs::HlsSegmentContainer::Mp4),
+            other => {
+                return Err(flow_like_types::anyhow!(
+                    "Unsupported HLS segment format: {}",
+                    other
+                ));
+            }
+        };
+        if let Some(segment_prefix) = clean_optional(segment_prefix) {
+            job = job.with_segment_prefix(segment_prefix);
+        }
+        if let Some(init_segment_name) = clean_optional(init_segment_name) {
+            job = job.with_init_segment_name(init_segment_name);
+        }
+        if let Some(uri_prefix) = clean_optional(uri_prefix) {
+            job = job.with_uri_prefix(uri_prefix);
+        }
+
+        let report = video_utils_rs::package_object_hls_vod_between_stores(
+            source_store.as_ref(),
+            &source_location,
+            playlist_store.as_ref(),
+            &playlist_location,
+            &job,
+        )
+        .await?;
+        let segments = report
+            .segments
+            .iter()
+            .map(|path| flow_path_from_object_path(path, &playlist))
+            .collect::<Vec<_>>();
+        let init_segment = report
+            .init_segment
+            .as_ref()
+            .map(|path| flow_path_from_object_path(path, &playlist));
+
+        context
+            .set_pin_value("playlist_out", json!(playlist))
+            .await?;
+        context.set_pin_value("segments", json!(segments)).await?;
+        context
+            .set_pin_value("init_segment", json!(init_segment))
+            .await?;
+        context
+            .set_pin_value("segment_count", json!(report.segment_count as i64))
+            .await?;
+        context
+            .set_pin_value("bytes_written", json!(report.bytes_written as i64))
+            .await?;
+        context.activate_exec_pin("exec_out").await?;
+        Ok(())
+    }
+
+    #[cfg(not(feature = "execute"))]
+    async fn run(&self, _context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        Err(execute_feature_error())
+    }
+}

--- a/packages/catalog/media/src/video/utils/package_hls_vod.rs
+++ b/packages/catalog/media/src/video/utils/package_hls_vod.rs
@@ -92,24 +92,12 @@ impl NodeLogic for PackageHlsVodNode {
         .set_schema::<FlowPath>()
         .set_value_type(ValueType::Array);
         node.add_output_pin(
-            "init_segment",
-            "Init Segment",
-            "Written fMP4 init segment FlowPath when present",
+            "report",
+            "Report",
+            "Written HLS package details",
             VariableType::Struct,
         )
-        .set_schema::<FlowPath>();
-        node.add_output_pin(
-            "segment_count",
-            "Segment Count",
-            "Number of media segments",
-            VariableType::Integer,
-        );
-        node.add_output_pin(
-            "bytes_written",
-            "Bytes Written",
-            "Total bytes written",
-            VariableType::Integer,
-        );
+        .set_schema::<HlsVodPackageReport>();
         node
     }
 
@@ -156,7 +144,7 @@ impl NodeLogic for PackageHlsVodNode {
             job = job.with_uri_prefix(uri_prefix);
         }
 
-        let report = video_utils_rs::package_object_hls_vod_between_stores(
+        let package_report = video_utils_rs::package_object_hls_vod_between_stores(
             source_store.as_ref(),
             &source_location,
             playlist_store.as_ref(),
@@ -164,29 +152,26 @@ impl NodeLogic for PackageHlsVodNode {
             &job,
         )
         .await?;
-        let segments = report
+        let segments = package_report
             .segments
             .iter()
             .map(|path| flow_path_from_object_path(path, &playlist))
             .collect::<Vec<_>>();
-        let init_segment = report
+        let init_segment = package_report
             .init_segment
             .as_ref()
             .map(|path| flow_path_from_object_path(path, &playlist));
+        let report = HlsVodPackageReport {
+            init_segment: init_segment.clone(),
+            segment_count: package_report.segment_count,
+            bytes_written: package_report.bytes_written,
+        };
 
         context
             .set_pin_value("playlist_out", json!(playlist))
             .await?;
         context.set_pin_value("segments", json!(segments)).await?;
-        context
-            .set_pin_value("init_segment", json!(init_segment))
-            .await?;
-        context
-            .set_pin_value("segment_count", json!(report.segment_count as i64))
-            .await?;
-        context
-            .set_pin_value("bytes_written", json!(report.bytes_written as i64))
-            .await?;
+        context.set_pin_value("report", json!(report)).await?;
         context.activate_exec_pin("exec_out").await?;
         Ok(())
     }

--- a/packages/catalog/media/src/video/utils/parse_subtitles.rs
+++ b/packages/catalog/media/src/video/utils/parse_subtitles.rs
@@ -1,0 +1,61 @@
+use super::*;
+
+#[crate::register_node]
+#[derive(Default)]
+pub struct ParseSubtitlesNode;
+
+impl ParseSubtitlesNode {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl NodeLogic for ParseSubtitlesNode {
+    fn get_node(&self) -> Node {
+        let mut node = Node::new(
+            "video_parse_subtitles",
+            "Parse Subtitles",
+            "Parse SRT or WebVTT sidecar subtitles into cue structs",
+            "Subtitles",
+        );
+        node.add_icon("/flow/icons/text.svg");
+        add_exec_pins(&mut node);
+        add_flow_path_input(&mut node, "sidecar", "Sidecar", "Subtitle sidecar FlowPath");
+        node.add_input_pin("format", "Format", "Subtitle format", VariableType::String)
+            .set_options(
+                PinOptions::new()
+                    .set_valid_values(vec!["srt".to_owned(), "webvtt".to_owned()])
+                    .build(),
+            )
+            .set_default_value(Some(json!("srt")));
+        node.add_output_pin("cues", "Cues", "Parsed subtitle cues", VariableType::Struct)
+            .set_schema::<SubtitleCue>()
+            .set_value_type(ValueType::Array);
+        node.add_output_pin("count", "Count", "Cue count", VariableType::Integer);
+        node
+    }
+
+    #[cfg(feature = "execute")]
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        context.deactivate_exec_pin("exec_out").await?;
+        let sidecar: FlowPath = context.evaluate_pin("sidecar").await?;
+        let format: String = context.evaluate_pin("format").await?;
+        let format = subtitle_format(&format)?;
+        let text = String::from_utf8(sidecar.get(context, false).await?)?;
+        let events = video_utils_rs::parse_subtitles(format, &text)?;
+        let cues = cues_from_events(&events);
+
+        context
+            .set_pin_value("count", json!(cues.len() as i64))
+            .await?;
+        context.set_pin_value("cues", json!(cues)).await?;
+        context.activate_exec_pin("exec_out").await?;
+        Ok(())
+    }
+
+    #[cfg(not(feature = "execute"))]
+    async fn run(&self, _context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        Err(execute_feature_error())
+    }
+}

--- a/packages/catalog/media/src/video/utils/pick_codec_backend.rs
+++ b/packages/catalog/media/src/video/utils/pick_codec_backend.rs
@@ -43,18 +43,6 @@ impl NodeLogic for PickCodecBackendNode {
         )
         .set_schema::<BackendSelectionInfo>();
         node.add_output_pin(
-            "backend",
-            "Backend",
-            "Preferred backend name",
-            VariableType::String,
-        );
-        node.add_output_pin(
-            "found",
-            "Found",
-            "True when a preferred backend exists",
-            VariableType::Boolean,
-        );
-        node.add_output_pin(
             "support",
             "Support",
             "Compiled codec support registry",
@@ -81,12 +69,6 @@ impl NodeLogic for PickCodecBackendNode {
             backend: backend.clone(),
         };
 
-        context
-            .set_pin_value("found", json!(selection.found))
-            .await?;
-        context
-            .set_pin_value("backend", json!(backend.unwrap_or_default()))
-            .await?;
         context.set_pin_value("selection", json!(selection)).await?;
         context
             .set_pin_value("support", json!(codec_support_info()))

--- a/packages/catalog/media/src/video/utils/pick_codec_backend.rs
+++ b/packages/catalog/media/src/video/utils/pick_codec_backend.rs
@@ -1,0 +1,102 @@
+use super::*;
+
+#[crate::register_node]
+#[derive(Default)]
+pub struct PickCodecBackendNode;
+
+impl PickCodecBackendNode {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl NodeLogic for PickCodecBackendNode {
+    fn get_node(&self) -> Node {
+        let mut node = Node::new(
+            "video_pick_codec_backend",
+            "Pick Codec Backend",
+            "Choose the preferred compiled backend for a codec and operation",
+            "Diagnostics",
+        );
+        node.add_icon("/flow/icons/info.svg");
+        add_exec_pins(&mut node);
+        node.add_input_pin(
+            "codec",
+            "Codec",
+            "Codec id such as h264, h265, av1, aac, or mp3",
+            VariableType::String,
+        )
+        .set_default_value(Some(json!("h264")));
+        node.add_input_pin(
+            "direction",
+            "Direction",
+            "decode or encode",
+            VariableType::String,
+        )
+        .set_default_value(Some(json!("decode")));
+        node.add_output_pin(
+            "selection",
+            "Selection",
+            "Preferred backend selection",
+            VariableType::Struct,
+        )
+        .set_schema::<BackendSelectionInfo>();
+        node.add_output_pin(
+            "backend",
+            "Backend",
+            "Preferred backend name",
+            VariableType::String,
+        );
+        node.add_output_pin(
+            "found",
+            "Found",
+            "True when a preferred backend exists",
+            VariableType::Boolean,
+        );
+        node.add_output_pin(
+            "support",
+            "Support",
+            "Compiled codec support registry",
+            VariableType::Struct,
+        )
+        .set_schema::<CodecSupportInfo>()
+        .set_value_type(ValueType::Array);
+        node
+    }
+
+    #[cfg(feature = "execute")]
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        context.deactivate_exec_pin("exec_out").await?;
+        let codec: String = context.evaluate_pin("codec").await?;
+        let direction: String = context.evaluate_pin("direction").await?;
+        let codec = codec_id(&codec);
+        let direction = codec_direction(&direction)?;
+        let backend = video_utils_rs::preferred_backend_for_codec(&codec, direction)
+            .map(|backend| format!("{backend:?}"));
+        let selection = BackendSelectionInfo {
+            codec: codec.to_string(),
+            direction: format!("{direction:?}").to_ascii_lowercase(),
+            found: backend.is_some(),
+            backend: backend.clone(),
+        };
+
+        context
+            .set_pin_value("found", json!(selection.found))
+            .await?;
+        context
+            .set_pin_value("backend", json!(backend.unwrap_or_default()))
+            .await?;
+        context.set_pin_value("selection", json!(selection)).await?;
+        context
+            .set_pin_value("support", json!(codec_support_info()))
+            .await?;
+        context.activate_exec_pin("exec_out").await?;
+        Ok(())
+    }
+
+    #[cfg(not(feature = "execute"))]
+    async fn run(&self, _context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        Err(execute_feature_error())
+    }
+}

--- a/packages/catalog/media/src/video/utils/probe_codec_backends.rs
+++ b/packages/catalog/media/src/video/utils/probe_codec_backends.rs
@@ -36,23 +36,15 @@ impl NodeLogic for ProbeCodecBackendsNode {
             VariableType::Struct,
         )
         .set_schema::<VideoUtilsFeatureSet>();
-        node.add_output_pin(
-            "backend_count",
-            "Backend Count",
-            "Number of backend lanes",
-            VariableType::Integer,
-        );
         node
     }
 
     #[cfg(feature = "execute")]
     async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
         context.deactivate_exec_pin("exec_out").await?;
-        let backends = backend_info();
         context
-            .set_pin_value("backend_count", json!(backends.len() as i64))
+            .set_pin_value("backends", json!(backend_info()))
             .await?;
-        context.set_pin_value("backends", json!(backends)).await?;
         context
             .set_pin_value("features", json!(feature_set()))
             .await?;

--- a/packages/catalog/media/src/video/utils/probe_codec_backends.rs
+++ b/packages/catalog/media/src/video/utils/probe_codec_backends.rs
@@ -1,0 +1,67 @@
+use super::*;
+
+#[crate::register_node]
+#[derive(Default)]
+pub struct ProbeCodecBackendsNode;
+
+impl ProbeCodecBackendsNode {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl NodeLogic for ProbeCodecBackendsNode {
+    fn get_node(&self) -> Node {
+        let mut node = Node::new(
+            "video_probe_codec_backends",
+            "Probe Codec Backends",
+            "Report compiled video-utils-rs features and recommended codec backend lanes",
+            "Diagnostics",
+        );
+        node.add_icon("/flow/icons/info.svg");
+        add_exec_pins(&mut node);
+        node.add_output_pin(
+            "backends",
+            "Backends",
+            "Recommended codec backends",
+            VariableType::Struct,
+        )
+        .set_schema::<CodecBackendInfo>()
+        .set_value_type(ValueType::Array);
+        node.add_output_pin(
+            "features",
+            "Features",
+            "Compiled video-utils-rs feature set",
+            VariableType::Struct,
+        )
+        .set_schema::<VideoUtilsFeatureSet>();
+        node.add_output_pin(
+            "backend_count",
+            "Backend Count",
+            "Number of backend lanes",
+            VariableType::Integer,
+        );
+        node
+    }
+
+    #[cfg(feature = "execute")]
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        context.deactivate_exec_pin("exec_out").await?;
+        let backends = backend_info();
+        context
+            .set_pin_value("backend_count", json!(backends.len() as i64))
+            .await?;
+        context.set_pin_value("backends", json!(backends)).await?;
+        context
+            .set_pin_value("features", json!(feature_set()))
+            .await?;
+        context.activate_exec_pin("exec_out").await?;
+        Ok(())
+    }
+
+    #[cfg(not(feature = "execute"))]
+    async fn run(&self, _context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        Err(execute_feature_error())
+    }
+}

--- a/packages/catalog/media/src/video/utils/probe_media_info.rs
+++ b/packages/catalog/media/src/video/utils/probe_media_info.rs
@@ -37,12 +37,6 @@ impl NodeLogic for ProbeMediaInfoNode {
         )
         .set_schema::<VideoStreamInfo>()
         .set_value_type(ValueType::Array);
-        node.add_output_pin(
-            "stream_count",
-            "Stream Count",
-            "Number of streams",
-            VariableType::Integer,
-        );
         node
     }
 
@@ -51,15 +45,16 @@ impl NodeLogic for ProbeMediaInfoNode {
         context.deactivate_exec_pin("exec_out").await?;
         let source: FlowPath = context.evaluate_pin("source").await?;
         let (store, location) = flow_path_object(context, &source).await?;
-        let media = video_utils_rs::probe_object_media_info(store.as_ref(), &location).await?;
-        let info = media_to_info(&media);
-        let stream_count = info.streams.len() as i64;
-
+        let info = match video_utils_rs::demux_object(store.as_ref(), &location).await {
+            Ok(demuxed) => media_to_info_with_packets(&demuxed.media, &demuxed.packets),
+            Err(_) => {
+                let media =
+                    video_utils_rs::probe_object_media_info(store.as_ref(), &location).await?;
+                media_to_info(&media)
+            }
+        };
         context
-            .set_pin_value("streams", json!(info.streams))
-            .await?;
-        context
-            .set_pin_value("stream_count", json!(stream_count))
+            .set_pin_value("streams", json!(info.streams.clone()))
             .await?;
         context.set_pin_value("media", json!(info)).await?;
         context.activate_exec_pin("exec_out").await?;

--- a/packages/catalog/media/src/video/utils/probe_media_info.rs
+++ b/packages/catalog/media/src/video/utils/probe_media_info.rs
@@ -1,0 +1,73 @@
+use super::*;
+
+#[crate::register_node]
+#[derive(Default)]
+pub struct ProbeMediaInfoNode;
+
+impl ProbeMediaInfoNode {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl NodeLogic for ProbeMediaInfoNode {
+    fn get_node(&self) -> Node {
+        let mut node = Node::new(
+            "video_probe_media_info",
+            "Probe Media Info",
+            "Extract stream metadata from a media FlowPath",
+            "Video/Inspect",
+        );
+        add_video_icon_and_scores(&mut node);
+        add_exec_pins(&mut node);
+        add_flow_path_input(&mut node, "source", "Source", "Media FlowPath to inspect");
+        node.add_output_pin(
+            "media",
+            "Media Info",
+            "Container and stream metadata",
+            VariableType::Struct,
+        )
+        .set_schema::<VideoMediaInfo>();
+        node.add_output_pin(
+            "streams",
+            "Streams",
+            "Detected media streams",
+            VariableType::Struct,
+        )
+        .set_schema::<VideoStreamInfo>()
+        .set_value_type(ValueType::Array);
+        node.add_output_pin(
+            "stream_count",
+            "Stream Count",
+            "Number of streams",
+            VariableType::Integer,
+        );
+        node
+    }
+
+    #[cfg(feature = "execute")]
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        context.deactivate_exec_pin("exec_out").await?;
+        let source: FlowPath = context.evaluate_pin("source").await?;
+        let (store, location) = flow_path_object(context, &source).await?;
+        let media = video_utils_rs::probe_object_media_info(store.as_ref(), &location).await?;
+        let info = media_to_info(&media);
+        let stream_count = info.streams.len() as i64;
+
+        context
+            .set_pin_value("streams", json!(info.streams))
+            .await?;
+        context
+            .set_pin_value("stream_count", json!(stream_count))
+            .await?;
+        context.set_pin_value("media", json!(info)).await?;
+        context.activate_exec_pin("exec_out").await?;
+        Ok(())
+    }
+
+    #[cfg(not(feature = "execute"))]
+    async fn run(&self, _context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        Err(execute_feature_error())
+    }
+}

--- a/packages/catalog/media/src/video/utils/probe_platform_codec.rs
+++ b/packages/catalog/media/src/video/utils/probe_platform_codec.rs
@@ -1,0 +1,86 @@
+use super::*;
+
+#[crate::register_node]
+#[derive(Default)]
+pub struct ProbePlatformCodecNode;
+
+impl ProbePlatformCodecNode {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl NodeLogic for ProbePlatformCodecNode {
+    fn get_node(&self) -> Node {
+        let mut node = Node::new(
+            "video_probe_platform_codec",
+            "Probe Platform Codec",
+            "Check whether the current host can decode or encode a codec through native platform APIs",
+            "Diagnostics",
+        );
+        node.add_icon("/flow/icons/info.svg");
+        add_exec_pins(&mut node);
+        node.add_input_pin(
+            "codec",
+            "Codec",
+            "Codec id such as h264, h265, av1, aac, or mp3",
+            VariableType::String,
+        )
+        .set_default_value(Some(json!("h264")));
+        node.add_input_pin(
+            "direction",
+            "Direction",
+            "decode or encode",
+            VariableType::String,
+        )
+        .set_default_value(Some(json!("decode")));
+        node.add_output_pin(
+            "probe",
+            "Probe",
+            "Platform codec probe result",
+            VariableType::Struct,
+        )
+        .set_schema::<PlatformCodecProbeInfo>();
+        node.add_output_pin(
+            "supported",
+            "Supported",
+            "True when a matching native backend is available",
+            VariableType::Boolean,
+        );
+        node.add_output_pin(
+            "backend",
+            "Backend",
+            "Selected backend name when available",
+            VariableType::String,
+        );
+        node
+    }
+
+    #[cfg(feature = "execute")]
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        context.deactivate_exec_pin("exec_out").await?;
+        let codec: String = context.evaluate_pin("codec").await?;
+        let direction: String = context.evaluate_pin("direction").await?;
+        let direction = codec_direction(&direction)?;
+        let probe = platform_probe_info(video_utils_rs::probe_platform_codec(
+            &codec_id(&codec),
+            direction,
+        ));
+
+        context
+            .set_pin_value("supported", json!(probe.supported))
+            .await?;
+        context
+            .set_pin_value("backend", json!(probe.backend.clone().unwrap_or_default()))
+            .await?;
+        context.set_pin_value("probe", json!(probe)).await?;
+        context.activate_exec_pin("exec_out").await?;
+        Ok(())
+    }
+
+    #[cfg(not(feature = "execute"))]
+    async fn run(&self, _context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        Err(execute_feature_error())
+    }
+}

--- a/packages/catalog/media/src/video/utils/probe_platform_codec.rs
+++ b/packages/catalog/media/src/video/utils/probe_platform_codec.rs
@@ -42,18 +42,6 @@ impl NodeLogic for ProbePlatformCodecNode {
             VariableType::Struct,
         )
         .set_schema::<PlatformCodecProbeInfo>();
-        node.add_output_pin(
-            "supported",
-            "Supported",
-            "True when a matching native backend is available",
-            VariableType::Boolean,
-        );
-        node.add_output_pin(
-            "backend",
-            "Backend",
-            "Selected backend name when available",
-            VariableType::String,
-        );
         node
     }
 
@@ -68,12 +56,6 @@ impl NodeLogic for ProbePlatformCodecNode {
             direction,
         ));
 
-        context
-            .set_pin_value("supported", json!(probe.supported))
-            .await?;
-        context
-            .set_pin_value("backend", json!(probe.backend.clone().unwrap_or_default()))
-            .await?;
         context.set_pin_value("probe", json!(probe)).await?;
         context.activate_exec_pin("exec_out").await?;
         Ok(())

--- a/packages/catalog/media/src/video/utils/remux.rs
+++ b/packages/catalog/media/src/video/utils/remux.rs
@@ -25,17 +25,12 @@ impl NodeLogic for RemuxVideoNode {
         add_flow_path_input(&mut node, "target", "Target", "Target media FlowPath");
         add_flow_path_output(&mut node, "result", "Result", "Written media FlowPath");
         node.add_output_pin(
-            "bytes_written",
-            "Bytes Written",
-            "Bytes written to the target",
-            VariableType::Integer,
-        );
-        node.add_output_pin(
-            "operation",
-            "Operation",
-            "Object-store remux operation used",
-            VariableType::String,
-        );
+            "report",
+            "Report",
+            "Remux operation report",
+            VariableType::Struct,
+        )
+        .set_schema::<VideoRemuxReport>();
         node
     }
 
@@ -46,7 +41,7 @@ impl NodeLogic for RemuxVideoNode {
         let target: FlowPath = context.evaluate_pin("target").await?;
         let (source_store, source_location) = flow_path_object(context, &source).await?;
         let (target_store, target_location) = flow_path_object(context, &target).await?;
-        let report = video_utils_rs::remux_object_between_stores(
+        let remux_report = video_utils_rs::remux_object_between_stores(
             source_store.as_ref(),
             &source_location,
             target_store.as_ref(),
@@ -54,14 +49,15 @@ impl NodeLogic for RemuxVideoNode {
             None,
         )
         .await?;
+        let report = VideoRemuxReport {
+            source: source_location.to_string(),
+            target: target_location.to_string(),
+            operation: format!("{:?}", remux_report.operation),
+            bytes_written: remux_report.bytes_written,
+        };
 
         context.set_pin_value("result", json!(target)).await?;
-        context
-            .set_pin_value("bytes_written", json!(report.bytes_written as i64))
-            .await?;
-        context
-            .set_pin_value("operation", json!(format!("{:?}", report.operation)))
-            .await?;
+        context.set_pin_value("report", json!(report)).await?;
         context.activate_exec_pin("exec_out").await?;
         Ok(())
     }

--- a/packages/catalog/media/src/video/utils/remux.rs
+++ b/packages/catalog/media/src/video/utils/remux.rs
@@ -1,0 +1,73 @@
+use super::*;
+
+#[crate::register_node]
+#[derive(Default)]
+pub struct RemuxVideoNode;
+
+impl RemuxVideoNode {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl NodeLogic for RemuxVideoNode {
+    fn get_node(&self) -> Node {
+        let mut node = Node::new(
+            "video_remux",
+            "Remux Video",
+            "Rewrap compatible streams into another container without decoding",
+            "Video/Containers",
+        );
+        add_video_icon_and_scores(&mut node);
+        add_exec_pins(&mut node);
+        add_flow_path_input(&mut node, "source", "Source", "Source media FlowPath");
+        add_flow_path_input(&mut node, "target", "Target", "Target media FlowPath");
+        add_flow_path_output(&mut node, "result", "Result", "Written media FlowPath");
+        node.add_output_pin(
+            "bytes_written",
+            "Bytes Written",
+            "Bytes written to the target",
+            VariableType::Integer,
+        );
+        node.add_output_pin(
+            "operation",
+            "Operation",
+            "Object-store remux operation used",
+            VariableType::String,
+        );
+        node
+    }
+
+    #[cfg(feature = "execute")]
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        context.deactivate_exec_pin("exec_out").await?;
+        let source: FlowPath = context.evaluate_pin("source").await?;
+        let target: FlowPath = context.evaluate_pin("target").await?;
+        let (source_store, source_location) = flow_path_object(context, &source).await?;
+        let (target_store, target_location) = flow_path_object(context, &target).await?;
+        let report = video_utils_rs::remux_object_between_stores(
+            source_store.as_ref(),
+            &source_location,
+            target_store.as_ref(),
+            &target_location,
+            None,
+        )
+        .await?;
+
+        context.set_pin_value("result", json!(target)).await?;
+        context
+            .set_pin_value("bytes_written", json!(report.bytes_written as i64))
+            .await?;
+        context
+            .set_pin_value("operation", json!(format!("{:?}", report.operation)))
+            .await?;
+        context.activate_exec_pin("exec_out").await?;
+        Ok(())
+    }
+
+    #[cfg(not(feature = "execute"))]
+    async fn run(&self, _context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        Err(execute_feature_error())
+    }
+}

--- a/packages/catalog/media/src/video/utils/shift_subtitle_file.rs
+++ b/packages/catalog/media/src/video/utils/shift_subtitle_file.rs
@@ -1,0 +1,71 @@
+use super::*;
+
+#[crate::register_node]
+#[derive(Default)]
+pub struct ShiftSubtitleFileNode;
+
+impl ShiftSubtitleFileNode {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl NodeLogic for ShiftSubtitleFileNode {
+    fn get_node(&self) -> Node {
+        let mut node = Node::new(
+            "video_shift_subtitle_file",
+            "Shift Subtitle File",
+            "Offset all SRT or WebVTT cues and write a new sidecar",
+            "Subtitles",
+        );
+        node.add_icon("/flow/icons/text.svg");
+        add_exec_pins(&mut node);
+        add_flow_path_input(&mut node, "source", "Source", "Subtitle sidecar FlowPath");
+        add_flow_path_input(&mut node, "target", "Target", "Target sidecar FlowPath");
+        node.add_input_pin("format", "Format", "Subtitle format", VariableType::String)
+            .set_options(
+                PinOptions::new()
+                    .set_valid_values(vec!["srt".to_owned(), "webvtt".to_owned()])
+                    .build(),
+            )
+            .set_default_value(Some(json!("srt")));
+        node.add_input_pin(
+            "offset_ms",
+            "Offset MS",
+            "Positive or negative subtitle offset in milliseconds",
+            VariableType::Integer,
+        )
+        .set_default_value(Some(json!(0)));
+        add_flow_path_output(&mut node, "result", "Result", "Written sidecar FlowPath");
+        node.add_output_pin("count", "Count", "Shifted cue count", VariableType::Integer);
+        node
+    }
+
+    #[cfg(feature = "execute")]
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        context.deactivate_exec_pin("exec_out").await?;
+        let source: FlowPath = context.evaluate_pin("source").await?;
+        let target: FlowPath = context.evaluate_pin("target").await?;
+        let format: String = context.evaluate_pin("format").await?;
+        let offset_ms: i64 = context.evaluate_pin("offset_ms").await?;
+        let format = subtitle_format(&format)?;
+        let text = String::from_utf8(source.get(context, false).await?)?;
+        let events = video_utils_rs::parse_subtitles(format, &text)?;
+        let shifted = video_utils_rs::shift_events(&events, offset_ms);
+        let output = subtitle_text(format, &shifted);
+        target.put(context, output.into_bytes(), false).await?;
+
+        context.set_pin_value("result", json!(target)).await?;
+        context
+            .set_pin_value("count", json!(shifted.len() as i64))
+            .await?;
+        context.activate_exec_pin("exec_out").await?;
+        Ok(())
+    }
+
+    #[cfg(not(feature = "execute"))]
+    async fn run(&self, _context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        Err(execute_feature_error())
+    }
+}

--- a/packages/catalog/media/src/video/utils/transcode_video.rs
+++ b/packages/catalog/media/src/video/utils/transcode_video.rs
@@ -66,18 +66,6 @@ impl NodeLogic for TranscodeVideoNode {
             VariableType::Struct,
         )
         .set_schema::<VideoTranscodeReport>();
-        node.add_output_pin(
-            "operation",
-            "Operation",
-            "Selected operation",
-            VariableType::String,
-        );
-        node.add_output_pin(
-            "bytes_written",
-            "Bytes Written",
-            "Bytes written to the target",
-            VariableType::Integer,
-        );
         node
     }
 
@@ -186,12 +174,6 @@ impl NodeLogic for TranscodeVideoNode {
         };
 
         context.set_pin_value("result", json!(target)).await?;
-        context
-            .set_pin_value("bytes_written", json!(report.bytes_written as i64))
-            .await?;
-        context
-            .set_pin_value("operation", json!(report.operation.clone()))
-            .await?;
         context.set_pin_value("report", json!(report)).await?;
         context.activate_exec_pin("exec_out").await?;
         Ok(())

--- a/packages/catalog/media/src/video/utils/transcode_video.rs
+++ b/packages/catalog/media/src/video/utils/transcode_video.rs
@@ -1,0 +1,204 @@
+use super::*;
+
+#[crate::register_node]
+#[derive(Default)]
+pub struct TranscodeVideoNode;
+
+impl TranscodeVideoNode {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl NodeLogic for TranscodeVideoNode {
+    fn get_node(&self) -> Node {
+        let mut node = Node::new(
+            "video_transcode_video",
+            "Transcode Video",
+            "Packet-copy when allowed or decode/encode a selected video stream into a target container",
+            "Video/Transcode",
+        );
+        add_video_icon_and_scores(&mut node);
+        add_exec_pins(&mut node);
+        add_flow_path_input(&mut node, "source", "Source", "Source media FlowPath");
+        add_flow_path_input(&mut node, "target", "Target", "Target media FlowPath");
+        node.add_input_pin(
+            "output_codec",
+            "Output Codec",
+            "Codec to encode, or copy to only packet-copy/remux",
+            VariableType::String,
+        )
+        .set_default_value(Some(json!("h264")));
+        node.add_input_pin(
+            "video_track_id",
+            "Video Track",
+            "Video track id, or 0 for default",
+            VariableType::Integer,
+        )
+        .set_default_value(Some(json!(0)));
+        node.add_input_pin(
+            "allow_packet_copy",
+            "Allow Packet Copy",
+            "Use copy/remux when no encode stage is requested",
+            VariableType::Boolean,
+        )
+        .set_default_value(Some(json!(true)));
+        node.add_input_pin(
+            "preserve_non_video",
+            "Preserve Non-Video",
+            "Copy compatible non-video packets",
+            VariableType::Boolean,
+        )
+        .set_default_value(Some(json!(true)));
+        node.add_input_pin(
+            "bitrate",
+            "Bitrate",
+            "Target bitrate in bits per second, or 0 for backend default",
+            VariableType::Integer,
+        )
+        .set_default_value(Some(json!(0)));
+        add_flow_path_output(&mut node, "result", "Result", "Written media FlowPath");
+        node.add_output_pin(
+            "report",
+            "Report",
+            "Video transcode report",
+            VariableType::Struct,
+        )
+        .set_schema::<VideoTranscodeReport>();
+        node.add_output_pin(
+            "operation",
+            "Operation",
+            "Selected operation",
+            VariableType::String,
+        );
+        node.add_output_pin(
+            "bytes_written",
+            "Bytes Written",
+            "Bytes written to the target",
+            VariableType::Integer,
+        );
+        node
+    }
+
+    #[cfg(feature = "execute")]
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        context.deactivate_exec_pin("exec_out").await?;
+        let source: FlowPath = context.evaluate_pin("source").await?;
+        let target: FlowPath = context.evaluate_pin("target").await?;
+        let output_codec: String = context.evaluate_pin("output_codec").await?;
+        let video_track_id: i64 = context.evaluate_pin("video_track_id").await?;
+        let allow_packet_copy: bool = context.evaluate_pin("allow_packet_copy").await?;
+        let preserve_non_video: bool = context.evaluate_pin("preserve_non_video").await?;
+        let bitrate: i64 = context.evaluate_pin("bitrate").await?;
+        let (source_store, source_location) = flow_path_object(context, &source).await?;
+        let (target_store, target_location) = flow_path_object(context, &target).await?;
+        let requested_track = optional_track_id(video_track_id)?;
+        let wants_copy_only = matches!(
+            output_codec.trim().to_ascii_lowercase().as_str(),
+            "" | "copy" | "packet_copy" | "packet-copy"
+        );
+
+        let report = if wants_copy_only {
+            if !allow_packet_copy {
+                return Err(flow_like_types::anyhow!(
+                    "output_codec is copy but allow_packet_copy is false"
+                ));
+            }
+            let report = video_utils_rs::remux_object_between_stores(
+                source_store.as_ref(),
+                &source_location,
+                target_store.as_ref(),
+                &target_location,
+                None,
+            )
+            .await?;
+            VideoTranscodeReport {
+                source: source_location.to_string(),
+                target: target_location.to_string(),
+                source_format: report.source_format.as_str().to_owned(),
+                target_format: report.target_format.as_str().to_owned(),
+                operation: format!("{:?}", report.operation),
+                video_track_id: None,
+                input_packets: 0,
+                output_packets: 0,
+                decoded_video_frames: 0,
+                encoded_video_packets: 0,
+                copied_packets: 0,
+                dropped_packets: 0,
+                bytes_written: report.bytes_written,
+            }
+        } else {
+            let demuxed =
+                video_utils_rs::demux_object(source_store.as_ref(), &source_location).await?;
+            let stream = selected_video_stream(&demuxed.media, requested_track)?;
+            let track_id = stream.track_id;
+            let width = stream
+                .width
+                .ok_or_else(|| flow_like_types::anyhow!("Source video stream has no width"))?;
+            let height = stream
+                .height
+                .ok_or_else(|| flow_like_types::anyhow!("Source video stream has no height"))?;
+            let frame_duration = packet_frame_duration(&demuxed.packets, track_id);
+            let processed = {
+                let mut decoder = platform_video_decoder(stream)?;
+                let mut encoder = platform_video_encoder(
+                    codec_id(&output_codec),
+                    width,
+                    height,
+                    stream.time_base,
+                    frame_duration,
+                    bitrate,
+                )?;
+                let output_codec_config = encoder.codec_config().map(Bytes::from);
+                process_video_transform(
+                    &demuxed,
+                    track_id,
+                    preserve_non_video,
+                    &video_utils_rs::FrameTransformPipeline::new(),
+                    &mut decoder,
+                    &mut encoder,
+                    output_codec_config,
+                )?
+            };
+            let mux_report = video_utils_rs::mux_object(
+                target_store.as_ref(),
+                &target_location,
+                &processed.media,
+                &processed.packets,
+            )
+            .await?;
+            VideoTranscodeReport {
+                source: source_location.to_string(),
+                target: target_location.to_string(),
+                source_format: demuxed.format.as_str().to_owned(),
+                target_format: mux_report.target_format.as_str().to_owned(),
+                operation: "VideoTranscodeMux".to_owned(),
+                video_track_id: Some(processed.video_track_id),
+                input_packets: processed.input_packets,
+                output_packets: processed.packets.len(),
+                decoded_video_frames: processed.decoded_frames,
+                encoded_video_packets: processed.encoded_video_packets,
+                copied_packets: processed.copied_packets,
+                dropped_packets: processed.dropped_packets,
+                bytes_written: mux_report.bytes_written,
+            }
+        };
+
+        context.set_pin_value("result", json!(target)).await?;
+        context
+            .set_pin_value("bytes_written", json!(report.bytes_written as i64))
+            .await?;
+        context
+            .set_pin_value("operation", json!(report.operation.clone()))
+            .await?;
+        context.set_pin_value("report", json!(report)).await?;
+        context.activate_exec_pin("exec_out").await?;
+        Ok(())
+    }
+
+    #[cfg(not(feature = "execute"))]
+    async fn run(&self, _context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        Err(execute_feature_error())
+    }
+}

--- a/packages/catalog/media/src/video/utils/transform_audio.rs
+++ b/packages/catalog/media/src/video/utils/transform_audio.rs
@@ -1,0 +1,142 @@
+use super::*;
+
+#[crate::register_node]
+#[derive(Default)]
+pub struct TransformAudioNode;
+
+impl TransformAudioNode {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl NodeLogic for TransformAudioNode {
+    fn get_node(&self) -> Node {
+        let mut node = Node::new(
+            "video_transform_audio",
+            "Transform Audio",
+            "Decode audio, apply gain/normalization/fades, and write WAV PCM output",
+            "Audio",
+        );
+        add_video_icon_and_scores(&mut node);
+        add_exec_pins(&mut node);
+        add_flow_path_input(&mut node, "source", "Source", "Source audio/media FlowPath");
+        add_flow_path_input(&mut node, "target", "Target", "Target WAV FlowPath");
+        node.add_input_pin(
+            "audio_track_id",
+            "Audio Track",
+            "Audio track id, or 0 for default",
+            VariableType::Integer,
+        )
+        .set_default_value(Some(json!(0)));
+        node.add_input_pin(
+            "gain_factor",
+            "Gain",
+            "Linear gain factor",
+            VariableType::Float,
+        )
+        .set_default_value(Some(json!(1.0)));
+        node.add_input_pin(
+            "gain_db",
+            "Gain dB",
+            "Gain in decibels",
+            VariableType::Float,
+        )
+        .set_default_value(Some(json!(0.0)));
+        node.add_input_pin(
+            "normalize_peak",
+            "Normalize Peak",
+            "Target peak amplitude, or 0 to skip",
+            VariableType::Float,
+        )
+        .set_default_value(Some(json!(0.0)));
+        node.add_input_pin(
+            "fade_in_seconds",
+            "Fade In",
+            "Fade-in seconds",
+            VariableType::Float,
+        )
+        .set_default_value(Some(json!(0.0)));
+        node.add_input_pin(
+            "fade_out_seconds",
+            "Fade Out",
+            "Fade-out seconds",
+            VariableType::Float,
+        )
+        .set_default_value(Some(json!(0.0)));
+        node.add_input_pin(
+            "fade_shape",
+            "Fade Shape",
+            "linear or equal_power",
+            VariableType::String,
+        )
+        .set_default_value(Some(json!("linear")));
+        add_flow_path_output(&mut node, "result", "Result", "Written WAV FlowPath");
+        node.add_output_pin(
+            "report",
+            "Report",
+            "Audio transform report",
+            VariableType::Struct,
+        )
+        .set_schema::<AudioTransformReport>();
+        node.add_output_pin(
+            "bytes_written",
+            "Bytes Written",
+            "Bytes written to the target",
+            VariableType::Integer,
+        );
+        node
+    }
+
+    #[cfg(feature = "execute")]
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        context.deactivate_exec_pin("exec_out").await?;
+        let source: FlowPath = context.evaluate_pin("source").await?;
+        let target: FlowPath = context.evaluate_pin("target").await?;
+        let audio_track_id: i64 = context.evaluate_pin("audio_track_id").await?;
+        let gain_factor: f64 = context.evaluate_pin("gain_factor").await?;
+        let gain_db: f64 = context.evaluate_pin("gain_db").await?;
+        let normalize_peak: f64 = context.evaluate_pin("normalize_peak").await?;
+        let fade_in_seconds: f64 = context.evaluate_pin("fade_in_seconds").await?;
+        let fade_out_seconds: f64 = context.evaluate_pin("fade_out_seconds").await?;
+        let fade_shape_name: String = context.evaluate_pin("fade_shape").await?;
+        let (source_store, source_location) = flow_path_object(context, &source).await?;
+        let (target_store, target_location) = flow_path_object(context, &target).await?;
+        let pipeline = audio_pipeline(
+            gain_factor,
+            gain_db,
+            normalize_peak,
+            fade_in_seconds,
+            fade_out_seconds,
+            &fade_shape_name,
+            None,
+        )?;
+        let mut job = video_utils_rs::ObjectAudioTransformJob::new(pipeline);
+        if let Some(track_id) = optional_track_id(audio_track_id)? {
+            job = job.with_audio_track(track_id);
+        }
+        let report = video_utils_rs::transform_object_audio_file_to_wav_between_stores(
+            source_store.as_ref(),
+            &source_location,
+            target_store.as_ref(),
+            &target_location,
+            &job,
+        )
+        .await?;
+        let report = audio_transform_report(report);
+
+        context.set_pin_value("result", json!(target)).await?;
+        context
+            .set_pin_value("bytes_written", json!(report.bytes_written as i64))
+            .await?;
+        context.set_pin_value("report", json!(report)).await?;
+        context.activate_exec_pin("exec_out").await?;
+        Ok(())
+    }
+
+    #[cfg(not(feature = "execute"))]
+    async fn run(&self, _context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        Err(execute_feature_error())
+    }
+}

--- a/packages/catalog/media/src/video/utils/transform_audio.rs
+++ b/packages/catalog/media/src/video/utils/transform_audio.rs
@@ -80,12 +80,6 @@ impl NodeLogic for TransformAudioNode {
             VariableType::Struct,
         )
         .set_schema::<AudioTransformReport>();
-        node.add_output_pin(
-            "bytes_written",
-            "Bytes Written",
-            "Bytes written to the target",
-            VariableType::Integer,
-        );
         node
     }
 
@@ -127,9 +121,6 @@ impl NodeLogic for TransformAudioNode {
         let report = audio_transform_report(report);
 
         context.set_pin_value("result", json!(target)).await?;
-        context
-            .set_pin_value("bytes_written", json!(report.bytes_written as i64))
-            .await?;
         context.set_pin_value("report", json!(report)).await?;
         context.activate_exec_pin("exec_out").await?;
         Ok(())

--- a/packages/catalog/media/src/video/utils/transform_image.rs
+++ b/packages/catalog/media/src/video/utils/transform_image.rs
@@ -1,0 +1,169 @@
+use super::*;
+
+#[crate::register_node]
+#[derive(Default)]
+pub struct TransformImageNode;
+
+impl TransformImageNode {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl NodeLogic for TransformImageNode {
+    fn get_node(&self) -> Node {
+        let mut node = Node::new(
+            "video_transform_image",
+            "Transform Image",
+            "Apply crop, resize, flip, rotate, blur, and color filters to a still image",
+            "Image",
+        );
+        add_video_icon_and_scores(&mut node);
+        add_exec_pins(&mut node);
+        add_flow_path_input(&mut node, "source", "Source", "Source image FlowPath");
+        add_flow_path_input(&mut node, "target", "Target", "Target image FlowPath");
+        node.add_input_pin(
+            "format",
+            "Format",
+            "Output image format, or auto from target extension",
+            VariableType::String,
+        )
+        .set_default_value(Some(json!("auto")));
+        for (id, name, default) in [
+            ("crop_x", "Crop X", 0),
+            ("crop_y", "Crop Y", 0),
+            ("crop_width", "Crop Width", 0),
+            ("crop_height", "Crop Height", 0),
+            ("resize_width", "Resize Width", 0),
+            ("resize_height", "Resize Height", 0),
+            ("rotate_degrees", "Rotate", 0),
+            ("blur_radius", "Blur", 0),
+        ] {
+            node.add_input_pin(id, name, "", VariableType::Integer)
+                .set_default_value(Some(json!(default)));
+        }
+        node.add_input_pin(
+            "flip_horizontal",
+            "Flip Horizontal",
+            "",
+            VariableType::Boolean,
+        )
+        .set_default_value(Some(json!(false)));
+        node.add_input_pin("flip_vertical", "Flip Vertical", "", VariableType::Boolean)
+            .set_default_value(Some(json!(false)));
+        node.add_input_pin(
+            "brightness",
+            "Brightness",
+            "-1.0 to 1.0",
+            VariableType::Float,
+        )
+        .set_default_value(Some(json!(0.0)));
+        node.add_input_pin(
+            "contrast",
+            "Contrast",
+            "1.0 keeps contrast unchanged",
+            VariableType::Float,
+        )
+        .set_default_value(Some(json!(1.0)));
+        node.add_input_pin(
+            "saturation",
+            "Saturation",
+            "1.0 keeps saturation unchanged",
+            VariableType::Float,
+        )
+        .set_default_value(Some(json!(1.0)));
+        add_flow_path_output(&mut node, "result", "Result", "Written image FlowPath");
+        node.add_output_pin(
+            "report",
+            "Report",
+            "Image transform report",
+            VariableType::Struct,
+        )
+        .set_schema::<ImageOperationReport>();
+        node.add_output_pin(
+            "bytes_written",
+            "Bytes Written",
+            "Bytes written to the target",
+            VariableType::Integer,
+        );
+        node
+    }
+
+    #[cfg(feature = "execute")]
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        context.deactivate_exec_pin("exec_out").await?;
+        let source: FlowPath = context.evaluate_pin("source").await?;
+        let target: FlowPath = context.evaluate_pin("target").await?;
+        let format: String = context.evaluate_pin("format").await?;
+        let crop_x: i64 = context.evaluate_pin("crop_x").await?;
+        let crop_y: i64 = context.evaluate_pin("crop_y").await?;
+        let crop_width: i64 = context.evaluate_pin("crop_width").await?;
+        let crop_height: i64 = context.evaluate_pin("crop_height").await?;
+        let resize_width: i64 = context.evaluate_pin("resize_width").await?;
+        let resize_height: i64 = context.evaluate_pin("resize_height").await?;
+        let flip_horizontal: bool = context.evaluate_pin("flip_horizontal").await?;
+        let flip_vertical: bool = context.evaluate_pin("flip_vertical").await?;
+        let rotate_degrees: i64 = context.evaluate_pin("rotate_degrees").await?;
+        let blur_radius: i64 = context.evaluate_pin("blur_radius").await?;
+        let brightness: f64 = context.evaluate_pin("brightness").await?;
+        let contrast: f64 = context.evaluate_pin("contrast").await?;
+        let saturation: f64 = context.evaluate_pin("saturation").await?;
+
+        let (source_store, source_location) = flow_path_object(context, &source).await?;
+        let (target_store, target_location) = flow_path_object(context, &target).await?;
+        let bytes =
+            video_utils_rs::read_object_bytes(source_store.as_ref(), &source_location).await?;
+        let mut decoder = video_utils_rs::ImageRgbaDecoder::new();
+        let frame = decoder.decode(&bytes)?;
+        let pipeline = video_frame_pipeline(
+            crop_x,
+            crop_y,
+            crop_width,
+            crop_height,
+            resize_width,
+            resize_height,
+            flip_horizontal,
+            flip_vertical,
+            rotate_degrees,
+            blur_radius,
+            brightness,
+            contrast,
+            saturation,
+        )?;
+        let transformed = pipeline.apply(&frame)?;
+        let output_format = image_format_for_target(&format, &target_location)?;
+        let mut encoder = image_encoder(output_format);
+        let output = encoder.encode(&transformed)?;
+        let bytes_written = output.len() as u64;
+        video_utils_rs::write_object_bytes(
+            target_store.as_ref(),
+            &target_location,
+            Bytes::from(output),
+        )
+        .await?;
+
+        let report = ImageOperationReport {
+            source: source_location.to_string(),
+            target: target_location.to_string(),
+            input_width: frame.width,
+            input_height: frame.height,
+            output_width: transformed.width,
+            output_height: transformed.height,
+            output_format: image_format_name(output_format).to_owned(),
+            bytes_written,
+        };
+        context.set_pin_value("result", json!(target)).await?;
+        context
+            .set_pin_value("bytes_written", json!(bytes_written as i64))
+            .await?;
+        context.set_pin_value("report", json!(report)).await?;
+        context.activate_exec_pin("exec_out").await?;
+        Ok(())
+    }
+
+    #[cfg(not(feature = "execute"))]
+    async fn run(&self, _context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        Err(execute_feature_error())
+    }
+}

--- a/packages/catalog/media/src/video/utils/transform_image.rs
+++ b/packages/catalog/media/src/video/utils/transform_image.rs
@@ -81,12 +81,6 @@ impl NodeLogic for TransformImageNode {
             VariableType::Struct,
         )
         .set_schema::<ImageOperationReport>();
-        node.add_output_pin(
-            "bytes_written",
-            "Bytes Written",
-            "Bytes written to the target",
-            VariableType::Integer,
-        );
         node
     }
 
@@ -154,9 +148,6 @@ impl NodeLogic for TransformImageNode {
             bytes_written,
         };
         context.set_pin_value("result", json!(target)).await?;
-        context
-            .set_pin_value("bytes_written", json!(bytes_written as i64))
-            .await?;
         context.set_pin_value("report", json!(report)).await?;
         context.activate_exec_pin("exec_out").await?;
         Ok(())

--- a/packages/catalog/media/src/video/utils/transform_video.rs
+++ b/packages/catalog/media/src/video/utils/transform_video.rs
@@ -1,0 +1,234 @@
+use super::*;
+
+#[crate::register_node]
+#[derive(Default)]
+pub struct TransformVideoNode;
+
+impl TransformVideoNode {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl NodeLogic for TransformVideoNode {
+    fn get_node(&self) -> Node {
+        let mut node = Node::new(
+            "video_transform_video",
+            "Transform Video",
+            "Decode video frames, apply frame transforms, encode, and mux the result",
+            "Video/Transcode",
+        );
+        add_video_icon_and_scores(&mut node);
+        add_exec_pins(&mut node);
+        add_flow_path_input(&mut node, "source", "Source", "Source media FlowPath");
+        add_flow_path_input(&mut node, "target", "Target", "Target media FlowPath");
+        node.add_input_pin(
+            "output_codec",
+            "Output Codec",
+            "Video codec to encode, such as h264, h265, vp9, or av1",
+            VariableType::String,
+        )
+        .set_default_value(Some(json!("h264")));
+        node.add_input_pin(
+            "video_track_id",
+            "Video Track",
+            "Video track id, or 0 for default",
+            VariableType::Integer,
+        )
+        .set_default_value(Some(json!(0)));
+        node.add_input_pin(
+            "preserve_non_video",
+            "Preserve Non-Video",
+            "Copy non-video packets when possible",
+            VariableType::Boolean,
+        )
+        .set_default_value(Some(json!(true)));
+        node.add_input_pin(
+            "bitrate",
+            "Bitrate",
+            "Target bitrate in bits per second, or 0 for backend default",
+            VariableType::Integer,
+        )
+        .set_default_value(Some(json!(0)));
+        for (id, name, default) in [
+            ("crop_x", "Crop X", 0),
+            ("crop_y", "Crop Y", 0),
+            ("crop_width", "Crop Width", 0),
+            ("crop_height", "Crop Height", 0),
+            ("resize_width", "Resize Width", 0),
+            ("resize_height", "Resize Height", 0),
+            ("rotate_degrees", "Rotate", 0),
+            ("blur_radius", "Blur", 0),
+        ] {
+            node.add_input_pin(id, name, "", VariableType::Integer)
+                .set_default_value(Some(json!(default)));
+        }
+        node.add_input_pin(
+            "flip_horizontal",
+            "Flip Horizontal",
+            "",
+            VariableType::Boolean,
+        )
+        .set_default_value(Some(json!(false)));
+        node.add_input_pin("flip_vertical", "Flip Vertical", "", VariableType::Boolean)
+            .set_default_value(Some(json!(false)));
+        node.add_input_pin(
+            "brightness",
+            "Brightness",
+            "-1.0 to 1.0",
+            VariableType::Float,
+        )
+        .set_default_value(Some(json!(0.0)));
+        node.add_input_pin(
+            "contrast",
+            "Contrast",
+            "1.0 keeps contrast unchanged",
+            VariableType::Float,
+        )
+        .set_default_value(Some(json!(1.0)));
+        node.add_input_pin(
+            "saturation",
+            "Saturation",
+            "1.0 keeps saturation unchanged",
+            VariableType::Float,
+        )
+        .set_default_value(Some(json!(1.0)));
+        add_flow_path_output(&mut node, "result", "Result", "Written media FlowPath");
+        node.add_output_pin(
+            "report",
+            "Report",
+            "Video transform report",
+            VariableType::Struct,
+        )
+        .set_schema::<VideoTransformReport>();
+        node.add_output_pin(
+            "bytes_written",
+            "Bytes Written",
+            "Bytes written to the target",
+            VariableType::Integer,
+        );
+        node
+    }
+
+    #[cfg(feature = "execute")]
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        context.deactivate_exec_pin("exec_out").await?;
+        let source: FlowPath = context.evaluate_pin("source").await?;
+        let target: FlowPath = context.evaluate_pin("target").await?;
+        let output_codec: String = context.evaluate_pin("output_codec").await?;
+        let video_track_id: i64 = context.evaluate_pin("video_track_id").await?;
+        let preserve_non_video: bool = context.evaluate_pin("preserve_non_video").await?;
+        let bitrate: i64 = context.evaluate_pin("bitrate").await?;
+        let crop_x: i64 = context.evaluate_pin("crop_x").await?;
+        let crop_y: i64 = context.evaluate_pin("crop_y").await?;
+        let crop_width: i64 = context.evaluate_pin("crop_width").await?;
+        let crop_height: i64 = context.evaluate_pin("crop_height").await?;
+        let resize_width: i64 = context.evaluate_pin("resize_width").await?;
+        let resize_height: i64 = context.evaluate_pin("resize_height").await?;
+        let flip_horizontal: bool = context.evaluate_pin("flip_horizontal").await?;
+        let flip_vertical: bool = context.evaluate_pin("flip_vertical").await?;
+        let rotate_degrees: i64 = context.evaluate_pin("rotate_degrees").await?;
+        let blur_radius: i64 = context.evaluate_pin("blur_radius").await?;
+        let brightness: f64 = context.evaluate_pin("brightness").await?;
+        let contrast: f64 = context.evaluate_pin("contrast").await?;
+        let saturation: f64 = context.evaluate_pin("saturation").await?;
+
+        let (source_store, source_location) = flow_path_object(context, &source).await?;
+        let (target_store, target_location) = flow_path_object(context, &target).await?;
+        let demuxed = video_utils_rs::demux_object(source_store.as_ref(), &source_location).await?;
+        let requested_track = optional_track_id(video_track_id)?;
+        let stream = selected_video_stream(&demuxed.media, requested_track)?;
+        let track_id = stream.track_id;
+        let mut width = if resize_width > 0 {
+            u32::try_from(resize_width)?
+        } else if crop_width > 0 {
+            u32::try_from(crop_width)?
+        } else {
+            stream
+                .width
+                .ok_or_else(|| flow_like_types::anyhow!("Source video stream has no width"))?
+        };
+        let mut height = if resize_height > 0 {
+            u32::try_from(resize_height)?
+        } else if crop_height > 0 {
+            u32::try_from(crop_height)?
+        } else {
+            stream
+                .height
+                .ok_or_else(|| flow_like_types::anyhow!("Source video stream has no height"))?
+        };
+        if matches!(rotate_degrees.rem_euclid(360), 90 | 270) {
+            std::mem::swap(&mut width, &mut height);
+        }
+        let frame_duration = packet_frame_duration(&demuxed.packets, track_id);
+        let pipeline = video_frame_pipeline(
+            crop_x,
+            crop_y,
+            crop_width,
+            crop_height,
+            resize_width,
+            resize_height,
+            flip_horizontal,
+            flip_vertical,
+            rotate_degrees,
+            blur_radius,
+            brightness,
+            contrast,
+            saturation,
+        )?;
+        let processed = {
+            let mut decoder = platform_video_decoder(stream)?;
+            let mut encoder = platform_video_encoder(
+                codec_id(&output_codec),
+                width,
+                height,
+                stream.time_base,
+                frame_duration,
+                bitrate,
+            )?;
+            let output_codec_config = encoder.codec_config().map(Bytes::from);
+            process_video_transform(
+                &demuxed,
+                track_id,
+                preserve_non_video,
+                &pipeline,
+                &mut decoder,
+                &mut encoder,
+                output_codec_config,
+            )?
+        };
+        let mux_report = video_utils_rs::mux_object(
+            target_store.as_ref(),
+            &target_location,
+            &processed.media,
+            &processed.packets,
+        )
+        .await?;
+        let report = VideoTransformReport {
+            source: source_location.to_string(),
+            target: target_location.to_string(),
+            source_format: demuxed.format.as_str().to_owned(),
+            target_format: mux_report.target_format.as_str().to_owned(),
+            video_track_id: processed.video_track_id,
+            input_packets: processed.input_packets,
+            decoded_frames: processed.decoded_frames,
+            encoded_video_packets: processed.encoded_video_packets,
+            copied_packets: processed.copied_packets,
+            bytes_written: mux_report.bytes_written,
+        };
+
+        context.set_pin_value("result", json!(target)).await?;
+        context
+            .set_pin_value("bytes_written", json!(report.bytes_written as i64))
+            .await?;
+        context.set_pin_value("report", json!(report)).await?;
+        context.activate_exec_pin("exec_out").await?;
+        Ok(())
+    }
+
+    #[cfg(not(feature = "execute"))]
+    async fn run(&self, _context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        Err(execute_feature_error())
+    }
+}

--- a/packages/catalog/media/src/video/utils/transform_video.rs
+++ b/packages/catalog/media/src/video/utils/transform_video.rs
@@ -102,12 +102,6 @@ impl NodeLogic for TransformVideoNode {
             VariableType::Struct,
         )
         .set_schema::<VideoTransformReport>();
-        node.add_output_pin(
-            "bytes_written",
-            "Bytes Written",
-            "Bytes written to the target",
-            VariableType::Integer,
-        );
         node
     }
 
@@ -219,9 +213,6 @@ impl NodeLogic for TransformVideoNode {
         };
 
         context.set_pin_value("result", json!(target)).await?;
-        context
-            .set_pin_value("bytes_written", json!(report.bytes_written as i64))
-            .await?;
         context.set_pin_value("report", json!(report)).await?;
         context.activate_exec_pin("exec_out").await?;
         Ok(())

--- a/packages/catalog/media/src/video/utils/trim_keyframes.rs
+++ b/packages/catalog/media/src/video/utils/trim_keyframes.rs
@@ -1,0 +1,105 @@
+use super::*;
+
+#[crate::register_node]
+#[derive(Default)]
+pub struct TrimOnKeyframesNode;
+
+impl TrimOnKeyframesNode {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl NodeLogic for TrimOnKeyframesNode {
+    fn get_node(&self) -> Node {
+        let mut node = Node::new(
+            "video_trim_keyframes",
+            "Trim On Keyframes",
+            "Trim a media file using a keyframe-aligned packet range",
+            "Video/Editing",
+        );
+        add_video_icon_and_scores(&mut node);
+        add_exec_pins(&mut node);
+        add_flow_path_input(&mut node, "source", "Source", "Source media FlowPath");
+        add_flow_path_input(&mut node, "target", "Target", "Target media FlowPath");
+        node.add_input_pin(
+            "start_seconds",
+            "Start Seconds",
+            "Requested start time",
+            VariableType::Float,
+        )
+        .set_default_value(Some(json!(0.0)));
+        node.add_input_pin(
+            "end_seconds",
+            "End Seconds",
+            "Requested end time",
+            VariableType::Float,
+        )
+        .set_default_value(Some(json!(10.0)));
+        node.add_input_pin(
+            "track_id",
+            "Track ID",
+            "Boundary video track; 0 uses first video track",
+            VariableType::Integer,
+        )
+        .set_default_value(Some(json!(0)));
+        add_flow_path_output(&mut node, "result", "Result", "Written media FlowPath");
+        node.add_output_pin(
+            "packet_count",
+            "Packet Count",
+            "Packets written",
+            VariableType::Integer,
+        );
+        node.add_output_pin(
+            "boundary_track_id",
+            "Boundary Track",
+            "Track used for keyframe selection",
+            VariableType::Integer,
+        );
+        node
+    }
+
+    #[cfg(feature = "execute")]
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        context.deactivate_exec_pin("exec_out").await?;
+        let source: FlowPath = context.evaluate_pin("source").await?;
+        let target: FlowPath = context.evaluate_pin("target").await?;
+        let start_seconds: f64 = context.evaluate_pin("start_seconds").await?;
+        let end_seconds: f64 = context.evaluate_pin("end_seconds").await?;
+        let track_id: i64 = context.evaluate_pin("track_id").await?;
+        let (source_store, source_location) = flow_path_object(context, &source).await?;
+        let (target_store, target_location) = flow_path_object(context, &target).await?;
+
+        let demuxed = video_utils_rs::demux_object(source_store.as_ref(), &source_location).await?;
+        let boundary_track_id =
+            select_video_track_id(&demuxed.media, optional_track_id(track_id)?)?;
+        let packet_slice = video_utils_rs::select_keyframe_range(
+            &demuxed.packets,
+            boundary_track_id,
+            start_seconds,
+            end_seconds,
+        )?;
+        let mut packets = demuxed.packets[packet_slice.start..packet_slice.end].to_vec();
+        video_utils_rs::normalize_timestamps(&mut packets)?;
+        let media = media_for_packet_subset(&demuxed.media, &packets);
+        let report =
+            video_utils_rs::mux_object(target_store.as_ref(), &target_location, &media, &packets)
+                .await?;
+
+        context.set_pin_value("result", json!(target)).await?;
+        context
+            .set_pin_value("packet_count", json!(report.packet_count as i64))
+            .await?;
+        context
+            .set_pin_value("boundary_track_id", json!(boundary_track_id as i64))
+            .await?;
+        context.activate_exec_pin("exec_out").await?;
+        Ok(())
+    }
+
+    #[cfg(not(feature = "execute"))]
+    async fn run(&self, _context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        Err(execute_feature_error())
+    }
+}

--- a/packages/catalog/media/src/video/utils/write_subtitles.rs
+++ b/packages/catalog/media/src/video/utils/write_subtitles.rs
@@ -1,0 +1,63 @@
+use super::*;
+
+#[crate::register_node]
+#[derive(Default)]
+pub struct WriteSubtitlesNode;
+
+impl WriteSubtitlesNode {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl NodeLogic for WriteSubtitlesNode {
+    fn get_node(&self) -> Node {
+        let mut node = Node::new(
+            "video_write_subtitles",
+            "Write Subtitles",
+            "Write subtitle cue structs to an SRT or WebVTT sidecar",
+            "Subtitles",
+        );
+        node.add_icon("/flow/icons/text.svg");
+        add_exec_pins(&mut node);
+        node.add_input_pin("cues", "Cues", "Subtitle cues", VariableType::Struct)
+            .set_schema::<SubtitleCue>()
+            .set_value_type(ValueType::Array);
+        add_flow_path_input(&mut node, "target", "Target", "Subtitle sidecar FlowPath");
+        node.add_input_pin("format", "Format", "Subtitle format", VariableType::String)
+            .set_options(
+                PinOptions::new()
+                    .set_valid_values(vec!["srt".to_owned(), "webvtt".to_owned()])
+                    .build(),
+            )
+            .set_default_value(Some(json!("srt")));
+        add_flow_path_output(&mut node, "result", "Result", "Written sidecar FlowPath");
+        node.add_output_pin("count", "Count", "Cue count", VariableType::Integer);
+        node
+    }
+
+    #[cfg(feature = "execute")]
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        context.deactivate_exec_pin("exec_out").await?;
+        let cues: Vec<SubtitleCue> = context.evaluate_pin("cues").await?;
+        let target: FlowPath = context.evaluate_pin("target").await?;
+        let format: String = context.evaluate_pin("format").await?;
+        let format = subtitle_format(&format)?;
+        let events = events_from_cues(cues)?;
+        let text = subtitle_text(format, &events);
+        target.put(context, text.into_bytes(), false).await?;
+
+        context.set_pin_value("result", json!(target)).await?;
+        context
+            .set_pin_value("count", json!(events.len() as i64))
+            .await?;
+        context.activate_exec_pin("exec_out").await?;
+        Ok(())
+    }
+
+    #[cfg(not(feature = "execute"))]
+    async fn run(&self, _context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        Err(execute_feature_error())
+    }
+}

--- a/packages/catalog/std/src/utils/user/project_users/mod.rs
+++ b/packages/catalog/std/src/utils/user/project_users/mod.rs
@@ -840,7 +840,7 @@ fn add_users_output(node: &mut Node) {
         VariableType::Generic,
     )
     .set_value_type(ValueType::Array)
-    .set_schema::<Vec<ProjectUser>>();
+    .set_schema::<ProjectUser>();
     node.add_output_pin(
         "count",
         "Count",

--- a/packages/catalog/std/src/utils/user/project_users/mod.rs
+++ b/packages/catalog/std/src/utils/user/project_users/mod.rs
@@ -837,10 +837,11 @@ fn add_users_output(node: &mut Node) {
         "users",
         "Users",
         "Matching project users.",
-        VariableType::Generic,
+        VariableType::Struct,
     )
     .set_value_type(ValueType::Array)
-    .set_schema::<ProjectUser>();
+    .set_schema::<ProjectUser>()
+    .set_options(PinOptions::new().set_enforce_schema(true).build());
     node.add_output_pin(
         "count",
         "Count",


### PR DESCRIPTION
This pull request expands the media catalog with a new `video::utils` module backed by the optional `video-utils-rs` dependency. It adds a broad set of video, audio, image, subtitle, stream-inspection, remuxing, transcoding, and HLS utility nodes, plus the dependency and feature wiring required to execute them behind the `execute` feature.

**Media Catalog Additions:**

* Added media inspection and planning nodes for probing media metadata, detecting containers, checking remux compatibility, probing codec backends, probing platform codec support, and selecting codec backends.
* Added packet/container operations for remuxing, concatenating compatible media, extracting encoded tracks, normalizing timestamps, trimming on keyframes, and converting H.264/H.265/AAC bitstreams.
* Added video processing nodes for transcoding, frame transforms, AV1 encoding, thumbnail extraction, and contact sheet generation.
* Added audio processing nodes for audio analysis, silence detection, WAV export, gain/normalize/fade transforms, and waveform/silence reporting.
* Added image utility nodes for still-image transforms and image format conversion.
* Added subtitle utility nodes for parsing, writing, shifting, extracting subtitle tracks, muxing subtitle sidecars, and burning subtitles into video.
* Added HLS VOD packaging support for playlists, media segments, optional fMP4 init segments, and package reports.

**Shared Types and Node Surface:**

* Added typed schema structs for media/stream metadata, codec/backend reports, transform/transcode reports, subtitle reports, image/frame reports, remux reports, HLS reports, waveform buckets, and silence ranges.
* Kept node outputs focused on typed structs and direct FlowPath artifacts rather than many flattened scalar pins.

**Dependency and Feature Updates:**

* Added the `video-utils-rs` crate as an optional dependency with codec/platform features.
* Wired `video-utils-rs` into the `execute` feature so node execution is available when enabled.
* Added `bytes` as a workspace dependency for binary media outputs.

**Std Catalog Update:**

* Updated the project users output schema typing so project-user arrays are exposed as typed struct arrays.