### PR TITLE
feat: enhance flow board functionality and state management

### DIFF
--- a/apps/desktop/components/tauri-provider/board-state.ts
+++ b/apps/desktop/components/tauri-provider/board-state.ts
@@ -2,6 +2,7 @@ import { Channel, invoke } from "@tauri-apps/api/core";
 import {
 	type ChatImage,
 	type CopilotScope,
+	type IApplyFlowScriptResponse,
 	type IBoard,
 	type IBoardState,
 	ICommentType,
@@ -702,7 +703,10 @@ export class BoardState implements IBoardState {
 					executionMode: remoteData.execution_mode,
 					boardData: remoteData,
 				}).catch((e: unknown) => {
-					console.warn("[BoardState] Failed to persist remote board locally:", e);
+					console.warn(
+						"[BoardState] Failed to persist remote board locally:",
+						e,
+					);
 				});
 			}
 			if (typeof version === "undefined") {
@@ -1834,6 +1838,69 @@ export class BoardState implements IBoardState {
 		}
 
 		return executedCommands;
+	}
+
+	async applyFlowScript(
+		appId: string,
+		boardId: string,
+		flowscript: string,
+		currentLayer?: string,
+		catalogNodes?: INode[],
+		allowDeletions = false,
+	): Promise<IApplyFlowScriptResponse> {
+		const result = await invoke<IApplyFlowScriptResponse>("apply_flowscript", {
+			appId,
+			boardId,
+			flowscript,
+			currentLayer,
+			catalogNodes: getAppPackageCatalogNodes(catalogNodes),
+			allowDeletions,
+		});
+
+		if (result.commands.length === 0) {
+			return result;
+		}
+
+		const isOffline = await this.backend.isOffline(appId);
+		if (isOffline) {
+			return result;
+		}
+
+		if (
+			!this.backend.profile ||
+			!this.backend.auth ||
+			!this.backend.queryClient
+		) {
+			await this.backend.pushOfflineSyncCommand(
+				appId,
+				boardId,
+				result.commands,
+			);
+			return result;
+		}
+
+		try {
+			await fetcher(
+				this.backend.profile,
+				`apps/${appId}/board/${boardId}`,
+				{
+					method: "POST",
+					body: JSON.stringify({
+						commands: result.commands,
+					}),
+				},
+				this.backend.auth,
+			);
+		} catch (error) {
+			console.error("Failed to push FlowScript commands to server:", error);
+			await this.backend.pushOfflineSyncCommand(
+				appId,
+				boardId,
+				result.commands,
+			);
+		}
+
+		return result;
 	}
 
 	async getExecutionElements(

--- a/apps/desktop/src-tauri/src/functions/ai/copilot.rs
+++ b/apps/desktop/src-tauri/src/functions/ai/copilot.rs
@@ -1490,7 +1490,7 @@ impl rmcp::ServerHandler for FlowPilotMcpServer {
                 .build(),
         )
         .with_instructions(
-            "FlowPilot tools share the exact board/frontend/runtime capabilities used by Bits and GitHub Copilot. Use edit_flowscript/emit_commands for workflow changes and answer the user in text when no board/UI edit is required.",
+            "FlowPilot tools share the exact board/frontend/runtime capabilities used by Bits and GitHub Copilot. For workflow changes on an existing board, call get_current_flowscript first, then edit_flowscript with the full edited document. Create workflow functions as FlowScript `function ... { ... }` declarations, not manual command JSON. Use emit_commands only for layout/non-FlowScript changes and answer the user in text when no board/UI edit is required.",
         )
     }
 
@@ -1800,7 +1800,7 @@ fn build_external_agent_prompt(system_content: &str, user_prompt: &str) -> Strin
         r#"SYSTEM INSTRUCTIONS
 {system_content}
 
-You are running through an external code-agent CLI connected to FlowPilot's shared MCP tools. Do not use shell/file-edit tools for workflow or UI edits. Use the FlowPilot MCP tools. For workflow changes, prefer FlowScript through get_declarations and edit_flowscript. If the user asks for explanation or no edit is needed, answer in normal text.
+You are running through an external code-agent CLI connected to FlowPilot's shared MCP tools. Do not use shell/file-edit tools for workflow or UI edits. Use the FlowPilot MCP tools. For workflow changes on an existing board, first call get_current_flowscript, then call get_declarations as needed, then call edit_flowscript with the full edited FlowScript document. Preserve all kept `//@n:<id>` anchors, and leave allow_deletions false unless the user explicitly asked to delete existing board items. Create workflow functions as FlowScript `function ... {{ ... }}` declarations, not manual command JSON. If the user asks for explanation or no edit is needed, answer in normal text.
 
 USER REQUEST
 {user_prompt}"#

--- a/apps/desktop/src-tauri/src/functions/ai/copilot_sdk_tools.rs
+++ b/apps/desktop/src-tauri/src/functions/ai/copilot_sdk_tools.rs
@@ -13,7 +13,10 @@ use std::{
 use super::frontend_tool_bridge::{FrontendToolApproval, FrontendToolBridge};
 pub use copilot_sdk::ToolHandler;
 use copilot_sdk::{Tool, ToolResultObject};
-use flow_like::flow::ast::reconcile_text_with_catalog;
+use flow_like::flow::ast::{
+    RenderOptions, blocked_destructive_flowscript_message, board_to_flowscript,
+    destructive_flowscript_command_summaries, reconcile_text_with_catalog,
+};
 use flow_like::flow::board::Board;
 use flow_like::flow::copilot::{
     BoardCommand, CatalogProvider, GraphContext, NodeMetadata, search_result_hint_lines,
@@ -44,6 +47,7 @@ pub fn create_board_tools(
     }
 
     if let Some(board) = board {
+        tools.push(create_get_current_flowscript_tool(board.clone()));
         tools.push(create_edit_flowscript_tool(
             board,
             catalog_provider,
@@ -682,6 +686,7 @@ const MAX_EMIT_COMMANDS: usize = 20;
 struct KnownPins {
     inputs: HashSet<String>,
     outputs: HashSet<String>,
+    is_layer: bool,
 }
 
 fn create_validate_commands_tool(graph_context: Option<Arc<GraphContext>>) -> (Tool, ToolHandler) {
@@ -961,6 +966,39 @@ typed arguments. Covers every package in the project's catalog."#,
 /// Always validates first: parse errors and reconcile diagnostics are reported back to the agent
 /// and NOTHING is queued. Only a clean parse that yields commands queues them (status "queued"),
 /// where the main chat loop turns them into a reviewable `<commands>` envelope.
+fn create_get_current_flowscript_tool(board: Arc<Board>) -> (Tool, ToolHandler) {
+    let tool = Tool::new("get_current_flowscript")
+        .description(
+            r#"Return the current live board as anchored FlowScript.
+
+Use this before editing an existing board, especially after prior tool calls or validation errors.
+The returned document is the source you must edit and submit in full to `edit_flowscript`; preserve
+all `//@n:<id>` anchors on statements you keep."#,
+        )
+        .schema(json!({
+            "type": "object",
+            "properties": {}
+        }));
+
+    let handler: ToolHandler = Arc::new(move |_name, _args| {
+        let flowscript = board_to_flowscript(
+            &board,
+            &RenderOptions {
+                anchors: true,
+                ..Default::default()
+            },
+        );
+        let payload = json!({
+            "status": "ok",
+            "flowscript": flowscript,
+            "message": "Edit this exact FlowScript document and submit the full edited source to edit_flowscript."
+        });
+        ToolResultObject::text(serde_json::to_string_pretty(&payload).unwrap_or_default())
+    });
+
+    (tool, handler)
+}
+
 fn create_edit_flowscript_tool(
     board: Arc<Board>,
     provider: Option<Arc<dyn CatalogProvider>>,
@@ -970,27 +1008,37 @@ fn create_edit_flowscript_tool(
         .description(
             r#"Apply an edited FlowScript document to the board (PRIMARY way to modify a workflow).
 
-Submit the FULL edited FlowScript source (the same document shown in the system context).
-Reconcile compares it to the live board using the `//@n:<id>` anchor comments and catalog
-declarations, then produces minimal changes:
+For existing-board edits, call `get_current_flowscript` first, edit that exact returned document,
+and submit the FULL edited FlowScript source. Reconcile compares it to the live board using the
+`//@n:<id>` anchor comments and catalog declarations, then produces minimal changes:
 - A changed literal argument on an anchored call → updates that node's pin value.
-- An anchored statement you removed → deletes that node.
+- An anchored statement you removed → deletes that node only when `allow_deletions` is true.
 - A new unanchored FlowScript call → adds that node, configures literal args, and connects
   resolvable FlowScript references/nested calls.
+- A new unanchored `function name(...) { ... }` declaration → creates a Function layer, places
+  body nodes inside it, creates boundary pins from params/returns, and wires `return` values.
 
 VALIDATION: This tool validates before queueing. If it reports parse errors or diagnostics,
 nothing was queued — fix the FlowScript and resubmit. Only a clean parse queues commands.
 
 RULES:
 - PRESERVE every `//@n:<id>` anchor comment on statements you keep, exactly as given.
+- Leave `allow_deletions` false unless the user explicitly asked to delete existing board items.
 - Do NOT invent anchors for brand-new nodes; write normal unanchored calls using declarations
   from `get_declarations`.
+- If you use `variableGet({ varRef: "NAME" })` or any `varRef`, `NAME` must resolve to an
+  existing variable or a top-level FlowScript variable declaration such as
+  `const NAME: string = ""`; missing varRefs are validation errors.
 - FlowScript statement order maps to the normal execution path only when the previous node has one
-  execution output or an explicit continuation policy in the reconciler. Multi-output nodes are
-  not guessed by pin order; API Call/httpFetch continues from `exec_success`, never `exec_error`.
-  If no policy exists, validation reports a diagnostic instead of queueing an unsafe edge.
+  execution output, a `done` / `exec_done` output, or an explicit continuation policy in the
+  reconciler. Multi-output nodes are not guessed by pin order; API Call/httpFetch continues from
+  `exec_success`, never `exec_error`. If no policy exists, validation reports a diagnostic instead
+  of queueing an unsafe edge.
 - Existing multi-output execution graphs render back to FlowScript as labelled branch blocks, so
   board -> FlowScript -> board preserves those branches rather than flattening them.
+- Streaming calls with `on_stream` plus `exec_done` may place `.chunk` consumers immediately after
+  the call; those consumers wire from `on_stream`, while later `.response` / `.stats` consumers
+  continue from `exec_done`.
 - For loops, the body is the `exec_out` path and the next statement continues from `done` /
   `exec_done`; make sure the loop's `array` input receives the array being iterated.
 - To reposition nodes on the canvas, use `emit_commands` with MoveNode."#,
@@ -1001,6 +1049,10 @@ RULES:
                 "flowscript": {
                     "type": "string",
                     "description": "The full edited FlowScript source for the board, with anchors preserved."
+                },
+                "allow_deletions": {
+                    "type": "boolean",
+                    "description": "Set true only when the user explicitly requested deletion of existing board items. Defaults false to prevent incomplete FlowScript from deleting nodes."
                 }
             },
             "required": ["flowscript"]
@@ -1014,6 +1066,11 @@ RULES:
             .or_else(|| args.get("content"))
             .and_then(|v| v.as_str())
             .unwrap_or("");
+        let allow_deletions = args
+            .get("allow_deletions")
+            .or_else(|| args.get("allowDeletions"))
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
 
         if flowscript.trim().is_empty() {
             let payload = json!({
@@ -1064,6 +1121,23 @@ RULES:
             );
         }
 
+        if !allow_deletions {
+            let destructive = destructive_flowscript_command_summaries(&result.commands);
+            if !destructive.is_empty() {
+                let message = blocked_destructive_flowscript_message(&destructive);
+                let payload = json!({
+                    "status": "validation_errors",
+                    "errors": [message],
+                    "diagnostics": result.diagnostics,
+                    "flowscript_workspace_summary": flowscript_summary(flowscript),
+                    "message": "FlowScript validation failed. Deletions require an explicit allow_deletions=true opt-in."
+                });
+                return ToolResultObject::text(
+                    serde_json::to_string_pretty(&payload).unwrap_or_default(),
+                );
+            }
+        }
+
         // Clean parse with derived commands → queue them for review.
         let commands_value = serde_json::to_value(&result.commands).unwrap_or(json!([]));
         if let Some(store) = &side_effect_commands
@@ -1110,6 +1184,7 @@ fn validate_sdk_emit_commands(
                 KnownPins {
                     inputs: node.inputs.iter().map(|pin| pin.name.clone()).collect(),
                     outputs: node.outputs.iter().map(|pin| pin.name.clone()).collect(),
+                    is_layer: false,
                 },
             );
         }
@@ -1120,6 +1195,7 @@ fn validate_sdk_emit_commands(
                 KnownPins {
                     inputs: layer.inputs.iter().map(|pin| pin.name.clone()).collect(),
                     outputs: layer.outputs.iter().map(|pin| pin.name.clone()).collect(),
+                    is_layer: true,
                 },
             );
         }
@@ -1192,6 +1268,7 @@ fn validate_sdk_emit_commands(
                                     .filter(|pin| pin.pin_type == PinType::Output)
                                     .map(|pin| pin.name.clone())
                                     .collect(),
+                                is_layer: false,
                             },
                         );
                     }
@@ -1230,6 +1307,7 @@ fn validate_sdk_emit_commands(
                         let mut entity = KnownPins {
                             inputs: HashSet::from(["exec_in".to_string()]),
                             outputs: HashSet::from(["exec_out".to_string()]),
+                            is_layer: true,
                         };
                         let mut seen_pins = HashSet::new();
                         for pin in pins.as_deref().unwrap_or(&[]) {
@@ -1274,7 +1352,9 @@ fn validate_sdk_emit_commands(
                     ));
                 }
                 match known_entities.get(from_node) {
-                    Some(entity) if entity.outputs.contains(from_pin) => {}
+                    Some(entity)
+                        if entity.outputs.contains(from_pin)
+                            || (entity.is_layer && entity.inputs.contains(from_pin)) => {}
                     Some(entity) => errors.push(pin_lookup_error(
                         index,
                         from_node,
@@ -1287,7 +1367,9 @@ fn validate_sdk_emit_commands(
                     )),
                 }
                 match known_entities.get(to_node) {
-                    Some(entity) if entity.inputs.contains(to_pin) => {}
+                    Some(entity)
+                        if entity.inputs.contains(to_pin)
+                            || (entity.is_layer && entity.outputs.contains(to_pin)) => {}
                     Some(entity) => errors.push(pin_lookup_error(
                         index,
                         to_node,
@@ -1356,6 +1438,9 @@ fn validate_sdk_emit_commands(
                 }
             }
             BoardCommand::CreateLayer {
+                name,
+                ref_id,
+                pins,
                 node_ids,
                 position,
                 target_layer,
@@ -1379,6 +1464,59 @@ fn validate_sdk_emit_commands(
                     errors.push(format!(
                         "Command {index}: target_layer '{layer_id}' is unknown"
                     ));
+                }
+                if let Some(pins) = pins {
+                    let mut seen_pins = HashSet::new();
+                    for pin in pins {
+                        if pin.name.trim().is_empty() {
+                            errors
+                                .push(format!("Command {index}: layer pin names cannot be empty"));
+                            continue;
+                        }
+                        if !seen_pins.insert(pin.name.clone()) {
+                            errors.push(format!(
+                                "Command {index}: duplicate layer pin '{}'",
+                                pin.name
+                            ));
+                        }
+                        if !matches!(pin.pin_type.as_str(), "Input" | "Output") {
+                            errors.push(format!(
+                                "Command {index}: layer pin '{}' has invalid pin_type '{}'",
+                                pin.name, pin.pin_type
+                            ));
+                        }
+                    }
+                }
+                let key = ref_id
+                    .clone()
+                    .unwrap_or_else(|| format!("__new_layer_{index}"));
+                if !known_entities.contains_key(&key) {
+                    known_entities.insert(
+                        key.clone(),
+                        KnownPins {
+                            inputs: pins
+                                .as_ref()
+                                .map(|pins| {
+                                    pins.iter()
+                                        .filter(|pin| pin.pin_type == "Input")
+                                        .map(|pin| pin.name.clone())
+                                        .collect()
+                                })
+                                .unwrap_or_default(),
+                            outputs: pins
+                                .as_ref()
+                                .map(|pins| {
+                                    pins.iter()
+                                        .filter(|pin| pin.pin_type == "Output")
+                                        .map(|pin| pin.name.clone())
+                                        .collect()
+                                })
+                                .unwrap_or_default(),
+                            is_layer: true,
+                        },
+                    );
+                    known_layers.insert(key);
+                    known_layers.insert(name.clone());
                 }
             }
             BoardCommand::RemoveLayer { layer_id, .. } => {

--- a/apps/desktop/src-tauri/src/functions/flow/board.rs
+++ b/apps/desktop/src-tauri/src/functions/flow/board.rs
@@ -4,9 +4,13 @@ use crate::{
 };
 use flow_like::{
     app::App,
-    flow::board::{Board, VersionType, commands::GenericCommand},
+    flow::{
+        ast::ApplyFlowScriptResult,
+        board::{Board, VersionType, commands::GenericCommand},
+        node::Node,
+    },
 };
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use tauri::AppHandle;
 use tauri_plugin_dialog::DialogExt;
 
@@ -223,6 +227,67 @@ pub async fn execute_commands(
 
     board.save(Some(store)).await?;
     Ok(commands)
+}
+
+#[tauri::command(async)]
+pub async fn apply_flowscript(
+    handler: AppHandle,
+    app_id: String,
+    board_id: String,
+    flowscript: String,
+    current_layer: Option<String>,
+    catalog_nodes: Option<Vec<Node>>,
+    allow_deletions: Option<bool>,
+) -> Result<ApplyFlowScriptResult, TauriFunctionError> {
+    let flow_like_state = TauriFlowLikeState::construct(&handler).await?;
+    let store = TauriFlowLikeState::get_project_meta_store(&handler).await?;
+    let board = flow_like_state.get_board(&board_id, None)?;
+
+    let all_nodes = flow_like_state.node_registry.read().await.get_nodes()?;
+    let app = App::load(app_id, flow_like_state.clone()).await?;
+    let allowed_packages: HashSet<String> = app.packages.keys().cloned().collect();
+
+    let mut catalog_nodes_for_app = all_nodes
+        .into_iter()
+        .filter(|node| match &node.wasm {
+            None => true,
+            Some(wasm) => allowed_packages.contains(&wasm.package_id),
+        })
+        .collect::<Vec<_>>();
+
+    let mut catalog_keys = catalog_nodes_for_app
+        .iter()
+        .map(catalog_node_key)
+        .collect::<HashSet<_>>();
+    for node in catalog_nodes.unwrap_or_default() {
+        if catalog_keys.insert(catalog_node_key(&node)) {
+            catalog_nodes_for_app.push(node);
+        }
+    }
+
+    let mut board = board.lock().await;
+    let result = flow_like::flow::ast::apply_flowscript_to_board(
+        &mut board,
+        &flowscript,
+        &catalog_nodes_for_app,
+        flow_like_state,
+        current_layer,
+        allow_deletions.unwrap_or(false),
+    )
+    .await?;
+
+    if !result.commands.is_empty() {
+        board.save(Some(store)).await?;
+    }
+
+    Ok(result)
+}
+
+fn catalog_node_key(node: &Node) -> (Option<String>, String) {
+    (
+        node.wasm.as_ref().map(|wasm| wasm.package_id.clone()),
+        node.name.clone(),
+    )
 }
 
 /// Gets the elements required for executing a workflow on a specific page.

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -949,6 +949,7 @@ pub fn run() {
             functions::flow::board::redo_board,
             functions::flow::board::execute_command,
             functions::flow::board::execute_commands,
+            functions::flow::board::apply_flowscript,
             functions::flow::board::get_execution_elements,
             functions::flow::board::save_board,
             functions::flow::run::execute_board,

--- a/apps/web/lib/web-states/board-state.ts
+++ b/apps/web/lib/web-states/board-state.ts
@@ -1,4 +1,5 @@
 import {
+	type IApplyFlowScriptResponse,
 	type IBoard,
 	type IBoardState,
 	ICommentType,
@@ -652,6 +653,21 @@ export class WebBoardState implements IBoardState {
 		return apiPost<IGenericCommand[]>(
 			`apps/${appId}/board/${boardId}`,
 			{ commands },
+			this.backend.auth,
+		);
+	}
+
+	async applyFlowScript(
+		appId: string,
+		boardId: string,
+		flowscript: string,
+		currentLayer?: string,
+		catalogNodes?: INode[],
+		allowDeletions = false,
+	): Promise<IApplyFlowScriptResponse> {
+		return apiPost<IApplyFlowScriptResponse>(
+			`apps/${appId}/board/${boardId}/flowscript/apply`,
+			{ flowscript, current_layer: currentLayer, allow_deletions: allowDeletions },
 			this.backend.auth,
 		);
 	}

--- a/packages/api/src/routes/app/board.rs
+++ b/packages/api/src/routes/app/board.rs
@@ -1,3 +1,4 @@
+pub mod apply_flowscript;
 pub mod delete_board;
 pub mod execute_commands;
 pub mod get_board;
@@ -41,6 +42,10 @@ pub fn routes() -> Router<AppState> {
         .route(
             "/{board_id}/version",
             get(get_board_versions::get_board_versions),
+        )
+        .route(
+            "/{board_id}/flowscript/apply",
+            post(apply_flowscript::apply_flowscript),
         )
         .route(
             "/{board_id}/realtime",

--- a/packages/api/src/routes/app/board/apply_flowscript.rs
+++ b/packages/api/src/routes/app/board/apply_flowscript.rs
@@ -1,0 +1,103 @@
+use std::sync::Arc;
+
+use crate::{
+    ensure_permission,
+    error::ApiError,
+    middleware::jwt::AppUser,
+    permission::role_permission::RolePermissions,
+    routes::app::wasm_catalog::{app_wasm_nodes, hydrate_board_wasm_metadata},
+    state::AppState,
+};
+use axum::{
+    Extension, Json,
+    extract::{Path, State},
+};
+use flow_like::flow::ast::ApplyFlowScriptResult;
+use serde::Deserialize;
+use utoipa::ToSchema;
+
+#[derive(Clone, Deserialize, ToSchema)]
+pub struct ApplyFlowScriptBody {
+    pub flowscript: String,
+    #[serde(default)]
+    pub current_layer: Option<String>,
+    #[serde(default)]
+    pub allow_deletions: bool,
+}
+
+#[utoipa::path(
+    post,
+    path = "/apps/{app_id}/board/{board_id}/flowscript/apply",
+    tag = "boards",
+    params(
+        ("app_id" = String, Path, description = "Application ID"),
+        ("board_id" = String, Path, description = "Board ID")
+    ),
+    request_body = ApplyFlowScriptBody,
+    responses(
+        (status = 200, description = "FlowScript applied, returns resulting commands", body = Object),
+        (status = 400, description = "Invalid FlowScript or generated command plan"),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Forbidden")
+    )
+)]
+#[tracing::instrument(
+    name = "POST /apps/{app_id}/board/{board_id}/flowscript/apply",
+    skip(state, user, params)
+)]
+pub async fn apply_flowscript(
+    State(state): State<AppState>,
+    Extension(user): Extension<AppUser>,
+    Path((app_id, board_id)): Path<(String, String)>,
+    Json(params): Json<ApplyFlowScriptBody>,
+) -> Result<Json<ApplyFlowScriptResult>, ApiError> {
+    let permission = ensure_permission!(user, &app_id, &state, RolePermissions::WriteBoards);
+    let sub = permission.sub()?;
+
+    let mut board = state
+        .master_board(&sub, &app_id, &board_id, &state, None)
+        .await?;
+
+    let flow_state = {
+        if let Some(flow_state) = &board.app_state {
+            flow_state.clone()
+        } else {
+            let flow_state = state
+                .scoped_credentials(
+                    &sub,
+                    &app_id,
+                    crate::credentials::CredentialsAccess::EditApp,
+                )
+                .await?
+                .to_state(state.clone())
+                .await?;
+            Arc::new(flow_state)
+        }
+    };
+
+    let wasm_nodes = app_wasm_nodes(&state, &app_id).await?;
+    let builtin_nodes = state.registry.as_ref().get_nodes();
+    if hydrate_board_wasm_metadata(&mut board, &wasm_nodes, &builtin_nodes) {
+        board.mark_changed();
+    }
+
+    let mut catalog_nodes = builtin_nodes;
+    catalog_nodes.extend(wasm_nodes);
+
+    let result = flow_like::flow::ast::apply_flowscript_to_board(
+        &mut board,
+        &params.flowscript,
+        &catalog_nodes,
+        flow_state,
+        params.current_layer,
+        params.allow_deletions,
+    )
+    .await
+    .map_err(|error| ApiError::bad_request(error.to_string()))?;
+
+    if !result.commands.is_empty() {
+        board.save(None).await?;
+    }
+
+    Ok(Json(result))
+}

--- a/packages/ast/src/parse/parser.rs
+++ b/packages/ast/src/parse/parser.rs
@@ -466,6 +466,12 @@ impl Parser<'_> {
             if self.at_eof() {
                 return Err(self.err("unexpected end of input inside block"));
             }
+            if matches!(self.cur(), Tok::LBrace) {
+                self.bump();
+                let nested = self.block_body()?;
+                stmts.extend(nested.stmts);
+                continue;
+            }
             stmts.push(self.stmt()?);
         }
         self.bump(); // }

--- a/packages/ast/tests/parse.rs
+++ b/packages/ast/tests/parse.rs
@@ -199,6 +199,17 @@ fn parses_untyped_let_assignment_sugar() {
 }
 
 #[test]
+fn parses_bare_group_blocks_inside_event_body() {
+    let text = "onStart() {\n    {\n        const request = httpMakeRequest({ method: \"GET\", url: \"https://example.com\" })\n        const response = httpFetch({ request: request.request })\n    }\n}\n";
+    let ast = parse(text).expect("parse should accept grouped statement blocks");
+
+    assert_eq!(
+        render(&ast, &RenderOptions::default()),
+        "onStart() {\n    const request = httpMakeRequest({ method: \"GET\", url: \"https://example.com\" })\n    const response = httpFetch({ request: request.request })\n}\n"
+    );
+}
+
+#[test]
 fn parses_model_authored_gmail_ingest_shape() {
     let text = r#"@category("Gmail")
 const GMAIL_ADDRESS: string = "GMAIL_ADDRESS"

--- a/packages/catalog/llm/src/agent/helpers.rs
+++ b/packages/catalog/llm/src/agent/helpers.rs
@@ -1826,8 +1826,7 @@ pub async fn execute_agent_streaming(
                     let args_map = arguments.as_object().cloned();
                     let mut params = CallToolRequestParams::new(name.clone());
                     params.arguments = args_map;
-                    match mcp_peer.call_tool(params).await
-                    {
+                    match mcp_peer.call_tool(params).await {
                         Ok(result) => {
                             context.log_message(
                                 &format!(

--- a/packages/core/src/a2ui/copilot/mod.rs
+++ b/packages/core/src/a2ui/copilot/mod.rs
@@ -22,8 +22,8 @@ pub use types::*;
 
 use std::sync::Arc;
 
-use flow_like_types::Result;
 use flow_like_model_provider::llm::CompletionClientDyn;
+use flow_like_types::Result;
 use futures::StreamExt;
 use rig::{
     OneOrMany,

--- a/packages/core/src/copilot/prompts.rs
+++ b/packages/core/src/copilot/prompts.rs
@@ -31,7 +31,7 @@ Every response you give MUST include at least one tool call. You are a tool-call
 - Repeating information the user can already see in the UI
 
 **MANDATORY TOOL USAGE BY REQUEST TYPE:**
-- User asks to CREATE/ADD/BUILD workflow behavior → call get_declarations, then edit_flowscript when available
+- User asks to CREATE/ADD/BUILD workflow behavior → call get_current_flowscript when a board exists, call get_declarations, then edit_flowscript when available
 - User asks to CREATE/ADD/BUILD UI → call validate_ui first when available, then emit_ui
 - User asks to MODIFY/CHANGE/UPDATE → call the relevant validate/emit tool sequence immediately
 - User asks about the current board/workflow, asks "explain", "what does this do", "why is this
@@ -126,9 +126,9 @@ unambiguous or explicitly mapped in code.
   blocks with labels such as `// exec_success` and `// exec_error`, preserving the real graph.
 - FlowScript -> Board: new straight-line statements are auto-wired through the default
   continuation output selected by the reconciler policy table, not by model guesswork or pin order.
-- Multi-output nodes MUST have an explicit policy/callback in `EXEC_OUTPUT_POLICIES` before
-  reconcile may auto-wire a following statement. For API Call / `httpFetch`, the policy is
-  `exec_success`; never continue normal work from `exec_error`.
+- Multi-output nodes may auto-wire a following statement only from a built-in `done` / `exec_done`
+  continuation or from an explicit policy/callback in `EXEC_OUTPUT_POLICIES`. For API Call /
+  `httpFetch`, the policy is `exec_success`; never continue normal work from `exec_error`.
 - If no policy exists for a multi-output node, `edit_flowscript` reports a diagnostic and queues no
   unsafe execution edge. Use exact branch/control declarations or `emit_commands` for explicit
   wiring instead of guessing a pin.
@@ -177,6 +177,9 @@ Actionable empty-board edits:
   `run() { const db = openLocalDb({ name: "email_vectors" }) }`.
 - Do not put node calls in top-level declarations. Top-level `const name: Type = literal` is only
   board state/defaults and must use literal defaults, not `openLocalDb(...)` or another call.
+- For `variableGet({ varRef: "NAME" })` and other `varRef` inputs, `NAME` must already exist as a
+  board variable or be declared as a top-level FlowScript variable, for example
+  `const NAME: string = ""`.
 - Inside a function/event block, `const name = ...` is only for binding a node-call output. The
   right side must be a call expression like `openLocalDb({ name: "x" })`, not a literal, object,
   array, field access, or arithmetic expression.
@@ -423,17 +426,24 @@ graph. This is your DEFAULT editing surface. Each statement that maps to a real 
 `//@n:<id>` anchor comment that ties it back to that node's stable identity.
 
 To MODIFY the workflow:
-1. Read the FlowScript below to understand the current graph.
+1. Read the FlowScript below to understand the current graph. For any existing-board edit, call
+   `get_current_flowscript` immediately before `edit_flowscript` and edit that returned source.
 2. Call `get_declarations` to look up the exact signatures of any nodes you want to call.
 3. Edit the FlowScript text and submit the FULL document via `edit_flowscript`.
    - PRESERVE every `//@n:<id>` anchor on statements you keep.
-   - Changing a literal argument updates that node's pin; deleting an anchored statement removes
-     that node.
+   - Changing a literal argument updates that node's pin. Deleting anchored statements is blocked
+     unless `allow_deletions` is explicitly true; leave it false unless the user asked to delete.
    - New unanchored catalog calls are translated automatically into AddNode/ConnectPins/
      UpdateNodePin commands after validation. Do NOT hand-write command JSON for normal workflow
      node authoring.
+   - Add `function name(params): (returns) {{ ... }}` declarations to create Function layers.
+     Function params become layer input pins, returns become output pins, and body nodes are placed
+     inside the function layer by FlowScript reconcile.
    - New catalog calls must be inside a function/event block. Top-level `const name: Type = ...`
      declarations are variables/defaults only, must use literal defaults, and do not create nodes.
+   - Any `varRef` string used by `variableGet`/variable set nodes must resolve to an existing
+     variable or a top-level FlowScript variable declaration.
+   - Do NOT use `emit_commands` for workflow functions; write/edit FlowScript functions.
    - Do NOT submit implementation plans, TODOs, function stubs, or comments-only FlowScript.
      `edit_flowscript` needs concrete catalog calls from `get_declarations`.
 
@@ -494,7 +504,7 @@ If target_layer is omitted, nodes are added to the current/root layer.
 **Inspect**: list_board_nodes (summarize existing graph), get_unconfigured_nodes (find nodes missing required inputs or setup), find_connectable_nodes (discover nodes that can connect to a given pin)
 **Catalog** ({node_count} nodes): catalog_search (by name/description), get_declarations (FlowScript .flow.d signatures), search_by_pin (by pin type), filter_category (by category){templates}{logs}
 **Runtime/Data**: internet_search (SearXNG web search), database_tool (list/query/modify LanceDB/Open Database tables), storage_tool (list/read/create/delete app storage files), execute_event (run an event and inspect logs), ask_user (rare targeted question with defaults)
-**Modify**: edit_flowscript (PRIMARY — apply edited FlowScript text), emit_commands (MoveNode/layout and non-FlowScript features)
+**Modify**: get_current_flowscript (retrieve exact live board code), edit_flowscript (PRIMARY — apply edited FlowScript text, including function layers), emit_commands (MoveNode/layout and non-FlowScript features)
 
 ## Key Rules
 1. Reference nodes in your explanations using: <focus_node>NODE_ID</focus_node> to highlight them in the UI
@@ -661,7 +671,7 @@ You are FlowPilot, an expert development assistant for both frontend UI and back
 
 Analyze the user's request and immediately call the appropriate tool:
 - UI work → call `validate_ui`, then `emit_ui` with complete A2UI JSON
-- Workflow work with a board/FlowScript context → call `get_declarations`, then `edit_flowscript` with the full edited FlowScript
+- Workflow work with a board/FlowScript context → call `get_current_flowscript`, call `get_declarations` as needed, then `edit_flowscript` with the full edited FlowScript
 - Workflow layout-only work → call `validate_commands`, then `emit_commands` with MoveNode commands
 - Both → call both tools in sequence
 - Unclear → call `catalog_search` or `list_board_nodes` to gather context, then act
@@ -822,18 +832,23 @@ node carries a `//@n:<id>` anchor comment tying it to that node's stable identit
 ```
 
 ## HOW TO MODIFY (execute in order)
-1. Read the FlowScript above to understand the current graph.
+1. Read the FlowScript above to understand the current graph. For any existing-board edit, call
+   `get_current_flowscript` immediately before `edit_flowscript` and edit that returned source.
 2. Call `get_declarations` with focused non-empty queries to look up exact signatures
    (camelCase name, typed params, `// impure` marker) of nodes you intend to call. Never use a
    blank query and never guess a node name or pin.
 3. Edit the FlowScript text and submit the FULL document via `edit_flowscript`.
    - PRESERVE every `//@n:<id>` anchor on statements you keep, exactly as given.
    - Changing a literal argument on an anchored call updates that node's pin value.
-   - Deleting an anchored statement removes that node.
+   - Deleting anchored statements is blocked unless `allow_deletions` is explicitly true; leave it
+     false unless the user asked to delete.
    - Adding a new unanchored catalog call creates that node, sets literal args, and connects
      resolvable FlowScript references/nested calls.
+   - Adding a new `function name(params): (returns) {{ ... }}` declaration creates a Function
+     layer with boundary pins from the signature and places the body nodes inside it.
    - Put new catalog calls inside a function/event block. Top-level `const name: Type = literal`
      declares state/defaults only; it cannot call nodes and is not enough to create a workflow.
+   - Do not use `emit_commands` for workflow functions; use FlowScript functions.
    - Never submit implementation plans, TODOs, function stubs, or comments-only FlowScript. Use
      exact declarations and concrete node calls.
 4. `edit_flowscript` ALWAYS validates first. If it reports parse errors or diagnostics, NOTHING is
@@ -842,8 +857,8 @@ node carries a `//@n:<id>` anchor comment tying it to that node's stable identit
 ## WHEN TO USE emit_commands INSTEAD
 Use the lower-level `emit_commands` tool ONLY for what FlowScript text cannot express:
 - Repositioning nodes on the canvas (MoveNode) — positions are visual and not part of FlowScript.
-- Comments, placeholders/layers, and other visual/modeling constructs that do not yet have
-  FlowScript syntax.
+- Comments, visual placeholders/collapsed layers, and other modeling constructs that do not yet
+  have FlowScript syntax. Function layers DO have FlowScript syntax: use `function ... {{ ... }}`.
 Always call `validate_commands` before `emit_commands`; fix any reported errors and re-validate
 before emitting.
 
@@ -866,8 +881,9 @@ get_unconfigured_nodes (nodes missing required inputs)
 LanceDB/Open Database tables), storage_tool (list/read/create/delete app storage files),
 execute_event (run an event and inspect bounded logs), ask_user (rare targeted question with
 defaults)
-**Modify**: edit_flowscript (PRIMARY — apply edited FlowScript text), emit_commands (layout or
-non-FlowScript changes; validate_commands first)
+**Modify**: get_current_flowscript (retrieve exact live board code), edit_flowscript (PRIMARY —
+apply edited FlowScript text, including function layers), emit_commands (layout or non-FlowScript
+changes; validate_commands first)
 
 ## Board Rules
 1. Reference nodes in explanations with <focus_node>NODE_ID</focus_node> to highlight them.

--- a/packages/core/src/flow/ast/apply.rs
+++ b/packages/core/src/flow/ast/apply.rs
@@ -1,0 +1,1019 @@
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+    time::SystemTime,
+};
+
+use flow_like_ast::to_camel_case;
+use flow_like_types::create_id;
+use serde::Serialize;
+
+use crate::{
+    flow::{
+        board::{
+            Board, Comment, CommentType, Layer, LayerType,
+            commands::{
+                GenericCommand,
+                comments::{
+                    remove_comment::RemoveCommentCommand, upsert_comment::UpsertCommentCommand,
+                },
+                layer::{remove_layer::RemoveLayerCommand, upsert_layer::UpsertLayerCommand},
+                nodes::{
+                    add_node::AddNodeCommand, move_node::MoveNodeCommand,
+                    remove_node::RemoveNodeCommand, update_node::UpdateNodeCommand,
+                },
+                pins::{connect_pins::ConnectPinsCommand, disconnect_pins::DisconnectPinsCommand},
+                variables::{
+                    remove_variable::RemoveVariableCommand, upsert_variable::UpsertVariableCommand,
+                },
+            },
+        },
+        copilot::{BoardCommand, NodePosition, PlaceholderPinDef, node_to_metadata},
+        node::Node,
+        pin::{Pin, PinType, ValueType},
+        variable::{Variable, VariableType},
+    },
+    state::FlowLikeState,
+};
+
+const DEFAULT_OUTPUT_PIN_ALIASES: &[&str] = &["result", "value", "output", "out"];
+
+/// Result returned by the server-side FlowScript apply path.
+///
+/// `commands` is the executed generic command batch and is the value callers should record for
+/// undo/redo. `board_commands` is the reconciled higher-level command plan for review/debug UI.
+#[derive(Clone, Serialize)]
+pub struct ApplyFlowScriptResult {
+    pub commands: Vec<GenericCommand>,
+    pub board_commands: Vec<BoardCommand>,
+    pub diagnostics: Vec<String>,
+}
+
+pub fn destructive_flowscript_command_summaries(commands: &[BoardCommand]) -> Vec<String> {
+    commands
+        .iter()
+        .filter_map(|command| match command {
+            BoardCommand::RemoveNode { node_id, .. } => Some(format!("node `{node_id}`")),
+            BoardCommand::RemoveVariable { variable_id, .. } => {
+                Some(format!("variable `{variable_id}`"))
+            }
+            BoardCommand::RemoveLayer { layer_id, .. } => Some(format!("layer `{layer_id}`")),
+            BoardCommand::RemoveComment { comment_id, .. } => {
+                Some(format!("comment `{comment_id}`"))
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+pub fn blocked_destructive_flowscript_message(summaries: &[String]) -> String {
+    let preview = summaries
+        .iter()
+        .take(8)
+        .cloned()
+        .collect::<Vec<_>>()
+        .join(", ");
+    let more = summaries
+        .len()
+        .checked_sub(8)
+        .filter(|count| *count > 0)
+        .map(|count| format!(" and {count} more"))
+        .unwrap_or_default();
+
+    format!(
+        "FlowScript edit would delete {} existing board item(s): {preview}{more}. Deletions are blocked by default so incomplete model edits cannot remove existing work. Re-submit the full current FlowScript with every kept `//@n:<id>` anchor preserved, or set `allow_deletions` only for an explicit delete request.",
+        summaries.len()
+    )
+}
+
+pub async fn apply_flowscript_to_board(
+    board: &mut Board,
+    flowscript: &str,
+    catalog_nodes: &[Node],
+    state: Arc<FlowLikeState>,
+    current_layer: Option<String>,
+    allow_deletions: bool,
+) -> flow_like_types::Result<ApplyFlowScriptResult> {
+    let catalog_metadata = catalog_nodes
+        .iter()
+        .map(node_to_metadata)
+        .collect::<Vec<_>>();
+    let mut reconcile = super::reconcile_text_with_catalog(board, flowscript, &catalog_metadata);
+
+    if !reconcile.diagnostics.is_empty() || reconcile.commands.is_empty() {
+        return Ok(ApplyFlowScriptResult {
+            commands: Vec::new(),
+            board_commands: reconcile.commands,
+            diagnostics: reconcile.diagnostics,
+        });
+    }
+
+    if !allow_deletions {
+        let destructive = destructive_flowscript_command_summaries(&reconcile.commands);
+        if !destructive.is_empty() {
+            let mut diagnostics = std::mem::take(&mut reconcile.diagnostics);
+            diagnostics.insert(0, blocked_destructive_flowscript_message(&destructive));
+            return Ok(ApplyFlowScriptResult {
+                commands: Vec::new(),
+                board_commands: reconcile.commands,
+                diagnostics,
+            });
+        }
+    }
+
+    let mut planner = FlowScriptApplyPlanner::new(board, catalog_nodes, current_layer);
+    let setup_commands = planner.build_setup_commands(board, &reconcile.commands)?;
+    let mut applied_commands = Vec::new();
+
+    if !setup_commands.is_empty() {
+        match board.execute_commands(setup_commands, state.clone()).await {
+            Ok(mut executed) => applied_commands.append(&mut executed),
+            Err(error) => return Err(error),
+        }
+    }
+
+    let remaining_commands = match planner.build_remaining_commands(board, &reconcile.commands) {
+        Ok(commands) => commands,
+        Err(error) => {
+            rollback_applied(board, &applied_commands, state.clone(), error).await?;
+            return Ok(ApplyFlowScriptResult {
+                commands: Vec::new(),
+                board_commands: reconcile.commands,
+                diagnostics: vec!["FlowScript apply failed and was rolled back".to_string()],
+            });
+        }
+    };
+
+    if !remaining_commands.is_empty() {
+        match board
+            .execute_commands(remaining_commands, state.clone())
+            .await
+        {
+            Ok(mut executed) => applied_commands.append(&mut executed),
+            Err(error) => {
+                rollback_applied(board, &applied_commands, state.clone(), error).await?;
+            }
+        }
+    }
+
+    Ok(ApplyFlowScriptResult {
+        commands: applied_commands,
+        board_commands: reconcile.commands,
+        diagnostics: reconcile.diagnostics,
+    })
+}
+
+async fn rollback_applied(
+    board: &mut Board,
+    applied_commands: &[GenericCommand],
+    state: Arc<FlowLikeState>,
+    error: flow_like_types::Error,
+) -> flow_like_types::Result<()> {
+    if applied_commands.is_empty() {
+        return Err(error);
+    }
+
+    let primary_error = error.to_string();
+    if let Err(rollback_error) = board.undo(applied_commands.to_vec(), state).await {
+        return Err(flow_like_types::anyhow!(
+            "FlowScript apply failed: {primary_error}; rollback failed: {rollback_error}"
+        ));
+    }
+
+    Err(flow_like_types::anyhow!(
+        "FlowScript apply failed and was rolled back: {primary_error}"
+    ))
+}
+
+struct FlowScriptApplyPlanner {
+    catalog_nodes: HashMap<String, Node>,
+    node_refs: HashMap<String, String>,
+    ambiguous_node_refs: HashSet<String>,
+    staged_nodes: HashMap<String, Node>,
+    staged_layers: HashMap<String, Layer>,
+    current_layer: Option<String>,
+    base_x: f32,
+    base_y: f32,
+    next_position: usize,
+    next_node_index: usize,
+}
+
+impl FlowScriptApplyPlanner {
+    fn new(board: &Board, catalog_nodes: &[Node], current_layer: Option<String>) -> Self {
+        let mut planner = Self {
+            catalog_nodes: catalog_nodes
+                .iter()
+                .map(|node| (node.name.clone(), node.clone()))
+                .collect(),
+            node_refs: HashMap::new(),
+            ambiguous_node_refs: HashSet::new(),
+            staged_nodes: HashMap::new(),
+            staged_layers: HashMap::new(),
+            current_layer,
+            base_x: 100.0,
+            base_y: 100.0,
+            next_position: 0,
+            next_node_index: 0,
+        };
+
+        if let Some(rightmost) = board.nodes.values().max_by(|left, right| {
+            let left_x = left.coordinates.map(|c| c.0).unwrap_or(0.0);
+            let right_x = right.coordinates.map(|c| c.0).unwrap_or(0.0);
+            left_x.total_cmp(&right_x)
+        }) {
+            planner.base_x = rightmost.coordinates.map(|c| c.0).unwrap_or(0.0) + 300.0;
+            planner.base_y = rightmost.coordinates.map(|c| c.1).unwrap_or(100.0);
+        }
+
+        for node in board.nodes.values() {
+            planner.register_node_aliases(&[Some(node.id.as_str())], &node.id);
+        }
+        for layer in board.layers.values() {
+            planner.register_node_aliases(
+                &[Some(layer.id.as_str()), Some(layer.name.as_str())],
+                &layer.id,
+            );
+        }
+        for (name, node_id) in &board.refs {
+            planner.register_node_aliases(&[Some(name.as_str())], node_id);
+        }
+
+        planner
+    }
+
+    fn build_setup_commands(
+        &mut self,
+        board: &Board,
+        commands: &[BoardCommand],
+    ) -> flow_like_types::Result<Vec<GenericCommand>> {
+        let mut generic_commands = Vec::new();
+
+        for command in commands {
+            match command {
+                BoardCommand::AddNode {
+                    node_type,
+                    ref_id,
+                    position,
+                    friendly_name,
+                    target_layer,
+                    ..
+                } => {
+                    let Some(catalog_node) = self.catalog_nodes.get(node_type) else {
+                        return Err(flow_like_types::anyhow!(
+                            "Node type `{node_type}` is not available in the catalog"
+                        ));
+                    };
+
+                    let mut add_command = AddNodeCommand::new(catalog_node.clone());
+                    let coordinates = self.position_or_next(position.as_ref());
+                    add_command.node.coordinates = Some(coordinates);
+                    if let Some(friendly_name) = friendly_name {
+                        add_command.node.friendly_name = friendly_name.clone();
+                    }
+                    add_command.current_layer =
+                        self.target_layer_or_current(board, target_layer.as_deref())?;
+
+                    let node_id = add_command.node.id.clone();
+                    self.staged_nodes
+                        .insert(node_id.clone(), add_command.node.clone());
+                    let index_alias = format!("${}", self.next_node_index);
+                    self.next_node_index += 1;
+                    self.register_node_aliases(
+                        &[
+                            ref_id.as_deref(),
+                            Some(index_alias.as_str()),
+                            Some(node_type.as_str()),
+                            Some(node_id.as_str()),
+                        ],
+                        &node_id,
+                    );
+
+                    generic_commands.push(GenericCommand::AddNode(add_command));
+                }
+                BoardCommand::AddPlaceholder {
+                    name,
+                    ref_id,
+                    position,
+                    pins,
+                    target_layer,
+                    ..
+                } => {
+                    let layer_id = create_id();
+                    let mut layer =
+                        Layer::new(layer_id.clone(), name.clone(), LayerType::Collapsed);
+                    layer.coordinates = self.position_or_next(position.as_ref());
+                    layer.pins = placeholder_pins(pins.as_deref());
+
+                    let mut command = UpsertLayerCommand::new(layer);
+                    command.current_layer =
+                        self.target_layer_or_current(board, target_layer.as_deref())?;
+
+                    let index_alias = format!("${}", self.next_node_index);
+                    self.next_node_index += 1;
+                    self.register_node_aliases(
+                        &[
+                            ref_id.as_deref(),
+                            Some(index_alias.as_str()),
+                            Some(name.as_str()),
+                            Some(layer_id.as_str()),
+                        ],
+                        &layer_id,
+                    );
+
+                    generic_commands.push(GenericCommand::UpsertLayer(command));
+                }
+                BoardCommand::CreateLayer {
+                    name,
+                    ref_id,
+                    layer_type,
+                    node_ids,
+                    pins,
+                    position,
+                    color,
+                    target_layer,
+                    ..
+                } if node_ids.is_empty() || ref_id.is_some() || pins.is_some() => {
+                    let layer_id = create_id();
+                    let mut layer = Layer::new(
+                        layer_id.clone(),
+                        name.clone(),
+                        layer_type_from_str(layer_type),
+                    );
+                    layer.coordinates = self.position_or_base(position.as_ref());
+                    layer.color = color.clone();
+                    layer.pins = layer_pins(pins.as_deref());
+
+                    let mut command = UpsertLayerCommand::new(layer.clone());
+                    command.current_layer =
+                        self.target_layer_or_current(board, target_layer.as_deref())?;
+
+                    self.staged_layers.insert(layer_id.clone(), layer);
+                    let index_alias = format!("${}", self.next_node_index);
+                    self.next_node_index += 1;
+                    self.register_node_aliases(
+                        &[
+                            ref_id.as_deref(),
+                            Some(index_alias.as_str()),
+                            Some(name.as_str()),
+                            Some(layer_id.as_str()),
+                        ],
+                        &layer_id,
+                    );
+
+                    generic_commands.push(GenericCommand::UpsertLayer(command));
+                }
+                BoardCommand::CreateVariable {
+                    variable_id,
+                    name,
+                    data_type,
+                    value_type,
+                    default_value,
+                    description,
+                    category,
+                    schema,
+                    exposed,
+                    secret,
+                    editable,
+                    runtime_configured,
+                    target_layer,
+                    ..
+                } => {
+                    let mut variable = Variable::new(
+                        name,
+                        variable_type_from_str(data_type),
+                        value_type_from_str(value_type),
+                    );
+                    variable.id = variable_id.clone().unwrap_or_else(create_id);
+                    variable.description = description.clone();
+                    variable.category = category.clone();
+                    variable.schema = schema.clone();
+                    variable.exposed = exposed.unwrap_or(false);
+                    variable.secret = secret.unwrap_or(false);
+                    variable.editable = editable.unwrap_or(true);
+                    variable.runtime_configured = runtime_configured.unwrap_or(false);
+                    if let Some(default_value) = default_value {
+                        variable.default_value =
+                            Some(flow_like_types::json::to_vec(default_value)?);
+                    }
+
+                    let mut command = UpsertVariableCommand::new(variable);
+                    command.layer_id =
+                        self.resolve_optional_layer(board, target_layer.as_deref())?;
+                    generic_commands.push(GenericCommand::UpsertVariable(command));
+                }
+                BoardCommand::UpdateNodePin {
+                    node_id,
+                    pin_id,
+                    value,
+                    ..
+                } => {
+                    let node_id = self.resolve_node_id(board, node_id)?;
+                    let mut node = self.resolve_node(board, &node_id)?.clone();
+                    let pin_id = resolve_pin_id_in_node(&node, pin_id, Some(PinType::Input))?;
+                    let Some(pin) = node.pins.get_mut(&pin_id) else {
+                        return Err(flow_like_types::anyhow!(
+                            "Pin `{pin_id}` not found on node `{node_id}`"
+                        ));
+                    };
+                    pin.default_value = Some(flow_like_types::json::to_vec(value)?);
+                    self.staged_nodes.insert(node_id.clone(), node.clone());
+                    generic_commands.push(GenericCommand::UpdateNode(UpdateNodeCommand::new(node)));
+                }
+                _ => {}
+            }
+        }
+
+        Ok(generic_commands)
+    }
+
+    fn build_remaining_commands(
+        &mut self,
+        board: &Board,
+        commands: &[BoardCommand],
+    ) -> flow_like_types::Result<Vec<GenericCommand>> {
+        self.staged_nodes.clear();
+        let mut generic_commands = Vec::new();
+
+        for command in commands {
+            match command {
+                BoardCommand::AddNode { .. }
+                | BoardCommand::AddPlaceholder { .. }
+                | BoardCommand::CreateVariable { .. }
+                | BoardCommand::UpdateNodePin { .. } => {}
+                BoardCommand::RemoveNode { node_id, .. } => {
+                    let node_id = self.resolve_node_id(board, node_id)?;
+                    let node = self.resolve_node(board, &node_id)?.clone();
+                    generic_commands.push(GenericCommand::RemoveNode(RemoveNodeCommand::new(node)));
+                }
+                BoardCommand::ConnectPins {
+                    from_node,
+                    from_pin,
+                    to_node,
+                    to_pin,
+                    ..
+                } => {
+                    let from_node_id = self.resolve_node_id(board, from_node)?;
+                    let to_node_id = self.resolve_node_id(board, to_node)?;
+                    let from_pin_id =
+                        self.resolve_pin_id(board, &from_node_id, from_pin, Some(PinType::Output))?;
+                    let to_pin_id =
+                        self.resolve_pin_id(board, &to_node_id, to_pin, Some(PinType::Input))?;
+                    generic_commands.push(GenericCommand::ConnectPin(ConnectPinsCommand::new(
+                        from_node_id,
+                        to_node_id,
+                        from_pin_id,
+                        to_pin_id,
+                    )));
+                }
+                BoardCommand::DisconnectPins {
+                    from_node,
+                    from_pin,
+                    to_node,
+                    to_pin,
+                    ..
+                } => {
+                    let from_node_id = self.resolve_node_id(board, from_node)?;
+                    let to_node_id = self.resolve_node_id(board, to_node)?;
+                    let from_pin_id =
+                        self.resolve_pin_id(board, &from_node_id, from_pin, Some(PinType::Output))?;
+                    let to_pin_id =
+                        self.resolve_pin_id(board, &to_node_id, to_pin, Some(PinType::Input))?;
+                    generic_commands.push(GenericCommand::DisconnectPin(
+                        DisconnectPinsCommand::new(
+                            from_node_id,
+                            to_node_id,
+                            from_pin_id,
+                            to_pin_id,
+                        ),
+                    ));
+                }
+                BoardCommand::MoveNode {
+                    node_id,
+                    position,
+                    target_layer,
+                    ..
+                } => {
+                    let node_id = self.resolve_node_id(board, node_id)?;
+                    let current_layer =
+                        self.target_layer_or_current(board, target_layer.as_deref())?;
+                    generic_commands.push(GenericCommand::MoveNode(MoveNodeCommand::new(
+                        node_id,
+                        (position.x as f32, position.y as f32, 0.0),
+                        current_layer,
+                    )));
+                }
+                BoardCommand::UpdateVariable {
+                    variable_id,
+                    name,
+                    data_type,
+                    value_type,
+                    default_value,
+                    clear_default_value,
+                    description,
+                    clear_description,
+                    category,
+                    clear_category,
+                    schema,
+                    clear_schema,
+                    exposed,
+                    secret,
+                    editable,
+                    runtime_configured,
+                    value,
+                    ..
+                } => {
+                    let Some(existing_variable) = board.variables.get(variable_id) else {
+                        return Err(flow_like_types::anyhow!(
+                            "Variable `{variable_id}` not found"
+                        ));
+                    };
+                    let mut variable = existing_variable.clone();
+                    if let Some(name) = name {
+                        variable.name = name.clone();
+                    }
+                    if let Some(data_type) = data_type {
+                        variable.data_type = variable_type_from_str(data_type);
+                    }
+                    if let Some(value_type) = value_type {
+                        variable.value_type = value_type_from_str(value_type);
+                    }
+                    if *clear_default_value {
+                        variable.default_value = None;
+                    } else if let Some(default_value) = default_value.as_ref().or(value.as_ref()) {
+                        variable.default_value =
+                            Some(flow_like_types::json::to_vec(default_value)?);
+                    }
+                    if *clear_description {
+                        variable.description = None;
+                    } else if let Some(description) = description {
+                        variable.description = Some(description.clone());
+                    }
+                    if *clear_category {
+                        variable.category = None;
+                    } else if let Some(category) = category {
+                        variable.category = Some(category.clone());
+                    }
+                    if *clear_schema {
+                        variable.schema = None;
+                    } else if let Some(schema) = schema {
+                        variable.schema = Some(schema.clone());
+                    }
+                    if let Some(exposed) = exposed {
+                        variable.exposed = *exposed;
+                    }
+                    if let Some(secret) = secret {
+                        variable.secret = *secret;
+                    }
+                    if let Some(editable) = editable {
+                        variable.editable = *editable;
+                    }
+                    if let Some(runtime_configured) = runtime_configured {
+                        variable.runtime_configured = *runtime_configured;
+                    }
+                    generic_commands.push(GenericCommand::UpsertVariable(
+                        UpsertVariableCommand::new(variable),
+                    ));
+                }
+                BoardCommand::RemoveVariable { variable_id, .. } => {
+                    let Some(variable) = board.variables.get(variable_id) else {
+                        return Err(flow_like_types::anyhow!(
+                            "Variable `{variable_id}` not found"
+                        ));
+                    };
+                    generic_commands.push(GenericCommand::RemoveVariable(
+                        RemoveVariableCommand::new(variable.clone()),
+                    ));
+                }
+                BoardCommand::AddComment {
+                    content,
+                    position,
+                    width,
+                    height,
+                    color,
+                    target_layer,
+                    ..
+                } => {
+                    let coordinates = self.position_or_base(Some(position));
+                    let comment = Comment {
+                        id: create_id(),
+                        author: Some("copilot".to_string()),
+                        content: content.clone(),
+                        comment_type: CommentType::Text,
+                        timestamp: SystemTime::now(),
+                        coordinates,
+                        width: width.map(|value| value as f32).or(Some(200.0)),
+                        height: height.map(|value| value as f32).or(Some(100.0)),
+                        layer: None,
+                        color: color.clone(),
+                        z_index: None,
+                        hash: None,
+                        is_locked: None,
+                    };
+                    let mut command = UpsertCommentCommand::new(comment);
+                    command.current_layer =
+                        self.target_layer_or_current(board, target_layer.as_deref())?;
+                    generic_commands.push(GenericCommand::UpsertComment(command));
+                }
+                BoardCommand::RemoveComment { comment_id, .. } => {
+                    let Some(comment) = board.comments.get(comment_id) else {
+                        return Err(flow_like_types::anyhow!("Comment `{comment_id}` not found"));
+                    };
+                    generic_commands.push(GenericCommand::RemoveComment(
+                        RemoveCommentCommand::new(comment.clone()),
+                    ));
+                }
+                BoardCommand::CreateLayer {
+                    name,
+                    ref_id,
+                    layer_type,
+                    node_ids,
+                    pins,
+                    position,
+                    color,
+                    target_layer,
+                    ..
+                } => {
+                    if node_ids.is_empty() || ref_id.is_some() || pins.is_some() {
+                        continue;
+                    }
+                    let mut layer =
+                        Layer::new(create_id(), name.clone(), layer_type_from_str(layer_type));
+                    layer.coordinates = self.position_or_base(position.as_ref());
+                    layer.color = color.clone();
+                    layer.pins = layer_pins(pins.as_deref());
+                    let node_ids = self.resolve_node_ids(board, node_ids)?;
+                    let mut command = UpsertLayerCommand::new(layer);
+                    command.node_ids = node_ids;
+                    command.current_layer =
+                        self.target_layer_or_current(board, target_layer.as_deref())?;
+                    generic_commands.push(GenericCommand::UpsertLayer(command));
+                }
+                BoardCommand::RemoveLayer { layer_id, .. } => {
+                    let layer_id = self.resolve_node_id(board, layer_id)?;
+                    let Some(layer) = board.layers.get(&layer_id) else {
+                        return Err(flow_like_types::anyhow!("Layer `{layer_id}` not found"));
+                    };
+                    generic_commands.push(GenericCommand::RemoveLayer(RemoveLayerCommand::new(
+                        layer.clone(),
+                        Vec::new(),
+                        true,
+                    )));
+                }
+            }
+        }
+
+        Ok(generic_commands)
+    }
+
+    fn register_node_aliases(&mut self, aliases: &[Option<&str>], node_id: &str) {
+        for alias in aliases.iter().flatten() {
+            if alias.trim().is_empty() || self.ambiguous_node_refs.contains(*alias) {
+                continue;
+            }
+            match self.node_refs.get(*alias) {
+                Some(existing) if existing == node_id => {}
+                Some(_) => {
+                    self.node_refs.remove(*alias);
+                    self.ambiguous_node_refs.insert((*alias).to_string());
+                }
+                None => {
+                    self.node_refs
+                        .insert((*alias).to_string(), node_id.to_string());
+                }
+            }
+        }
+    }
+
+    fn resolve_node_id(&self, board: &Board, node_ref: &str) -> flow_like_types::Result<String> {
+        if board.nodes.contains_key(node_ref)
+            || board.layers.contains_key(node_ref)
+            || self.staged_nodes.contains_key(node_ref)
+            || self.staged_layers.contains_key(node_ref)
+        {
+            return Ok(node_ref.to_string());
+        }
+        if self.ambiguous_node_refs.contains(node_ref) {
+            return Err(flow_like_types::anyhow!(
+                "Node reference `{node_ref}` is ambiguous"
+            ));
+        }
+        self.node_refs
+            .get(node_ref)
+            .cloned()
+            .ok_or_else(|| flow_like_types::anyhow!("Node reference `{node_ref}` not found"))
+    }
+
+    fn resolve_node<'a>(
+        &'a self,
+        board: &'a Board,
+        node_id: &str,
+    ) -> flow_like_types::Result<&'a Node> {
+        self.staged_nodes
+            .get(node_id)
+            .or_else(|| board.nodes.get(node_id))
+            .or_else(|| {
+                board
+                    .layers
+                    .values()
+                    .find_map(|layer| layer.nodes.get(node_id))
+            })
+            .ok_or_else(|| flow_like_types::anyhow!("Node `{node_id}` not found"))
+    }
+
+    fn resolve_pin_id(
+        &self,
+        board: &Board,
+        entity_id: &str,
+        pin_ref: &str,
+        expected: Option<PinType>,
+    ) -> flow_like_types::Result<String> {
+        if let Some(node) = self
+            .staged_nodes
+            .get(entity_id)
+            .or_else(|| board.nodes.get(entity_id))
+        {
+            return resolve_pin_id_in_node(node, pin_ref, expected);
+        }
+
+        if let Some(layer) = board.layers.get(entity_id) {
+            return resolve_pin_id_in_pins(&layer.name, &layer.pins, pin_ref, None);
+        }
+
+        if let Some(layer) = self.staged_layers.get(entity_id) {
+            return resolve_pin_id_in_pins(&layer.name, &layer.pins, pin_ref, None);
+        }
+
+        Err(flow_like_types::anyhow!("Entity `{entity_id}` not found"))
+    }
+
+    fn resolve_optional_layer(
+        &self,
+        board: &Board,
+        layer_ref: Option<&str>,
+    ) -> flow_like_types::Result<Option<String>> {
+        let Some(layer_ref) = layer_ref.filter(|value| !value.trim().is_empty()) else {
+            return Ok(None);
+        };
+        let layer_id = self.resolve_node_id(board, layer_ref)?;
+        if !board.layers.contains_key(&layer_id) && !self.staged_layers.contains_key(&layer_id) {
+            return Err(flow_like_types::anyhow!("Layer `{layer_ref}` not found"));
+        }
+        Ok(Some(layer_id))
+    }
+
+    fn target_layer_or_current(
+        &self,
+        board: &Board,
+        target_layer: Option<&str>,
+    ) -> flow_like_types::Result<Option<String>> {
+        self.resolve_optional_layer(board, target_layer)
+            .map(|layer| layer.or_else(|| self.current_layer.clone()))
+    }
+
+    fn resolve_node_ids(
+        &self,
+        board: &Board,
+        refs: &[String],
+    ) -> flow_like_types::Result<Vec<String>> {
+        refs.iter()
+            .map(|node_ref| self.resolve_node_id(board, node_ref))
+            .collect()
+    }
+
+    fn position_or_next(&mut self, position: Option<&NodePosition>) -> (f32, f32, f32) {
+        if let Some(position) = position {
+            return (position.x as f32, position.y as f32, 0.0);
+        }
+
+        let index = self.next_position;
+        self.next_position += 1;
+        (
+            self.base_x + ((index % 3) as f32 * 300.0),
+            self.base_y + ((index / 3) as f32 * 200.0),
+            0.0,
+        )
+    }
+
+    fn position_or_base(&self, position: Option<&NodePosition>) -> (f32, f32, f32) {
+        position
+            .map(|position| (position.x as f32, position.y as f32, 0.0))
+            .unwrap_or((self.base_x, self.base_y, 0.0))
+    }
+}
+
+fn placeholder_pins(defs: Option<&[PlaceholderPinDef]>) -> HashMap<String, Pin> {
+    let mut pins = HashMap::new();
+    insert_placeholder_pin(
+        &mut pins,
+        "exec_in",
+        "Exec In",
+        "",
+        PinType::Input,
+        VariableType::Execution,
+        ValueType::Normal,
+        0,
+    );
+    insert_placeholder_pin(
+        &mut pins,
+        "exec_out",
+        "Exec Out",
+        "",
+        PinType::Output,
+        VariableType::Execution,
+        ValueType::Normal,
+        1,
+    );
+
+    let Some(defs) = defs else {
+        return pins;
+    };
+    insert_layer_pins(&mut pins, defs, 2);
+    pins
+}
+
+fn layer_pins(defs: Option<&[PlaceholderPinDef]>) -> HashMap<String, Pin> {
+    let mut pins = HashMap::new();
+    if let Some(defs) = defs {
+        insert_layer_pins(&mut pins, defs, 0);
+    }
+    pins
+}
+
+fn insert_layer_pins(
+    pins: &mut HashMap<String, Pin>,
+    defs: &[PlaceholderPinDef],
+    start_index: usize,
+) {
+    for (offset, def) in defs.iter().enumerate() {
+        insert_placeholder_pin(
+            pins,
+            &def.name,
+            &def.friendly_name,
+            def.description.as_deref().unwrap_or(""),
+            pin_type_from_str(&def.pin_type),
+            variable_type_from_str(&def.data_type),
+            def.value_type
+                .as_deref()
+                .map(value_type_from_str)
+                .unwrap_or(ValueType::Normal),
+            (offset + start_index) as u16,
+        );
+    }
+}
+
+fn insert_placeholder_pin(
+    pins: &mut HashMap<String, Pin>,
+    name: &str,
+    friendly_name: &str,
+    description: &str,
+    pin_type: PinType,
+    data_type: VariableType,
+    value_type: ValueType,
+    index: u16,
+) {
+    let id = create_id();
+    pins.insert(
+        id.clone(),
+        Pin {
+            id,
+            name: name.to_string(),
+            friendly_name: friendly_name.to_string(),
+            description: description.to_string(),
+            pin_type,
+            data_type,
+            schema: None,
+            value_type,
+            depends_on: Default::default(),
+            connected_to: Default::default(),
+            default_value: None,
+            index,
+            options: None,
+            value: None,
+        },
+    );
+}
+
+fn resolve_pin_id_in_node(
+    node: &Node,
+    pin_ref: &str,
+    expected: Option<PinType>,
+) -> flow_like_types::Result<String> {
+    resolve_pin_id_in_pins(
+        &format!("{} ({})", node.friendly_name, node.name),
+        &node.pins,
+        pin_ref,
+        expected,
+    )
+}
+
+fn resolve_pin_id_in_pins(
+    entity_name: &str,
+    pins: &HashMap<String, Pin>,
+    pin_ref: &str,
+    expected: Option<PinType>,
+) -> flow_like_types::Result<String> {
+    if let Some(pin) = pins.get(pin_ref) {
+        if pin_matches_direction(pin, expected.as_ref()) {
+            return Ok(pin_ref.to_string());
+        }
+    }
+
+    let requested = pin_lookup_keys(pin_ref);
+    for pin in pins.values() {
+        if !pin_matches_direction(pin, expected.as_ref()) {
+            continue;
+        }
+        if pin_lookup_keys(&pin.name)
+            .iter()
+            .chain(pin_lookup_keys(&pin.friendly_name).iter())
+            .any(|key| requested.contains(key))
+        {
+            return Ok(pin.id.clone());
+        }
+    }
+
+    if expected.as_ref() != Some(&PinType::Input)
+        && DEFAULT_OUTPUT_PIN_ALIASES
+            .iter()
+            .any(|alias| alias.eq_ignore_ascii_case(pin_ref))
+    {
+        if let Some(default_pin) = default_data_output_pin(pins) {
+            return Ok(default_pin.id.clone());
+        }
+    }
+
+    Err(flow_like_types::anyhow!(
+        "Pin `{pin_ref}` not found on `{entity_name}`"
+    ))
+}
+
+fn default_data_output_pin(pins: &HashMap<String, Pin>) -> Option<&Pin> {
+    let mut outputs = pins
+        .values()
+        .filter(|pin| pin.pin_type == PinType::Output && pin.data_type != VariableType::Execution)
+        .collect::<Vec<_>>();
+    outputs.sort_by_key(|pin| pin.index);
+    match outputs.as_slice() {
+        [single] => Some(*single),
+        many => many.iter().copied().find(|pin| {
+            DEFAULT_OUTPUT_PIN_ALIASES
+                .iter()
+                .any(|alias| alias.eq_ignore_ascii_case(&pin.name))
+        }),
+    }
+}
+
+fn pin_matches_direction(pin: &Pin, expected: Option<&PinType>) -> bool {
+    expected.is_none_or(|expected| &pin.pin_type == expected)
+}
+
+fn pin_lookup_keys(value: &str) -> HashSet<String> {
+    let camel = to_camel_case(value);
+    [
+        value.to_string(),
+        value.to_lowercase(),
+        camel.clone(),
+        camel.to_lowercase(),
+    ]
+    .into_iter()
+    .collect()
+}
+
+fn variable_type_from_str(value: &str) -> VariableType {
+    match value {
+        "Execution" | "exec" => VariableType::Execution,
+        "Integer" | "int" => VariableType::Integer,
+        "Float" | "float" => VariableType::Float,
+        "Boolean" | "bool" => VariableType::Boolean,
+        "Date" => VariableType::Date,
+        "PathBuf" | "Path" => VariableType::PathBuf,
+        "Generic" | "any" => VariableType::Generic,
+        "Struct" => VariableType::Struct,
+        "Byte" | "bytes" => VariableType::Byte,
+        _ => VariableType::String,
+    }
+}
+
+fn value_type_from_str(value: &str) -> ValueType {
+    match value {
+        "Array" => ValueType::Array,
+        "HashMap" | "Map" => ValueType::HashMap,
+        "HashSet" | "Set" => ValueType::HashSet,
+        _ => ValueType::Normal,
+    }
+}
+
+fn layer_type_from_str(value: &Option<String>) -> LayerType {
+    match value.as_deref().unwrap_or("Collapsed") {
+        "Function" | "function" => LayerType::Function,
+        "Macro" | "macro" => LayerType::Macro,
+        _ => LayerType::Collapsed,
+    }
+}
+
+fn pin_type_from_str(value: &str) -> PinType {
+    match value {
+        "Output" => PinType::Output,
+        _ => PinType::Input,
+    }
+}

--- a/packages/core/src/flow/ast/mod.rs
+++ b/packages/core/src/flow/ast/mod.rs
@@ -6,11 +6,16 @@
 //!
 //! See `todo/ast.md`.
 
+mod apply;
 mod lower;
 mod reconcile;
 mod signatures;
 mod types;
 
+pub use apply::{
+    ApplyFlowScriptResult, apply_flowscript_to_board, blocked_destructive_flowscript_message,
+    destructive_flowscript_command_summaries,
+};
 pub use flow_like_ast::{
     BoardAst, DeclarationFile, NodeSchemas, RenderOptions, Signature, SignatureSet,
     declarations_by_category, declarations_by_package, render, schema_sidecar,

--- a/packages/core/src/flow/ast/reconcile.rs
+++ b/packages/core/src/flow/ast/reconcile.rs
@@ -27,7 +27,9 @@ use flow_like_ast::model::*;
 use flow_like_ast::to_camel_case;
 
 use crate::flow::board::Board;
-use crate::flow::copilot::{BoardCommand, NodeMetadata, NodePosition, PinMetadata};
+use crate::flow::copilot::{
+    BoardCommand, NodeMetadata, NodePosition, PinMetadata, PlaceholderPinDef, node_to_metadata,
+};
 use crate::flow::node::Node;
 use crate::flow::pin::{Pin, PinType};
 use crate::flow::variable::VariableType;
@@ -73,6 +75,7 @@ fn reconcile_inner(
 ) -> ReconcileResult {
     let mut result = ReconcileResult::default();
     let board_ast = super::lower_to_ast(existing);
+    let variable_refs = VariableRefLookup::from_board_and_ast(existing, new);
 
     let variable_changes = reconcile_variables(&board_ast, new);
     result.commands.extend(variable_changes.commands);
@@ -92,7 +95,7 @@ fn reconcile_inner(
             continue;
         };
         for arg in &call.args {
-            let Expr::Literal(lit) = &arg.value else {
+            let Some(mut new_value) = literal_expr_to_value(&arg.value) else {
                 // References / nested calls describe wiring, which v1 does not rewrite.
                 continue;
             };
@@ -103,7 +106,7 @@ fn reconcile_inner(
                 ));
                 continue;
             };
-            let new_value = literal_to_value(lit);
+            normalize_variable_ref_value_for_pin(&mut new_value, &pin.name, &variable_refs);
             let current = pin
                 .default_value
                 .as_deref()
@@ -124,7 +127,7 @@ fn reconcile_inner(
     //    "text-visible" from the board's own lowered AST so sugared/inlined nodes (reroutes,
     //    struct_make, pure helpers) are never removed just for lacking an anchor in the text.
     let mut visible: HashMap<String, &Call> = HashMap::new();
-    collect_calls(&board_ast, &mut visible);
+    collect_statement_calls(&board_ast, &mut visible);
     let new_anchors: HashSet<&String> = new_calls.keys().collect();
     for anchor in visible.keys() {
         if new_anchors.contains(anchor) {
@@ -202,12 +205,6 @@ fn reconcile_variables(existing: &BoardAst, new: &BoardAst) -> ReconcileResult {
                 if let Some(command) = update_variable_command(existing, new, old, var) {
                     result.commands.push(command);
                 }
-            }
-            None if var.anchor.is_some() => {
-                result.diagnostics.push(format!(
-                    "variable anchor {} no longer resolves to a board variable; skipped",
-                    var.anchor.as_deref().unwrap_or_default()
-                ));
             }
             None => {
                 result.commands.push(create_variable_command(new, var));
@@ -409,6 +406,53 @@ fn variable_value_type(var: &VarDecl) -> &'static str {
     }
 }
 
+fn function_layer_pins(func: &FnDecl) -> Vec<LayerPinMetadata> {
+    func.params
+        .iter()
+        .map(|param| layer_pin_from_param(param, "Input"))
+        .chain(
+            func.returns
+                .iter()
+                .map(|param| layer_pin_from_param(param, "Output")),
+        )
+        .collect()
+}
+
+fn layer_pin_from_param(param: &Param, pin_type: &str) -> LayerPinMetadata {
+    LayerPinMetadata {
+        name: param.name.clone(),
+        friendly_name: param.name.clone(),
+        data_type: type_ref_data_type(&param.ty).to_string(),
+        value_type: type_ref_value_type(&param.ty).to_string(),
+        pin_type: pin_type.to_string(),
+    }
+}
+
+fn type_ref_data_type(ty: &TypeRef) -> &'static str {
+    match ty.base.as_str() {
+        "exec" | "Execution" => "Execution",
+        "string" | "String" => "String",
+        "int" | "Integer" => "Integer",
+        "float" | "Float" => "Float",
+        "bool" | "Boolean" => "Boolean",
+        "Date" => "Date",
+        "Path" | "PathBuf" => "PathBuf",
+        "any" | "Generic" => "Generic",
+        "Struct" => "Struct",
+        "bytes" | "Byte" => "Byte",
+        _ => "Struct",
+    }
+}
+
+fn type_ref_value_type(ty: &TypeRef) -> &'static str {
+    match ty.container {
+        Container::Normal => "Normal",
+        Container::Array => "Array",
+        Container::Map => "HashMap",
+        Container::Set => "HashSet",
+    }
+}
+
 fn visible_variable_schema(ast: &BoardAst, var: &VarDecl) -> Option<String> {
     let schema = var.schema.as_deref()?;
     let interface_name = flow_like_ast::interface_name_for_schema(&ast.interfaces, schema)?;
@@ -476,6 +520,96 @@ fn literal_expr_to_value(expr: &Expr) -> Option<flow_like_types::Value> {
     }
 }
 
+#[derive(Debug, Default, Clone)]
+struct VariableRefLookup {
+    by_ref: HashMap<String, String>,
+}
+
+impl VariableRefLookup {
+    fn from_board(board: &Board) -> Self {
+        let mut lookup = Self::default();
+        for variable in board.variables.values() {
+            lookup.insert(&variable.id, &variable.name);
+        }
+        for layer in board.layers.values() {
+            for variable in layer.variables.values() {
+                lookup.insert(&variable.id, &variable.name);
+            }
+        }
+        lookup
+    }
+
+    fn from_board_and_ast(board: &Board, ast: &BoardAst) -> Self {
+        let mut lookup = Self::from_board(board);
+        for variable in &ast.variables {
+            let id = variable_id_for_decl_against_board(board, variable);
+            lookup.insert(&id, &variable.name);
+        }
+        lookup
+    }
+
+    fn insert(&mut self, id: &str, name: &str) {
+        self.by_ref.insert(id.to_string(), id.to_string());
+        self.by_ref.insert(name.to_string(), id.to_string());
+        self.by_ref.insert(to_camel_case(name), id.to_string());
+    }
+
+    fn resolve(&self, value: &str) -> Option<String> {
+        self.by_ref
+            .get(value)
+            .cloned()
+            .or_else(|| self.by_ref.get(&to_camel_case(value)).cloned())
+    }
+}
+
+fn variable_id_for_decl_against_board(board: &Board, var: &VarDecl) -> String {
+    if let Some(anchor) = var.anchor.as_deref() {
+        return anchor.to_string();
+    }
+
+    if let Some(existing) = board
+        .variables
+        .values()
+        .find(|existing| existing.name == var.name)
+    {
+        return existing.id.clone();
+    }
+
+    for layer in board.layers.values() {
+        if let Some(existing) = layer
+            .variables
+            .values()
+            .find(|existing| existing.name == var.name)
+        {
+            return existing.id.clone();
+        }
+    }
+
+    variable_id_for_decl(var)
+}
+
+fn is_variable_ref_pin_name(name: &str) -> bool {
+    pin_name_matches(name, "var_ref") || pin_name_matches(name, "varRef")
+}
+
+fn normalize_variable_ref_value_for_pin(
+    value: &mut flow_like_types::Value,
+    pin_name: &str,
+    lookup: &VariableRefLookup,
+) {
+    if !is_variable_ref_pin_name(pin_name) {
+        return;
+    }
+
+    let flow_like_types::Value::String(raw) = value else {
+        return;
+    };
+
+    if let Some(variable_id) = lookup.resolve(raw) {
+        *raw = variable_id;
+    }
+}
+
 fn find_input_pin<'a>(node: &'a Node, name: &str) -> Option<&'a Pin> {
     node.pins
         .values()
@@ -498,6 +632,15 @@ fn node_pin_name_matches(pin: &Pin, requested: &str) -> bool {
 
 fn metadata_pin_name_matches(pin: &PinMetadata, requested: &str) -> bool {
     pin_name_matches(&pin.name, requested) || pin_name_matches(&pin.friendly_name, requested)
+}
+
+fn call_matches_node(call: &Call, node: &Node) -> bool {
+    if !call.node_type.trim().is_empty() {
+        return call.node_type == node.name;
+    }
+
+    pin_name_matches(&node.name, &call.display)
+        || pin_name_matches(&node.friendly_name, &call.display)
 }
 
 fn is_exec_pin(pin: &Pin) -> bool {
@@ -640,13 +783,17 @@ fn default_exec_output_by_policy(
             {
                 return selector(many);
             }
-            None
+            select_exec_done(many)
         }
     }
 }
 
 fn select_exec_success(candidates: &[ExecPinCandidate]) -> Option<String> {
     select_named_exec_pin(candidates, &["exec_success"])
+}
+
+fn select_exec_done(candidates: &[ExecPinCandidate]) -> Option<String> {
+    select_named_exec_pin(candidates, &["exec_done", "done"])
 }
 
 fn select_named_exec_pin(candidates: &[ExecPinCandidate], names: &[&str]) -> Option<String> {
@@ -658,10 +805,24 @@ fn select_named_exec_pin(candidates: &[ExecPinCandidate], names: &[&str]) -> Opt
     })
 }
 
+fn is_streaming_data_output_pin_name(name: &str) -> bool {
+    matches!(
+        name,
+        "chunk" | "token" | "delta" | "stream_chunk" | "streamed_chunk"
+    )
+}
+
 #[derive(Debug, Clone)]
 enum NodeEntity {
     Existing(String),
-    New { ref_id: String, meta: NodeMetadata },
+    New {
+        ref_id: String,
+        meta: NodeMetadata,
+    },
+    Layer {
+        ref_id: String,
+        pins: Vec<LayerPinMetadata>,
+    },
 }
 
 impl NodeEntity {
@@ -669,8 +830,18 @@ impl NodeEntity {
         match self {
             Self::Existing(id) => id.clone(),
             Self::New { ref_id, .. } => ref_id.clone(),
+            Self::Layer { ref_id, .. } => ref_id.clone(),
         }
     }
+}
+
+#[derive(Debug, Clone)]
+struct LayerPinMetadata {
+    name: String,
+    friendly_name: String,
+    data_type: String,
+    value_type: String,
+    pin_type: String,
 }
 
 #[derive(Debug, Clone)]
@@ -696,6 +867,7 @@ impl ExecCursor {
 struct PlannedStmt {
     entity: NodeEntity,
     next_exec_pin: Option<String>,
+    input_sources: Vec<ValueSource>,
 }
 
 impl PlannedStmt {
@@ -703,6 +875,7 @@ impl PlannedStmt {
         Self {
             entity,
             next_exec_pin: None,
+            input_sources: Vec::new(),
         }
     }
 
@@ -710,6 +883,15 @@ impl PlannedStmt {
         Self {
             entity,
             next_exec_pin,
+            input_sources: Vec::new(),
+        }
+    }
+
+    fn with_input_sources(entity: NodeEntity, input_sources: Vec<ValueSource>) -> Self {
+        Self {
+            entity,
+            next_exec_pin: None,
+            input_sources,
         }
     }
 
@@ -847,6 +1029,19 @@ impl<'a> BoardIndex<'a> {
             })
             .collect()
     }
+
+    fn data_source_for_input(&self, node: &Node, input_pin_name: &str) -> Option<ValueSource> {
+        let input = find_input_pin(node, input_pin_name)?;
+        if is_exec_pin(input) {
+            return None;
+        }
+        let source_pin_id = input.depends_on.iter().next()?;
+        let (source_node, source_pin) = self.pin_owner.get(source_pin_id.as_str())?;
+        Some(ValueSource {
+            node: NodeEntity::Existing(source_node.id.clone()),
+            output_pin: Some(source_pin.name.clone()),
+        })
+    }
 }
 
 struct StructuralPlanner<'a> {
@@ -859,6 +1054,9 @@ struct StructuralPlanner<'a> {
     connect_commands: Vec<BoardCommand>,
     update_commands: Vec<BoardCommand>,
     symbols: Vec<HashMap<String, SymbolValue>>,
+    variable_refs: VariableRefLookup,
+    function_return_targets: Vec<(NodeEntity, Vec<String>)>,
+    unresolved_variable_refs: HashSet<String>,
     next_ref: usize,
     next_position: usize,
 }
@@ -875,6 +1073,9 @@ impl<'a> StructuralPlanner<'a> {
             connect_commands: Vec::new(),
             update_commands: Vec::new(),
             symbols: Vec::new(),
+            variable_refs: VariableRefLookup::from_board(existing),
+            function_return_targets: Vec::new(),
+            unresolved_variable_refs: HashSet::new(),
             next_ref: 0,
             next_position: 0,
         }
@@ -917,9 +1118,19 @@ impl<'a> StructuralPlanner<'a> {
     }
 
     fn plan_function(&mut self, func: &FnDecl) {
-        let target_layer = func.anchor.clone();
+        let layer = self.function_layer_entity(func);
+        let target_layer = Some(layer.node_ref());
         self.push_scope();
+        self.seed_function_params(&func.params, &layer);
+        self.function_return_targets.push((
+            layer.clone(),
+            func.returns
+                .iter()
+                .map(|param| param.name.clone())
+                .collect(),
+        ));
         self.plan_block(&func.body, None, target_layer);
+        self.function_return_targets.pop();
         self.pop_scope();
     }
 
@@ -952,8 +1163,25 @@ impl<'a> StructuralPlanner<'a> {
 
             if accepts_exec {
                 if let Some(previous) = &previous_exec {
-                    if self.connect_exec(previous, &current.entity, inserted_since_existing) {
+                    let preferred_output = self.preferred_exec_output_for_input_sources(
+                        &previous.entity,
+                        &current.input_sources,
+                    );
+                    let previous = match preferred_output {
+                        Some(output_pin) => {
+                            ExecCursor::with_output(previous.entity.clone(), Some(output_pin))
+                        }
+                        None => previous.clone(),
+                    };
+                    let used_branch_output = previous.output_pin.is_some()
+                        && self.entity_exec_output_pin(&previous.entity) != previous.output_pin;
+                    if self.connect_exec(&previous, &current.entity, inserted_since_existing)
+                        && !used_branch_output
+                    {
                         inserted_since_existing |= matches!(current.entity, NodeEntity::New { .. });
+                    }
+                    if used_branch_output {
+                        continue;
                     }
                 } else {
                     inserted_since_existing |= matches!(current.entity, NodeEntity::New { .. });
@@ -979,40 +1207,63 @@ impl<'a> StructuralPlanner<'a> {
     ) -> Option<PlannedStmt> {
         match stmt {
             Stmt::Let { name, call, anchor } => {
-                let entity = self.plan_call_statement(call, anchor.as_deref(), target_layer);
-                if let Some(entity) = &entity {
-                    self.insert_symbol(
-                        name.clone(),
-                        SymbolValue::Source(ValueSource {
-                            node: entity.clone(),
-                            output_pin: None,
-                        }),
-                    );
-                }
-                entity.map(PlannedStmt::new)
+                let planned_call =
+                    self.plan_call_statement_with_sources(call, anchor.as_deref(), target_layer);
+                let (entity, input_sources) = planned_call?;
+                self.insert_symbol(
+                    name.clone(),
+                    SymbolValue::Source(ValueSource {
+                        node: entity.clone(),
+                        output_pin: None,
+                    }),
+                );
+                Some(PlannedStmt::with_input_sources(entity, input_sources))
             }
-            Stmt::Call { call, anchor } => self
-                .plan_call_statement(call, anchor.as_deref(), target_layer)
-                .map(PlannedStmt::new),
+            Stmt::Call { call, anchor } => {
+                let (entity, input_sources) =
+                    self.plan_call_statement_with_sources(call, anchor.as_deref(), target_layer)?;
+                Some(PlannedStmt::with_input_sources(entity, input_sources))
+            }
             Stmt::Assign {
                 target,
                 value,
                 anchor,
             } => {
                 if let Some(anchor) = anchor {
-                    let entity = NodeEntity::Existing(anchor.clone());
-                    if let Some(output_pin) = assigned_call_output_pin(value)
-                        && find_board_node(self.existing, anchor).is_some()
-                    {
+                    if let Some(variable_id) = self.variable_id_for_assignment_target(target) {
+                        let entity = NodeEntity::Existing(anchor.clone());
+                        self.plan_existing_variable_set_node(
+                            &entity,
+                            &variable_id,
+                            value,
+                            target_layer,
+                        );
+                        self.assign_symbol(
+                            target.clone(),
+                            SymbolValue::VariableRef {
+                                variable_id: variable_id.clone(),
+                            },
+                        );
+                        return Some(PlannedStmt::new(entity));
+                    }
+
+                    if let Some((call, output_pin)) = assigned_call_expr(value) {
+                        let entity = self
+                            .plan_call_statement(call, Some(anchor), target_layer)
+                            .unwrap_or_else(|| NodeEntity::Existing(anchor.clone()));
+                        let output_pin = output_pin
+                            .and_then(|pin| self.resolve_entity_output_pin(&entity, Some(pin)));
                         self.insert_symbol(
                             target.clone(),
                             SymbolValue::Source(ValueSource {
                                 node: entity.clone(),
-                                output_pin: Some(output_pin.to_string()),
+                                output_pin,
                             }),
                         );
+                        return Some(PlannedStmt::new(entity));
                     }
-                    return Some(PlannedStmt::new(entity));
+
+                    return Some(PlannedStmt::new(NodeEntity::Existing(anchor.clone())));
                 }
 
                 if let Some(variable_id) = self.variable_id_for_assignment_target(target) {
@@ -1051,19 +1302,23 @@ impl<'a> StructuralPlanner<'a> {
                 anchor,
             } => {
                 if let Some(anchor) = anchor {
-                    let entity = NodeEntity::Existing(anchor.clone());
-                    if let Some(output_pin) = assigned_call_output_pin(value)
-                        && find_board_node(self.existing, anchor).is_some()
-                    {
+                    if let Some((call, output_pin)) = assigned_call_expr(value) {
+                        let entity = self
+                            .plan_call_statement(call, Some(anchor), target_layer)
+                            .unwrap_or_else(|| NodeEntity::Existing(anchor.clone()));
+                        let output_pin = output_pin
+                            .and_then(|pin| self.resolve_entity_output_pin(&entity, Some(pin)));
                         self.insert_symbol(
                             name.clone(),
                             SymbolValue::Source(ValueSource {
                                 node: entity.clone(),
-                                output_pin: Some(output_pin.to_string()),
+                                output_pin,
                             }),
                         );
+                        return Some(PlannedStmt::new(entity));
                     }
-                    return Some(PlannedStmt::new(entity));
+
+                    return Some(PlannedStmt::new(NodeEntity::Existing(anchor.clone())));
                 }
 
                 if promote_local_alias {
@@ -1187,7 +1442,102 @@ impl<'a> StructuralPlanner<'a> {
                 self.plan_event(event);
                 None
             }
-            Stmt::Local(_) | Stmt::Return { .. } | Stmt::Comment(_) => None,
+            Stmt::Return { values } => {
+                self.plan_return(values, target_layer);
+                None
+            }
+            Stmt::Local(_) | Stmt::Comment(_) => None,
+        }
+    }
+
+    fn function_layer_entity(&mut self, func: &FnDecl) -> NodeEntity {
+        if let Some(anchor) = &func.anchor {
+            return NodeEntity::Existing(anchor.clone());
+        }
+
+        let ref_id = format!("${}", self.next_ref);
+        self.next_ref += 1;
+        let pins = function_layer_pins(func);
+        let position = self.next_position();
+        self.add_commands.push(BoardCommand::CreateLayer {
+            name: func.name.clone(),
+            ref_id: Some(ref_id.clone()),
+            layer_type: Some("Function".to_string()),
+            node_ids: Vec::new(),
+            pins: Some(
+                pins.iter()
+                    .map(|pin| PlaceholderPinDef {
+                        name: pin.name.clone(),
+                        friendly_name: pin.friendly_name.clone(),
+                        description: None,
+                        pin_type: pin.pin_type.clone(),
+                        data_type: pin.data_type.clone(),
+                        value_type: Some(pin.value_type.clone()),
+                    })
+                    .collect(),
+            ),
+            position: Some(position),
+            color: None,
+            target_layer: None,
+            summary: Some(format!("Create function {}", func.name)),
+        });
+        NodeEntity::Layer { ref_id, pins }
+    }
+
+    fn seed_function_params(&mut self, params: &[Param], layer: &NodeEntity) {
+        for param in params {
+            self.insert_symbol(
+                param.name.clone(),
+                SymbolValue::Source(ValueSource {
+                    node: layer.clone(),
+                    output_pin: Some(param.name.clone()),
+                }),
+            );
+        }
+    }
+
+    fn plan_return(&mut self, values: &[Expr], target_layer: Option<String>) {
+        let Some((layer, return_pins)) = self.function_return_targets.last().cloned() else {
+            if !values.is_empty() {
+                self.result.diagnostics.push(
+                    "return statements are only supported inside FlowScript functions".to_string(),
+                );
+            }
+            return;
+        };
+
+        for (index, value) in values.iter().enumerate() {
+            let Some(return_pin) = return_pins.get(index).cloned() else {
+                self.result.diagnostics.push(format!(
+                    "return value {} has no matching function return pin",
+                    index + 1
+                ));
+                continue;
+            };
+            let Some(source) = self
+                .resolve_expr(value, target_layer.clone())
+                .and_then(|symbol| self.symbol_to_source(symbol, target_layer.clone()))
+            else {
+                self.result.diagnostics.push(format!(
+                    "return value {} is not a resolvable FlowScript value",
+                    index + 1
+                ));
+                continue;
+            };
+            let Some(output_pin) = self.resolve_source_output_pin(&source) else {
+                self.result.diagnostics.push(format!(
+                    "could not choose output pin for return value {}",
+                    index + 1
+                ));
+                continue;
+            };
+            self.connect_commands.push(BoardCommand::ConnectPins {
+                from_node: source.node.node_ref(),
+                from_pin: output_pin,
+                to_node: layer.node_ref(),
+                to_pin: return_pin,
+                summary: Some("Connect FlowScript function return".to_string()),
+            });
         }
     }
 
@@ -1197,16 +1547,28 @@ impl<'a> StructuralPlanner<'a> {
         anchor: Option<&str>,
         target_layer: Option<String>,
     ) -> Option<NodeEntity> {
+        self.plan_call_statement_with_sources(call, anchor, target_layer)
+            .map(|(entity, _)| entity)
+    }
+
+    fn plan_call_statement_with_sources(
+        &mut self,
+        call: &Call,
+        anchor: Option<&str>,
+        target_layer: Option<String>,
+    ) -> Option<(NodeEntity, Vec<ValueSource>)> {
         if let Some(anchor) = anchor {
-            return find_board_node(self.existing, anchor)
-                .map(|_| NodeEntity::Existing(anchor.to_string()));
+            let meta = find_board_node(self.existing, anchor).map(node_to_metadata)?;
+            let entity = NodeEntity::Existing(anchor.to_string());
+            let input_sources = self.plan_call_arguments(call, &entity, &meta, target_layer, false);
+            return Some((entity, input_sources));
         }
 
         if call.display.trim().is_empty() {
             return None;
         }
 
-        self.add_call_node(call, target_layer)
+        self.add_call_node_with_sources(call, target_layer)
     }
 
     fn add_entry_node(&mut self, display: &str) -> Option<NodeEntity> {
@@ -1225,6 +1587,15 @@ impl<'a> StructuralPlanner<'a> {
     }
 
     fn add_call_node(&mut self, call: &Call, target_layer: Option<String>) -> Option<NodeEntity> {
+        self.add_call_node_with_sources(call, target_layer)
+            .map(|(entity, _)| entity)
+    }
+
+    fn add_call_node_with_sources(
+        &mut self,
+        call: &Call,
+        target_layer: Option<String>,
+    ) -> Option<(NodeEntity, Vec<ValueSource>)> {
         let meta = match self.catalog.resolve_call(call) {
             Ok(meta) => meta,
             Err(err) => {
@@ -1234,26 +1605,40 @@ impl<'a> StructuralPlanner<'a> {
         };
         let entity = self.queue_add_node(meta.clone(), target_layer.clone());
 
+        let input_sources = self.plan_call_arguments(call, &entity, &meta, target_layer, true);
+
+        Some((entity, input_sources))
+    }
+
+    fn plan_call_arguments(
+        &mut self,
+        call: &Call,
+        entity: &NodeEntity,
+        meta: &NodeMetadata,
+        target_layer: Option<String>,
+        include_direct_literals: bool,
+    ) -> Vec<ValueSource> {
+        let mut input_sources = Vec::new();
         for arg in &call.args {
             let Some(input) = metadata_input_pin(&meta, &arg.name) else {
                 self.result.diagnostics.push(format!(
-                    "new node `{}` has no input pin named `{}`; skipped that argument",
+                    "node `{}` has no input pin named `{}`; skipped that argument",
                     call.display, arg.name
                 ));
                 continue;
             };
 
-            if let Some(value) = literal_expr_to_value(&arg.value) {
-                self.update_commands.push(BoardCommand::UpdateNodePin {
-                    node_id: entity.node_ref(),
-                    pin_id: input.name.clone(),
-                    value,
-                    summary: Some(format!("Set {} on {}", input.name, meta.friendly_name)),
-                });
+            if let Some(mut value) = literal_expr_to_value(&arg.value) {
+                self.normalize_input_value(input, &mut value);
+                if include_direct_literals {
+                    self.queue_update_input(entity, input, value, meta);
+                }
                 continue;
             }
 
-            let Some(source) = self.resolve_expr(&arg.value, target_layer.clone()) else {
+            let Some(source) =
+                self.resolve_expr_for_argument(&arg.value, entity, input, target_layer.clone())
+            else {
                 self.result.diagnostics.push(format!(
                     "argument `{}` on `{}` is not a literal or resolvable node output; skipped connection",
                     arg.name, call.display
@@ -1261,13 +1646,20 @@ impl<'a> StructuralPlanner<'a> {
                 continue;
             };
             let source = match source {
-                SymbolValue::Literal(value) => {
-                    self.update_commands.push(BoardCommand::UpdateNodePin {
-                        node_id: entity.node_ref(),
-                        pin_id: input.name.clone(),
-                        value,
-                        summary: Some(format!("Set {} on {}", input.name, meta.friendly_name)),
-                    });
+                SymbolValue::Literal(mut value) => {
+                    self.normalize_input_value(input, &mut value);
+                    self.queue_update_input(entity, input, value, meta);
+                    continue;
+                }
+                SymbolValue::VariableRef { variable_id }
+                    if is_variable_ref_pin_name(&input.name) =>
+                {
+                    self.queue_update_input(
+                        entity,
+                        input,
+                        flow_like_types::Value::String(variable_id),
+                        meta,
+                    );
                     continue;
                 }
                 SymbolValue::Source(source) => source,
@@ -1293,14 +1685,147 @@ impl<'a> StructuralPlanner<'a> {
             };
             self.connect_commands.push(BoardCommand::ConnectPins {
                 from_node: source.node.node_ref(),
-                from_pin: output_pin,
+                from_pin: output_pin.clone(),
                 to_node: entity.node_ref(),
                 to_pin: input.name.clone(),
                 summary: Some(format!("Connect {} into {}", arg.name, meta.friendly_name)),
             });
+            input_sources.push(ValueSource {
+                node: source.node,
+                output_pin: Some(output_pin),
+            });
+        }
+        input_sources
+    }
+
+    fn resolve_expr_for_argument(
+        &mut self,
+        expr: &Expr,
+        target_entity: &NodeEntity,
+        input: &PinMetadata,
+        target_layer: Option<String>,
+    ) -> Option<SymbolValue> {
+        if let Some(source) = self.existing_source_for_input(target_entity, input)
+            && let Some(symbol) =
+                self.resolve_expr_using_existing_source(expr, source, target_layer.clone())
+        {
+            return Some(symbol);
         }
 
-        Some(entity)
+        self.resolve_expr(expr, target_layer)
+    }
+
+    fn existing_source_for_input(
+        &self,
+        target_entity: &NodeEntity,
+        input: &PinMetadata,
+    ) -> Option<ValueSource> {
+        let NodeEntity::Existing(node_id) = target_entity else {
+            return None;
+        };
+        let node = find_board_node(self.existing, node_id)?;
+        self.board_index.data_source_for_input(node, &input.name)
+    }
+
+    fn resolve_expr_using_existing_source(
+        &mut self,
+        expr: &Expr,
+        source: ValueSource,
+        target_layer: Option<String>,
+    ) -> Option<SymbolValue> {
+        match expr {
+            Expr::Call(call) => self.reuse_existing_call_source(call, source, None, target_layer),
+            Expr::Field { base, pin } => {
+                if let Expr::Call(call) = base.as_ref() {
+                    self.reuse_existing_call_source(call, source, Some(pin), target_layer)
+                } else {
+                    None
+                }
+            }
+            Expr::Member { base, .. } | Expr::Index { base, .. } => {
+                self.resolve_expr_using_existing_source(base, source, target_layer)
+            }
+            _ => None,
+        }
+    }
+
+    fn reuse_existing_call_source(
+        &mut self,
+        call: &Call,
+        source: ValueSource,
+        requested_output: Option<&str>,
+        target_layer: Option<String>,
+    ) -> Option<SymbolValue> {
+        let NodeEntity::Existing(source_node_id) = &source.node else {
+            return None;
+        };
+        let source_node = find_board_node(self.existing, source_node_id)?;
+        let meta = match self.catalog.resolve_call(call) {
+            Ok(meta) if meta.name == source_node.name => meta,
+            Ok(_) => return None,
+            Err(_) if call_matches_node(call, source_node) => node_to_metadata(source_node),
+            Err(_) => return None,
+        };
+        let entity = NodeEntity::Existing(source_node_id.clone());
+        self.plan_call_arguments(call, &entity, &meta, target_layer, true);
+
+        let output_pin = requested_output
+            .and_then(|pin| self.resolve_entity_output_pin(&entity, Some(pin)))
+            .or(source.output_pin)
+            .or_else(|| self.resolve_entity_output_pin(&entity, None));
+
+        Some(SymbolValue::Source(ValueSource {
+            node: entity,
+            output_pin,
+        }))
+    }
+
+    fn normalize_input_value(&mut self, input: &PinMetadata, value: &mut flow_like_types::Value) {
+        if !is_variable_ref_pin_name(&input.name) {
+            return;
+        }
+
+        let flow_like_types::Value::String(raw) = value else {
+            return;
+        };
+
+        if let Some(variable_id) = self.variable_refs.resolve(raw) {
+            *raw = variable_id;
+            return;
+        }
+
+        if self.unresolved_variable_refs.insert(raw.clone()) {
+            self.result.diagnostics.push(format!(
+                "variable reference `{raw}` does not resolve to a board or FlowScript variable; declare it as a top-level FlowScript variable so it can be created"
+            ));
+        }
+    }
+
+    fn queue_update_input(
+        &mut self,
+        entity: &NodeEntity,
+        input: &PinMetadata,
+        value: flow_like_types::Value,
+        meta: &NodeMetadata,
+    ) {
+        if let NodeEntity::Existing(node_id) = entity
+            && let Some(node) = find_board_node(self.existing, node_id)
+            && let Some(pin) = find_input_pin(node, &input.name)
+        {
+            let current = pin.default_value.as_deref().and_then(|bytes| {
+                flow_like_types::json::from_slice::<flow_like_types::Value>(bytes).ok()
+            });
+            if current.as_ref() == Some(&value) {
+                return;
+            }
+        }
+
+        self.update_commands.push(BoardCommand::UpdateNodePin {
+            node_id: entity.node_ref(),
+            pin_id: input.name.clone(),
+            value,
+            summary: Some(format!("Set {} on {}", input.name, meta.friendly_name)),
+        });
     }
 
     fn queue_add_node(&mut self, meta: NodeMetadata, target_layer: Option<String>) -> NodeEntity {
@@ -1398,10 +1923,36 @@ impl<'a> StructuralPlanner<'a> {
         true
     }
 
+    fn preferred_exec_output_for_input_sources(
+        &self,
+        previous: &NodeEntity,
+        input_sources: &[ValueSource],
+    ) -> Option<String> {
+        let previous_ref = previous.node_ref();
+        input_sources.iter().find_map(|source| {
+            if source.node.node_ref() != previous_ref {
+                return None;
+            }
+            let output_pin = source.output_pin.as_deref()?;
+            self.exec_output_for_data_output(previous, output_pin)
+        })
+    }
+
+    fn exec_output_for_data_output(&self, entity: &NodeEntity, output_pin: &str) -> Option<String> {
+        if !is_streaming_data_output_pin_name(output_pin) {
+            return None;
+        }
+        self.entity_exec_output_pin_named(
+            entity,
+            &["on_stream", "on_chunk", "for_chunk", "on_delta", "on_token"],
+        )
+    }
+
     fn entity_exec_input_pin(&self, entity: &NodeEntity) -> Option<String> {
         match entity {
             NodeEntity::Existing(id) => find_board_node(self.existing, id).and_then(exec_input_pin),
             NodeEntity::New { meta, .. } => metadata_exec_input_pin(meta),
+            NodeEntity::Layer { .. } => None,
         }
     }
 
@@ -1411,6 +1962,7 @@ impl<'a> StructuralPlanner<'a> {
                 find_board_node(self.existing, id).and_then(exec_output_pin)
             }
             NodeEntity::New { meta, .. } => metadata_exec_output_pin(meta),
+            NodeEntity::Layer { .. } => None,
         }
     }
 
@@ -1433,6 +1985,7 @@ impl<'a> StructuralPlanner<'a> {
                 .filter(|p| p.data_type == "Execution")
                 .map(|p| p.name.clone())
                 .collect(),
+            NodeEntity::Layer { .. } => Vec::new(),
         }
     }
 
@@ -1453,6 +2006,7 @@ impl<'a> StructuralPlanner<'a> {
                     })
                 })
                 .map(|pin| pin.name.clone()),
+            NodeEntity::Layer { .. } => None,
         }
     }
 
@@ -1582,6 +2136,67 @@ impl<'a> StructuralPlanner<'a> {
         Some(entity)
     }
 
+    fn plan_existing_variable_set_node(
+        &mut self,
+        entity: &NodeEntity,
+        variable_id: &str,
+        value: &Expr,
+        target_layer: Option<String>,
+    ) {
+        let NodeEntity::Existing(node_id) = entity else {
+            return;
+        };
+        let Some(node) = find_board_node(self.existing, node_id) else {
+            return;
+        };
+        let meta = node_to_metadata(node);
+
+        if let Some(input) = metadata_input_pin(&meta, "var_ref") {
+            self.queue_update_input(
+                entity,
+                input,
+                flow_like_types::Value::String(variable_id.to_string()),
+                &meta,
+            );
+        }
+
+        let Some(input) = metadata_input_pin(&meta, "value_in")
+            .or_else(|| metadata_input_pin(&meta, "new_value"))
+            .or_else(|| metadata_input_pin(&meta, "value"))
+        else {
+            self.result.diagnostics.push(format!(
+                "variable set node `{node_id}` has no value input pin"
+            ));
+            return;
+        };
+
+        if let Some(mut literal) = literal_expr_to_value(value) {
+            self.normalize_input_value(input, &mut literal);
+            self.queue_update_input(entity, input, literal, &meta);
+            return;
+        }
+
+        let Some(source) = self
+            .resolve_expr_for_argument(value, entity, input, target_layer.clone())
+            .and_then(|symbol| self.symbol_to_source(symbol, target_layer))
+        else {
+            self.result.diagnostics.push(format!(
+                "assignment to variable `{variable_id}` is not a resolvable value"
+            ));
+            return;
+        };
+
+        if let Some(output_pin) = self.resolve_source_output_pin_for_input(&source, input) {
+            self.connect_commands.push(BoardCommand::ConnectPins {
+                from_node: source.node.node_ref(),
+                from_pin: output_pin,
+                to_node: entity.node_ref(),
+                to_pin: input.name.clone(),
+                summary: Some("Set FlowScript variable value".to_string()),
+            });
+        }
+    }
+
     fn resolve_variable_node(&mut self, node_type: &str, display: &str) -> Option<NodeMetadata> {
         if let Some(meta) = self.catalog.by_type.get(node_type) {
             return Some(meta.clone());
@@ -1602,6 +2217,7 @@ impl<'a> StructuralPlanner<'a> {
         target_layer: Option<String>,
     ) -> String {
         let variable_id = generated_variable_id(name);
+        self.variable_refs.insert(&variable_id, name);
         let default_value = literal_expr_to_value(value);
         let (data_type, value_type) = infer_variable_types(default_value.as_ref());
         self.add_commands.push(BoardCommand::CreateVariable {
@@ -1665,7 +2281,9 @@ impl<'a> StructuralPlanner<'a> {
                         .or_else(|| self.resolve_entity_output_pin(&source.node, None)),
                 }
             }
-            NodeEntity::Existing(_) => self.resolve_source_output_pin(source),
+            NodeEntity::Existing(_) | NodeEntity::Layer { .. } => {
+                self.resolve_source_output_pin(source)
+            }
         }
     }
 
@@ -1688,6 +2306,17 @@ impl<'a> StructuralPlanner<'a> {
                 }
                 default_metadata_output_pin(meta)
             }
+            NodeEntity::Layer { pins, .. } => {
+                if let Some(requested) = requested {
+                    return pins
+                        .iter()
+                        .find(|pin| pin_name_matches(&pin.name, requested))
+                        .map(|pin| pin.name.clone());
+                }
+                pins.iter()
+                    .find(|pin| pin.pin_type == "Output")
+                    .map(|pin| pin.name.clone())
+            }
         }
     }
 
@@ -1707,12 +2336,9 @@ impl<'a> StructuralPlanner<'a> {
 
     fn seed_top_level_variables(&mut self, ast: &BoardAst) {
         for var in &ast.variables {
-            self.insert_symbol(
-                var.name.clone(),
-                SymbolValue::VariableRef {
-                    variable_id: self.variable_id_for_decl(var),
-                },
-            );
+            let variable_id = self.variable_id_for_decl(var);
+            self.variable_refs.insert(&variable_id, &var.name);
+            self.insert_symbol(var.name.clone(), SymbolValue::VariableRef { variable_id });
         }
     }
 
@@ -1788,6 +2414,9 @@ fn ast_has_unanchored_calls(ast: &BoardAst) -> bool {
         }
     }
     for f in &ast.functions {
+        if f.anchor.is_none() {
+            return true;
+        }
         if block_has_unanchored_calls(&f.body) {
             return true;
         }
@@ -1877,6 +2506,67 @@ fn collect_calls<'a>(ast: &'a BoardAst, out: &mut HashMap<String, &'a Call>) {
 fn collect_block<'a>(block: &'a Block, out: &mut HashMap<String, &'a Call>) {
     for stmt in &block.stmts {
         collect_stmt(stmt, out);
+    }
+}
+
+/// Walk only statement-owned calls. This is intentionally shallower than [`collect_calls`]:
+/// inlined helper expressions are render conveniences, not standalone text-visible statements,
+/// and must not be removed just because their anchors are absent from edited FlowScript.
+fn collect_statement_calls<'a>(ast: &'a BoardAst, out: &mut HashMap<String, &'a Call>) {
+    for ev in &ast.events {
+        collect_statement_block(&ev.body, out);
+    }
+    for f in &ast.functions {
+        collect_statement_block(&f.body, out);
+    }
+}
+
+fn collect_statement_block<'a>(block: &'a Block, out: &mut HashMap<String, &'a Call>) {
+    for stmt in &block.stmts {
+        collect_statement_stmt(stmt, out);
+    }
+}
+
+fn collect_statement_stmt<'a>(stmt: &'a Stmt, out: &mut HashMap<String, &'a Call>) {
+    match stmt {
+        Stmt::Let { call, anchor, .. } | Stmt::Call { call, anchor } => {
+            collect_call_anchor_only(call, anchor.as_deref(), out)
+        }
+        Stmt::Branch {
+            call, arms, anchor, ..
+        } => {
+            if !is_placeholder_call(call) {
+                collect_call_anchor_only(call, anchor.as_deref(), out);
+            }
+            for arm in arms {
+                collect_statement_block(&arm.body, out);
+            }
+        }
+        Stmt::Loop {
+            call, body, anchor, ..
+        } => {
+            collect_call_anchor_only(call, anchor.as_deref(), out);
+            collect_statement_block(body, out);
+        }
+        Stmt::Assign { value, anchor, .. } | Stmt::LocalAlias { value, anchor, .. } => {
+            if let Some(anchor) = anchor.as_deref()
+                && let Some((call, _)) = assigned_call_expr(value)
+            {
+                collect_call_anchor_only(call, Some(anchor), out);
+            }
+        }
+        Stmt::Handler(event) => collect_statement_block(&event.body, out),
+        Stmt::Return { .. } | Stmt::Local(_) | Stmt::Comment(_) => {}
+    }
+}
+
+fn collect_call_anchor_only<'a>(
+    call: &'a Call,
+    fallback_anchor: Option<&str>,
+    out: &mut HashMap<String, &'a Call>,
+) {
+    if let Some(anchor) = call.anchor.as_deref().or(fallback_anchor) {
+        out.insert(anchor.to_string(), call);
     }
 }
 
@@ -1997,9 +2687,15 @@ fn collect_assigned_call_with_anchor<'a>(
     }
 }
 
-fn assigned_call_output_pin(expr: &Expr) -> Option<&str> {
+fn assigned_call_expr(expr: &Expr) -> Option<(&Call, Option<&str>)> {
     match expr {
-        Expr::Field { base, pin } if matches!(base.as_ref(), Expr::Call(_)) => Some(pin),
+        Expr::Call(call) => Some((call, None)),
+        Expr::Field { base, pin } => {
+            let Expr::Call(call) = base.as_ref() else {
+                return None;
+            };
+            Some((call, Some(pin.as_str())))
+        }
         _ => None,
     }
 }
@@ -2585,6 +3281,77 @@ mod tests {
         }));
     }
 
+    #[test]
+    fn catalog_aware_reconcile_creates_function_layers_from_functions() {
+        let board = empty_board();
+        let catalog = vec![catalog_meta(
+            "string_format",
+            "String Format",
+            vec![
+                pin_meta("exec_in", "Execution", PinType::Input),
+                pin_meta("format_string", "String", PinType::Input),
+                pin_meta("name", "String", PinType::Input),
+            ],
+            vec![
+                pin_meta("exec_out", "Execution", PinType::Output),
+                pin_meta("value", "String", PinType::Output),
+            ],
+        )];
+
+        let result = reconcile_text_with_catalog(
+            &board,
+            r#"function greet(name: string): (message: string) {
+    const formatted = stringFormat({ formatString: "Hello {name}", name: name })
+    return formatted.value
+}
+"#,
+            &catalog,
+        );
+
+        assert!(result.diagnostics.is_empty(), "{:?}", result.diagnostics);
+        assert!(matches!(
+            &result.commands[0],
+            BoardCommand::CreateLayer {
+                name,
+                ref_id,
+                layer_type,
+                pins: Some(pins),
+                ..
+            } if name == "greet"
+                && ref_id.as_deref() == Some("$0")
+                && layer_type.as_deref() == Some("Function")
+                && pins.iter().any(|pin| pin.name == "name" && pin.pin_type == "Input")
+                && pins.iter().any(|pin| pin.name == "message" && pin.pin_type == "Output")
+        ));
+        assert!(result.commands.iter().any(|command| {
+            matches!(
+                command,
+                BoardCommand::AddNode { node_type, target_layer, .. }
+                    if node_type == "string_format" && target_layer.as_deref() == Some("$0")
+            )
+        }));
+        assert!(result.commands.iter().any(|command| {
+            matches!(
+                command,
+                BoardCommand::ConnectPins { from_node, from_pin, to_node, to_pin, .. }
+                    if from_node == "$0"
+                        && from_pin == "name"
+                        && to_node == "$1"
+                        && to_pin == "name"
+            )
+        }));
+        assert!(result.commands.iter().any(|command| {
+            matches!(
+                command,
+                BoardCommand::ConnectPins { from_node, from_pin, to_node, to_pin, .. }
+                    if from_node == "$1"
+                        && from_pin == "value"
+                        && to_node == "$0"
+                        && to_pin == "message"
+            )
+        }));
+    }
+
     fn accumulator_catalog() -> Vec<NodeMetadata> {
         vec![
             catalog_meta(
@@ -2694,6 +3461,450 @@ mod tests {
             } if id == ref_id => Some(node_type.clone()),
             _ => None,
         })
+    }
+
+    fn by_ref_catalog() -> Vec<NodeMetadata> {
+        vec![
+            catalog_meta(
+                "events_simple",
+                "Simple Event",
+                Vec::new(),
+                vec![pin_meta("exec_out", "Execution", PinType::Output)],
+            ),
+            catalog_meta(
+                "variable_get",
+                "Get Variable",
+                vec![pin_meta("var_ref", "String", PinType::Input)],
+                vec![pin_meta("value_ref", "Generic", PinType::Output)],
+            ),
+            catalog_meta(
+                "array_clear_ref",
+                "Clear (By Ref)",
+                vec![
+                    pin_meta("exec_in", "Execution", PinType::Input),
+                    pin_meta("var_ref", "String", PinType::Input),
+                ],
+                vec![pin_meta("exec_out", "Execution", PinType::Output)],
+            ),
+            catalog_meta(
+                "array_push_ref",
+                "Push (By Ref)",
+                vec![
+                    pin_meta("exec_in", "Execution", PinType::Input),
+                    pin_meta("var_ref", "String", PinType::Input),
+                    pin_meta("value", "Generic", PinType::Input),
+                ],
+                vec![pin_meta("exec_out", "Execution", PinType::Output)],
+            ),
+            catalog_meta(
+                "batch_upsert_local_db",
+                "Batch Upsert",
+                vec![
+                    pin_meta("exec_in", "Execution", PinType::Input),
+                    pin_meta("database", "Struct", PinType::Input),
+                    pin_meta_friendly("id_row", "ID Column", "String", "Normal", PinType::Input),
+                    pin_meta_friendly("value", "Value", "Generic", "Array", PinType::Input),
+                ],
+                vec![pin_meta("exec_out", "Execution", PinType::Output)],
+            ),
+        ]
+    }
+
+    #[test]
+    fn catalog_aware_reconcile_normalizes_by_ref_variable_names_to_ids() {
+        let board = empty_board();
+        let catalog = by_ref_catalog();
+
+        let result = reconcile_text_with_catalog(
+            &board,
+            r#"const rows: Struct[] = []   //@v:var_rows
+
+eventsSimple() {
+    arrayClearRef({ varRef: "rows" })
+    arrayPushRef({ varRef: "rows", value: {} })
+    batchUpsertLocalDb({ database: {}, idRow: "id", value: rows })
+}
+"#,
+            &catalog,
+        );
+
+        assert!(result.diagnostics.is_empty(), "{:?}", result.diagnostics);
+        assert!(result.commands.iter().any(|command| {
+            matches!(
+                command,
+                BoardCommand::UpdateNodePin { node_id, pin_id, value, .. }
+                    if command_node_type(&result.commands, node_id).as_deref()
+                        == Some("array_clear_ref")
+                        && pin_id == "var_ref"
+                        && value == &flow_like_types::Value::String("var_rows".to_string())
+            )
+        }));
+        assert!(result.commands.iter().any(|command| {
+            matches!(
+                command,
+                BoardCommand::UpdateNodePin { node_id, pin_id, value, .. }
+                    if command_node_type(&result.commands, node_id).as_deref()
+                        == Some("array_push_ref")
+                        && pin_id == "var_ref"
+                        && value == &flow_like_types::Value::String("var_rows".to_string())
+            )
+        }));
+        assert!(result.commands.iter().any(|command| {
+            matches!(
+                command,
+                BoardCommand::UpdateNodePin { node_id, pin_id, value, .. }
+                    if command_node_type(&result.commands, node_id).as_deref()
+                        == Some("batch_upsert_local_db")
+                        && pin_id == "id_row"
+                        && value == &flow_like_types::Value::String("id".to_string())
+            )
+        }));
+        assert!(result.commands.iter().any(|command| {
+            matches!(
+                command,
+                BoardCommand::ConnectPins { from_node, from_pin, to_node, to_pin, .. }
+                    if command_node_type(&result.commands, from_node).as_deref()
+                        == Some("variable_get")
+                        && from_pin == "value_ref"
+                        && command_node_type(&result.commands, to_node).as_deref()
+                            == Some("batch_upsert_local_db")
+                        && to_pin == "value"
+            )
+        }));
+    }
+
+    #[test]
+    fn catalog_aware_reconcile_wires_existing_anchored_variable_argument() {
+        let mut board = empty_board();
+        let mut variable = Variable::new("rows", VariableType::Struct, ValueType::Array);
+        variable.id = "var_rows".to_string();
+        board.variables.insert(variable.id.clone(), variable);
+
+        let mut event = Node::new("events_simple", "Simple Event", "", "events");
+        event.id = "event".to_string();
+        event.set_start(true);
+        event.add_output_pin("exec_out", "Out", "", VariableType::Execution);
+        board.nodes.insert(event.id.clone(), event);
+
+        let mut batch = Node::new("batch_upsert_local_db", "Batch Upsert", "", "data");
+        batch.id = "batch".to_string();
+        batch.add_input_pin("exec_in", "In", "", VariableType::Execution);
+        batch.add_input_pin("database", "Database", "", VariableType::Struct);
+        batch.add_input_pin("id_row", "ID Column", "", VariableType::String);
+        let value_pin = batch.add_input_pin("value", "Value", "", VariableType::Generic);
+        value_pin.value_type = ValueType::Array;
+        batch.add_output_pin("exec_out", "Out", "", VariableType::Execution);
+        board.nodes.insert(batch.id.clone(), batch);
+
+        let result = reconcile_text_with_catalog(
+            &board,
+            r#"const rows: Struct[] = []   //@v:var_rows
+
+eventsSimple() {   //@n:event
+    batchUpsertLocalDb({ database: {}, idRow: "id", value: rows })   //@n:batch
+}
+"#,
+            &by_ref_catalog(),
+        );
+
+        assert!(result.diagnostics.is_empty(), "{:?}", result.diagnostics);
+        assert!(result.commands.iter().any(|command| {
+            matches!(
+                command,
+                BoardCommand::AddNode { node_type, .. } if node_type == "variable_get"
+            )
+        }));
+        assert!(result.commands.iter().any(|command| {
+            matches!(
+                command,
+                BoardCommand::UpdateNodePin { node_id, pin_id, value, .. }
+                    if command_node_type(&result.commands, node_id).as_deref()
+                        == Some("variable_get")
+                        && pin_id == "var_ref"
+                        && value == &flow_like_types::Value::String("var_rows".to_string())
+            )
+        }));
+        assert!(result.commands.iter().any(|command| {
+            matches!(
+                command,
+                BoardCommand::ConnectPins { from_node, from_pin, to_node, to_pin, .. }
+                    if command_node_type(&result.commands, from_node).as_deref()
+                        == Some("variable_get")
+                        && from_pin == "value_ref"
+                        && to_node == "batch"
+                        && to_pin == "value"
+            )
+        }));
+        assert!(result.commands.iter().any(|command| {
+            matches!(
+                command,
+                BoardCommand::UpdateNodePin { node_id, pin_id, value, .. }
+                    if node_id == "batch"
+                        && pin_id == "id_row"
+                        && value == &flow_like_types::Value::String("id".to_string())
+            )
+        }));
+    }
+
+    #[test]
+    fn catalog_aware_reconcile_recreates_missing_inline_request_chain_for_anchored_call() {
+        let mut board = empty_board();
+
+        let mut event = Node::new("events_simple", "Simple Event", "", "events");
+        event.id = "event".to_string();
+        event.set_start(true);
+        event.add_output_pin("exec_out", "Out", "", VariableType::Execution);
+        board.nodes.insert(event.id.clone(), event);
+
+        let mut fetch = Node::new("http_fetch", "API Call", "", "http");
+        fetch.id = "fetch".to_string();
+        fetch.add_input_pin("exec_in", "In", "", VariableType::Execution);
+        fetch.add_input_pin("request", "Request", "", VariableType::Struct);
+        fetch.add_output_pin("exec_success", "Success", "", VariableType::Execution);
+        fetch.add_output_pin("response", "Response", "", VariableType::Struct);
+        board.nodes.insert(fetch.id.clone(), fetch);
+
+        let catalog = vec![
+            catalog_meta(
+                "events_simple",
+                "Simple Event",
+                Vec::new(),
+                vec![pin_meta("exec_out", "Execution", PinType::Output)],
+            ),
+            catalog_meta(
+                "http_make_request",
+                "Make Request",
+                vec![
+                    pin_meta("method", "String", PinType::Input),
+                    pin_meta("url", "String", PinType::Input),
+                ],
+                vec![pin_meta("request", "Struct", PinType::Output)],
+            ),
+            catalog_meta(
+                "http_set_header",
+                "Set Header",
+                vec![
+                    pin_meta("request", "Struct", PinType::Input),
+                    pin_meta("name", "String", PinType::Input),
+                    pin_meta("value", "String", PinType::Input),
+                ],
+                vec![pin_meta("request", "Struct", PinType::Output)],
+            ),
+            catalog_meta(
+                "http_fetch",
+                "API Call",
+                vec![
+                    pin_meta("exec_in", "Execution", PinType::Input),
+                    pin_meta("request", "Struct", PinType::Input),
+                ],
+                vec![
+                    pin_meta("exec_success", "Execution", PinType::Output),
+                    pin_meta("response", "Struct", PinType::Output),
+                ],
+            ),
+        ];
+
+        let result = reconcile_text_with_catalog(
+            &board,
+            r#"simpleEvent() {   //@n:event
+    const aPICall = httpFetch({ request: httpSetHeader({ request: httpMakeRequest({ method: "GET", url: "https://www.reddit.com/r/rust/.rss" }), name: "User-Agent", value: "FlowLikeRedditRSS/1.0" }) })   //@n:fetch
+}
+"#,
+            &catalog,
+        );
+
+        assert!(result.diagnostics.is_empty(), "{:?}", result.diagnostics);
+        assert!(result.commands.iter().any(|command| {
+            matches!(
+                command,
+                BoardCommand::AddNode { node_type, .. } if node_type == "http_make_request"
+            )
+        }));
+        assert!(result.commands.iter().any(|command| {
+            matches!(
+                command,
+                BoardCommand::AddNode { node_type, .. } if node_type == "http_set_header"
+            )
+        }));
+        assert!(result.commands.iter().any(|command| {
+            matches!(
+                command,
+                BoardCommand::UpdateNodePin { node_id, pin_id, value, .. }
+                    if command_node_type(&result.commands, node_id).as_deref()
+                        == Some("http_make_request")
+                        && pin_id == "method"
+                        && value == &flow_like_types::Value::String("GET".to_string())
+            )
+        }));
+        assert!(result.commands.iter().any(|command| {
+            matches!(
+                command,
+                BoardCommand::ConnectPins { from_node, from_pin, to_node, to_pin, .. }
+                    if command_node_type(&result.commands, from_node).as_deref()
+                        == Some("http_make_request")
+                        && from_pin == "request"
+                        && command_node_type(&result.commands, to_node).as_deref()
+                            == Some("http_set_header")
+                        && to_pin == "request"
+            )
+        }));
+        assert!(result.commands.iter().any(|command| {
+            matches!(
+                command,
+                BoardCommand::ConnectPins { from_node, from_pin, to_node, to_pin, .. }
+                    if command_node_type(&result.commands, from_node).as_deref()
+                        == Some("http_set_header")
+                        && from_pin == "request"
+                        && to_node == "fetch"
+                        && to_pin == "request"
+            )
+        }));
+    }
+
+    #[test]
+    fn catalog_aware_reconcile_does_not_remove_unanchored_inline_helpers() {
+        let mut board = empty_board();
+
+        let mut request = Node::new("http_make_request", "Make Request", "", "http");
+        request.id = "request".to_string();
+        request
+            .add_input_pin("method", "Method", "", VariableType::String)
+            .default_value = Some(flow_like_types::json::to_vec("GET").unwrap());
+        request
+            .add_input_pin("url", "URL", "", VariableType::String)
+            .default_value =
+            Some(flow_like_types::json::to_vec("https://www.reddit.com/r/rust/.rss").unwrap());
+        let request_out = request
+            .add_output_pin("request", "Request", "", VariableType::Struct)
+            .id
+            .clone();
+        board.nodes.insert(request.id.clone(), request);
+
+        let mut fetch = Node::new("http_fetch", "API Call", "", "http");
+        fetch.id = "fetch".to_string();
+        fetch.add_input_pin("exec_in", "In", "", VariableType::Execution);
+        let fetch_request = fetch
+            .add_input_pin("request", "Request", "", VariableType::Struct)
+            .id
+            .clone();
+        fetch.add_output_pin("exec_success", "Success", "", VariableType::Execution);
+        fetch.add_output_pin("response", "Response", "", VariableType::Struct);
+        board.nodes.insert(fetch.id.clone(), fetch);
+
+        connect(&mut board, "request", &request_out, "fetch", &fetch_request);
+
+        let catalog = vec![
+            catalog_meta(
+                "events_simple",
+                "Simple Event",
+                Vec::new(),
+                vec![pin_meta("exec_out", "Execution", PinType::Output)],
+            ),
+            catalog_meta(
+                "http_make_request",
+                "Make Request",
+                vec![
+                    pin_meta("method", "String", PinType::Input),
+                    pin_meta("url", "String", PinType::Input),
+                ],
+                vec![pin_meta("request", "Struct", PinType::Output)],
+            ),
+            catalog_meta(
+                "http_fetch",
+                "API Call",
+                vec![
+                    pin_meta("exec_in", "Execution", PinType::Input),
+                    pin_meta("request", "Struct", PinType::Input),
+                ],
+                vec![
+                    pin_meta("exec_success", "Execution", PinType::Output),
+                    pin_meta("response", "Struct", PinType::Output),
+                ],
+            ),
+        ];
+
+        let result = reconcile_text_with_catalog(
+            &board,
+            r#"simpleEvent() {
+    const aPICall = httpFetch({ request: httpMakeRequest({ method: "GET", url: "https://www.reddit.com/r/rust/.rss" }) })   //@n:fetch
+}
+"#,
+            &catalog,
+        );
+
+        assert!(result.diagnostics.is_empty(), "{:?}", result.diagnostics);
+        assert!(!result.commands.iter().any(|command| {
+            matches!(
+                command,
+                BoardCommand::RemoveNode { node_id, .. } if node_id == "request"
+            )
+        }));
+        assert!(!result.commands.iter().any(|command| {
+            matches!(
+                command,
+                BoardCommand::AddNode { node_type, .. } if node_type == "http_make_request"
+            )
+        }));
+    }
+
+    #[test]
+    fn catalog_aware_reconcile_repairs_anchored_variable_set_assignment() {
+        let mut board = empty_board();
+        let mut variable = Variable::new("rows", VariableType::Struct, ValueType::Array);
+        variable.id = "var_rows".to_string();
+        board.variables.insert(variable.id.clone(), variable);
+
+        let mut push = Node::new("array_push", "Push", "", "array");
+        push.id = "push".to_string();
+        push.add_input_pin("exec_in", "In", "", VariableType::Execution);
+        push.add_output_pin("exec_out", "Out", "", VariableType::Execution);
+        push.add_output_pin("array_out", "Array", "", VariableType::Struct)
+            .value_type = ValueType::Array;
+        board.nodes.insert(push.id.clone(), push);
+
+        let mut set_rows = Node::new("variable_set", "Set rows", "", "variables");
+        set_rows.id = "set_rows".to_string();
+        set_rows.add_input_pin("exec_in", "In", "", VariableType::Execution);
+        set_rows.add_input_pin("var_ref", "rows", "", VariableType::String);
+        let value_pin = set_rows.add_input_pin("value_in", "Value", "", VariableType::Struct);
+        value_pin.value_type = ValueType::Array;
+        set_rows.add_output_pin("exec_out", "Out", "", VariableType::Execution);
+        set_rows
+            .add_output_pin("value_ref", "New Value", "", VariableType::Struct)
+            .value_type = ValueType::Array;
+        board.nodes.insert(set_rows.id.clone(), set_rows);
+
+        let result = reconcile_text_with_catalog(
+            &board,
+            r#"const rows: Struct[] = []   //@v:var_rows
+
+push(arrayOut: Struct[]) {   //@n:push
+    rows = arrayOut   //@n:set_rows
+}
+"#,
+            &accumulator_catalog(),
+        );
+
+        assert!(result.diagnostics.is_empty(), "{:?}", result.diagnostics);
+        assert!(result.commands.iter().any(|command| {
+            matches!(
+                command,
+                BoardCommand::UpdateNodePin { node_id, pin_id, value, .. }
+                    if node_id == "set_rows"
+                        && pin_id == "var_ref"
+                        && value == &flow_like_types::Value::String("var_rows".to_string())
+            )
+        }));
+        assert!(result.commands.iter().any(|command| {
+            matches!(
+                command,
+                BoardCommand::ConnectPins { from_node, from_pin, to_node, to_pin, .. }
+                    if from_node == "push"
+                        && from_pin == "array_out"
+                        && to_node == "set_rows"
+                        && to_pin == "value_in"
+            )
+        }));
     }
 
     #[test]
@@ -3454,5 +4665,212 @@ eventsSimple() {
                     if from_node == "$1" && to_node == "$2"
             )
         }));
+    }
+
+    #[test]
+    fn catalog_aware_reconcile_continues_unknown_streaming_nodes_from_exec_done() {
+        let board = empty_board();
+        let catalog = vec![
+            catalog_meta(
+                "events_simple",
+                "Simple Event",
+                Vec::new(),
+                vec![pin_meta("exec_out", "Execution", PinType::Output)],
+            ),
+            catalog_meta(
+                "custom_stream",
+                "Custom Stream",
+                vec![pin_meta("exec_in", "Execution", PinType::Input)],
+                vec![
+                    pin_meta("on_stream", "Execution", PinType::Output),
+                    pin_meta("exec_done", "Execution", PinType::Output),
+                    pin_meta("result", "String", PinType::Output),
+                ],
+            ),
+            catalog_meta(
+                "log_info",
+                "Log Info",
+                vec![
+                    pin_meta("exec_in", "Execution", PinType::Input),
+                    pin_meta("message", "String", PinType::Input),
+                ],
+                Vec::new(),
+            ),
+        ];
+
+        let result = reconcile_text_with_catalog(
+            &board,
+            r#"eventsSimple() {
+    const streamed = customStream()
+    logInfo({ message: streamed.result })
+}
+"#,
+            &catalog,
+        );
+
+        assert!(result.diagnostics.is_empty(), "{:?}", result.diagnostics);
+        assert!(result.commands.iter().any(|command| {
+            matches!(
+                command,
+                BoardCommand::ConnectPins { from_node, from_pin, to_node, to_pin, .. }
+                    if from_node == "$1"
+                        && from_pin == "exec_done"
+                        && to_node == "$2"
+                        && to_pin == "exec_in"
+            )
+        }));
+        assert!(!result.commands.iter().any(|command| {
+            matches!(
+                command,
+                BoardCommand::ConnectPins { from_node, from_pin, to_node, .. }
+                    if from_node == "$1" && from_pin == "on_stream" && to_node == "$2"
+            )
+        }));
+    }
+
+    #[test]
+    fn catalog_aware_reconcile_wires_stream_chunk_consumers_from_on_stream_only() {
+        let board = empty_board();
+        let catalog = vec![
+            catalog_meta(
+                "events_simple",
+                "Simple Event",
+                Vec::new(),
+                vec![pin_meta("exec_out", "Execution", PinType::Output)],
+            ),
+            catalog_meta(
+                "agent_stream_invoke",
+                "Stream Invoke Agent",
+                vec![pin_meta("exec_in", "Execution", PinType::Input)],
+                vec![
+                    pin_meta("on_stream", "Execution", PinType::Output),
+                    pin_meta("chunk", "Struct", PinType::Output),
+                    pin_meta("exec_done", "Execution", PinType::Output),
+                    pin_meta("response", "Struct", PinType::Output),
+                    pin_meta("stats", "Struct", PinType::Output),
+                ],
+            ),
+            catalog_meta(
+                "events_chat_push_response_chunk",
+                "Push Chunk",
+                vec![
+                    pin_meta("exec_in", "Execution", PinType::Input),
+                    pin_meta("chunk", "Struct", PinType::Input),
+                ],
+                vec![pin_meta("exec_out", "Execution", PinType::Output)],
+            ),
+            catalog_meta(
+                "events_chat_push_response",
+                "Push Response",
+                vec![
+                    pin_meta("exec_in", "Execution", PinType::Input),
+                    pin_meta("response", "Struct", PinType::Input),
+                ],
+                vec![pin_meta("exec_out", "Execution", PinType::Output)],
+            ),
+            catalog_meta(
+                "events_chat_push_stat",
+                "Push Stat",
+                vec![
+                    pin_meta("exec_in", "Execution", PinType::Input),
+                    pin_meta("stat", "Struct", PinType::Input),
+                ],
+                vec![pin_meta("exec_out", "Execution", PinType::Output)],
+            ),
+        ];
+
+        let result = reconcile_text_with_catalog(
+            &board,
+            r#"eventsSimple() {
+    const invokeAgent = agentStreamInvoke()
+    eventsChatPushResponseChunk({ chunk: invokeAgent.chunk })
+    eventsChatPushResponse({ response: invokeAgent.response })
+    eventsChatPushStat({ stat: invokeAgent.stats })
+}
+"#,
+            &catalog,
+        );
+
+        assert!(result.diagnostics.is_empty(), "{:?}", result.diagnostics);
+        for (from_node, from_pin, to_node, to_pin) in [
+            ("$0", "exec_out", "$1", "exec_in"),
+            ("$1", "on_stream", "$2", "exec_in"),
+            ("$1", "exec_done", "$3", "exec_in"),
+            ("$3", "exec_out", "$4", "exec_in"),
+        ] {
+            assert!(
+                result.commands.iter().any(|command| {
+                    matches!(
+                        command,
+                        BoardCommand::ConnectPins {
+                            from_node: actual_from_node,
+                            from_pin: actual_from_pin,
+                            to_node: actual_to_node,
+                            to_pin: actual_to_pin,
+                            ..
+                        } if actual_from_node == from_node
+                            && actual_from_pin == from_pin
+                            && actual_to_node == to_node
+                            && actual_to_pin == to_pin
+                    )
+                }),
+                "missing exec edge {from_node}.{from_pin} -> {to_node}.{to_pin}; commands: {:?}",
+                result.commands
+            );
+        }
+
+        for (from_node, from_pin, to_node) in [
+            ("$1", "exec_done", "$2"),
+            ("$2", "exec_out", "$3"),
+            ("$1", "on_stream", "$3"),
+        ] {
+            assert!(!result.commands.iter().any(|command| {
+                matches!(
+                    command,
+                    BoardCommand::ConnectPins { from_node: actual_from_node, from_pin: actual_from_pin, to_node: actual_to_node, .. }
+                        if actual_from_node == from_node
+                            && actual_from_pin == from_pin
+                            && actual_to_node == to_node
+                )
+            }));
+        }
+    }
+
+    #[test]
+    fn catalog_aware_reconcile_reports_missing_variable_refs() {
+        let board = empty_board();
+        let catalog = vec![
+            catalog_meta(
+                "events_simple",
+                "Simple Event",
+                Vec::new(),
+                vec![pin_meta("exec_out", "Execution", PinType::Output)],
+            ),
+            catalog_meta(
+                "variable_get",
+                "Get Variable",
+                vec![pin_meta("var_ref", "String", PinType::Input)],
+                vec![pin_meta("value_ref", "String", PinType::Output)],
+            ),
+        ];
+
+        let result = reconcile_text_with_catalog(
+            &board,
+            r#"eventsSimple() {
+    variableGet({ varRef: "GMAIL_ADDRESS" })
+}
+"#,
+            &catalog,
+        );
+
+        assert!(
+            result
+                .diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.contains("GMAIL_ADDRESS")
+                    && diagnostic.contains("top-level FlowScript variable")),
+            "{:?}",
+            result.diagnostics
+        );
     }
 }

--- a/packages/core/src/flow/board/commands/layer/upsert_layer.rs
+++ b/packages/core/src/flow/board/commands/layer/upsert_layer.rs
@@ -84,7 +84,7 @@ impl Command for UpsertLayerCommand {
             }
         }
 
-        if self.old_layer.is_none() {
+        if self.old_layer.is_none() && total_coordinates > 0 {
             let center_position = (
                 added_coordinates.0 / total_coordinates as f32,
                 added_coordinates.1 / total_coordinates as f32,

--- a/packages/core/src/flow/copilot/mod.rs
+++ b/packages/core/src/flow/copilot/mod.rs
@@ -14,7 +14,7 @@ mod validation;
 pub use context::{
     EdgeContext, GraphContext, LayerContext, NodeContext, PinContext, prepare_context,
 };
-pub use provider::CatalogProvider;
+pub use provider::{CatalogProvider, node_to_metadata, pin_to_metadata};
 pub use search::{
     SearchQueryAnalysis, analyze_search_query, enrich_node_metadata, score_catalog_metadata,
     search_result_hint_lines,
@@ -22,10 +22,11 @@ pub use search::{
 pub use tools::{
     CatalogTool, EditFlowScriptArgs, EditFlowScriptTool, EmitCommandsArgs, EmitCommandsTool,
     FilterCategoryArgs, FilterCategoryTool, FindConnectableNodesArgs, FindConnectableNodesTool,
-    GetDeclarationsArgs, GetDeclarationsTool, GetNodeDetailsArgs, GetNodeDetailsTool,
-    GetUnconfiguredNodesTool, ListBoardNodesTool, QueryLogsArgs, QueryLogsTool, SearchArgs,
-    SearchByPinArgs, SearchByPinTool, SearchTemplatesArgs, SearchTemplatesTool, ThinkingArgs,
-    board_has_no_nodes, build_find_connectable_nodes_output, build_list_board_nodes_output,
+    GetCurrentFlowScriptArgs, GetCurrentFlowScriptTool, GetDeclarationsArgs, GetDeclarationsTool,
+    GetNodeDetailsArgs, GetNodeDetailsTool, GetUnconfiguredNodesTool, ListBoardNodesTool,
+    QueryLogsArgs, QueryLogsTool, SearchArgs, SearchByPinArgs, SearchByPinTool,
+    SearchTemplatesArgs, SearchTemplatesTool, ThinkingArgs, board_has_no_nodes,
+    build_find_connectable_nodes_output, build_list_board_nodes_output,
     build_unconfigured_nodes_output, get_tool_description, render_edit_flowscript_result,
 };
 pub use types::{
@@ -36,8 +37,8 @@ pub use types::{
 
 use std::sync::Arc;
 
-use flow_like_types::Result;
 use flow_like_model_provider::llm::CompletionClientDyn;
+use flow_like_types::Result;
 use futures::StreamExt;
 use rig::{
     OneOrMany,
@@ -233,6 +234,9 @@ impl Copilot {
             .tool(CatalogTool {
                 provider: self.catalog_provider.clone(),
             })
+            .tool(GetCurrentFlowScriptTool {
+                board: board_for_tools.clone(),
+            })
             .tool(GetDeclarationsTool {
                 provider: self.catalog_provider.clone(),
             })
@@ -354,7 +358,7 @@ impl Copilot {
         let mut all_commands: Vec<BoardCommand> = Vec::new();
         let max_iterations = 10u64;
         let max_discovery_rounds_before_emit = 4u64;
-        let force_emit_instruction = "You have enough context. Stop searching or planning. In your next response, call edit_flowscript with the full edited FlowScript document. Preserve all existing //@n anchors you keep. Write new workflow nodes as concrete unanchored FlowScript calls inside a function/event block using declarations from get_declarations, and let edit_flowscript translate the text into commands. Do not submit TODOs, function stubs, implementation-plan comments, lists of node names, or top-level node-call assignments. Use emit_commands only for layout-only MoveNode or non-FlowScript visual/modeling changes. If edit_flowscript returns validation errors, fix the FlowScript and call edit_flowscript again; do not answer in text instead.";
+        let force_emit_instruction = "You have enough context. Stop searching or planning. In your next response, call edit_flowscript with the full edited FlowScript document. Preserve all existing //@n anchors you keep. Leave allow_deletions false unless the user explicitly asked to delete existing board items. Write new workflow nodes as concrete unanchored FlowScript calls inside a function/event block using declarations from get_declarations, and let edit_flowscript translate the text into commands. Do not submit TODOs, function stubs, implementation-plan comments, lists of node names, or top-level node-call assignments. Use emit_commands only for layout-only MoveNode or non-FlowScript visual/modeling changes. If edit_flowscript returns validation errors, fix the FlowScript and call edit_flowscript again; do not answer in text instead.";
         let mut plan_step_counter = 0u32;
         let mut invalid_emit_attempts = 0u8;
         let mut discovery_rounds_without_emit = 0u64;
@@ -1003,6 +1007,13 @@ impl Copilot {
                 Ok(args) => self.catalog_provider.get_declarations(&args.query).await,
                 Err(e) => format!("Failed to parse declarations query: {}", e),
             },
+            "get_current_flowscript" => crate::flow::ast::board_to_flowscript(
+                board,
+                &crate::flow::ast::RenderOptions {
+                    anchors: true,
+                    ..Default::default()
+                },
+            ),
             "edit_flowscript" => match serde_json::from_value::<EditFlowScriptArgs>(arguments) {
                 Ok(args) => {
                     let catalog = self.catalog_provider.get_all_metadata().await;
@@ -1015,6 +1026,7 @@ impl Copilot {
                         &args.flowscript,
                         &result,
                         board_has_no_nodes(board),
+                        args.allow_deletions,
                     )
                 }
                 Err(e) => format!("Failed to parse FlowScript edit: {}", e),

--- a/packages/core/src/flow/copilot/provider.rs
+++ b/packages/core/src/flow/copilot/provider.rs
@@ -6,6 +6,9 @@ use std::collections::HashSet;
 use super::declarations::{render_declaration_matches, search_declarations};
 use super::search::score_catalog_metadata;
 use super::types::{NodeMetadata, PinMetadata};
+use crate::flow::node::Node;
+use crate::flow::pin::{Pin, PinType};
+use crate::flow::variable::VariableType;
 
 /// Trait for providing catalog search functionality
 #[async_trait]
@@ -182,6 +185,79 @@ fn pin_to_sig_param(pin: &PinMetadata) -> SigParam {
         doc,
         schema: pin.schema.clone(),
     }
+}
+
+/// Convert a board/catalog pin into the metadata shape FlowPilot and FlowScript use.
+pub fn pin_to_metadata(pin: &Pin) -> PinMetadata {
+    let is_generic = pin.data_type == VariableType::Generic;
+    let enforce_schema = pin
+        .options
+        .as_ref()
+        .and_then(|options| options.enforce_schema)
+        .unwrap_or(false);
+    let valid_values = pin
+        .options
+        .as_ref()
+        .and_then(|options| options.valid_values.clone());
+
+    PinMetadata {
+        name: pin.name.clone(),
+        friendly_name: pin.friendly_name.clone(),
+        description: pin.description.clone(),
+        data_type: format!("{:?}", pin.data_type),
+        value_type: format!("{:?}", pin.value_type),
+        default_value: pin
+            .default_value
+            .as_ref()
+            .map(|value| String::from_utf8_lossy(value).to_string())
+            .filter(|value| !value.is_empty() && value != "null"),
+        schema: pin.schema.clone(),
+        is_generic,
+        valid_values,
+        enforce_schema,
+    }
+}
+
+/// Convert a board/catalog node into the metadata shape FlowPilot and FlowScript use.
+pub fn node_to_metadata(node: &Node) -> NodeMetadata {
+    let derived_category = node
+        .name
+        .to_lowercase()
+        .split("::")
+        .nth(1)
+        .unwrap_or("")
+        .to_string();
+    let category = if derived_category.is_empty() {
+        node.category.clone()
+    } else {
+        derived_category
+    };
+
+    let mut inputs: Vec<&Pin> = node
+        .pins
+        .values()
+        .filter(|pin| pin.pin_type == PinType::Input)
+        .collect();
+    inputs.sort_by_key(|pin| (pin.index, pin.name.clone()));
+
+    let mut outputs: Vec<&Pin> = node
+        .pins
+        .values()
+        .filter(|pin| pin.pin_type == PinType::Output)
+        .collect();
+    outputs.sort_by_key(|pin| (pin.index, pin.name.clone()));
+
+    super::search::enrich_node_metadata(NodeMetadata {
+        name: node.name.clone(),
+        friendly_name: node.friendly_name.clone(),
+        description: node.description.clone(),
+        inputs: inputs.into_iter().map(pin_to_metadata).collect(),
+        outputs: outputs.into_iter().map(pin_to_metadata).collect(),
+        category: Some(category),
+        required_inputs: Vec::new(),
+        companion_nodes: Vec::new(),
+        capability_tags: Vec::new(),
+    })
 }
 
 /// Build a FlowScript [`Signature`] from catalog [`NodeMetadata`].

--- a/packages/core/src/flow/copilot/tools.rs
+++ b/packages/core/src/flow/copilot/tools.rs
@@ -7,7 +7,10 @@ use serde_json::json;
 use super::provider::CatalogProvider;
 use super::search::score_catalog_metadata;
 use super::types::{BoardCommand, RunContext, TemplateInfo};
-use crate::flow::ast::{ReconcileResult, reconcile_text_with_catalog};
+use crate::flow::ast::{
+    ReconcileResult, RenderOptions, blocked_destructive_flowscript_message, board_to_flowscript,
+    destructive_flowscript_command_summaries, reconcile_text_with_catalog,
+};
 use crate::flow::board::Board;
 use crate::state::FlowLikeState;
 
@@ -108,12 +111,19 @@ pub struct GetDeclarationsArgs {
 }
 
 #[derive(Deserialize)]
+pub struct GetCurrentFlowScriptArgs {}
+
+#[derive(Deserialize)]
 pub struct EditFlowScriptArgs {
     /// The full edited FlowScript source for the board. Preserve the `//@n:<id>` anchor comments
     /// on existing statements so identities are matched; literal argument changes become pin
-    /// updates and removed anchored statements become node deletions.
+    /// updates. Removed anchored statements are blocked unless `allow_deletions` is true.
     #[serde(alias = "script", alias = "source", alias = "content")]
     pub flowscript: String,
+    /// Explicit opt-in for destructive FlowScript edits. Leave false unless the user asked to
+    /// remove existing board items.
+    #[serde(default)]
+    pub allow_deletions: bool,
 }
 
 // ============================================================================
@@ -1069,6 +1079,49 @@ RETURNS: Logs with level, message, node_id (use node_id with get_node_details)"#
 // FlowScript Tools
 // ============================================================================
 
+/// Return the live board rendered as anchored FlowScript.
+///
+/// This is intentionally a tool, even though the system prompt also includes the board source,
+/// because long multi-step agents can lose the inline copy. Calling this immediately before
+/// `edit_flowscript` gives the model the exact current document to edit.
+pub struct GetCurrentFlowScriptTool {
+    pub board: Arc<Board>,
+}
+
+impl Tool for GetCurrentFlowScriptTool {
+    const NAME: &'static str = "get_current_flowscript";
+
+    type Error = FlowScriptToolError;
+    type Args = GetCurrentFlowScriptArgs;
+    type Output = String;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        ToolDefinition {
+            name: "get_current_flowscript".to_string(),
+            description: r#"Return the current live board as anchored FlowScript.
+
+Use this before editing an existing board, especially after prior tool calls or after validation
+failed. The returned document is the source you must edit and submit in full to
+`edit_flowscript`; preserve all `//@n:<id>` anchors on statements you keep."#
+                .to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {}
+            }),
+        }
+    }
+
+    async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
+        Ok(board_to_flowscript(
+            &self.board,
+            &RenderOptions {
+                anchors: true,
+                ..Default::default()
+            },
+        ))
+    }
+}
+
 /// Retrieve `.flow.d`-style FlowScript declarations for nodes matching a query.
 ///
 /// This is the FlowScript counterpart to `catalog_search`/`get_node_details`: instead of
@@ -1268,6 +1321,7 @@ pub fn render_edit_flowscript_result(
     flowscript: &str,
     result: &ReconcileResult,
     board_is_empty: bool,
+    allow_deletions: bool,
 ) -> String {
     let blocking_diagnostics: Vec<&String> = result
         .diagnostics
@@ -1319,6 +1373,26 @@ pub fn render_edit_flowscript_result(
             flowscript_workspace_tag(flowscript, "validation_errors"),
             msg
         );
+    }
+
+    if !allow_deletions {
+        let destructive = destructive_flowscript_command_summaries(&result.commands);
+        if !destructive.is_empty() {
+            let mut msg = blocked_destructive_flowscript_message(&destructive);
+            if !result.diagnostics.is_empty() {
+                msg.push_str("\nDiagnostics:\n");
+                for d in &result.diagnostics {
+                    msg.push_str("- ");
+                    msg.push_str(d);
+                    msg.push('\n');
+                }
+            }
+            return format!(
+                "{}\n{}",
+                flowscript_workspace_tag(flowscript, "validation_errors"),
+                msg
+            );
+        }
     }
 
     let commands_json = serde_json::to_string(&result.commands).unwrap_or_default();
@@ -1382,33 +1456,44 @@ impl Tool for EditFlowScriptTool {
             name: "edit_flowscript".to_string(),
             description: r#"Apply an edited FlowScript document to the board.
 
-This is the PRIMARY way to modify a workflow. Submit the FULL edited FlowScript source (the same
-document shown in the system context). Reconcile compares it to the live board using the
-`//@n:<id>` anchor comments and catalog declarations, then produces minimal changes:
+This is the PRIMARY way to modify a workflow. For existing-board edits, call
+`get_current_flowscript` first, edit that exact returned document, and submit the FULL edited
+FlowScript source. Reconcile compares it to the live board using the `//@n:<id>` anchor comments
+and catalog declarations, then produces minimal changes:
 - A changed literal argument on an anchored call → updates that node's pin value.
-- An anchored statement you removed → deletes that node.
+- An anchored statement you removed → deletes that node only when `allow_deletions` is true.
 - A new unanchored FlowScript call → adds that node, configures literal args, and connects
   resolvable FlowScript references/nested calls.
+- A new unanchored `function name(...) { ... }` declaration → creates a Function layer, places
+  body nodes inside it, creates boundary pins from params/returns, and wires `return` values.
 
 RULES:
 - PRESERVE every `//@n:<id>` anchor comment on statements you keep, exactly as given.
+- Leave `allow_deletions` false unless the user explicitly asked to delete existing board items.
 - Do NOT invent anchors for brand-new nodes; write normal unanchored calls using declarations
   from `get_declarations`.
 - New catalog calls must be inside a function/event block, e.g.
   `run() { const db = openLocalDb({ name: "email_vectors" }) }`.
 - Top-level `const name: Type = literal` declarations are variables/defaults only; they must use
   literal defaults and do not create node calls.
+- If you use `variableGet({ varRef: "NAME" })` or any `varRef`, `NAME` must resolve to an
+  existing variable or a top-level FlowScript variable declaration such as
+  `const NAME: string = ""`; missing varRefs are validation errors.
 - Inside a function/event block, `const name = ...` must bind a node-call expression. Use
   local alias syntax like `let rows = []` / `rows = arrayPush(...)`, typed `let name: Type =
   literal`, or direct literals for non-call values.
 - Do not rely on mutable assignments inside brand-new `if`/`for` blocks; new control-flow body
   lowering is limited and unsafe partial graph edits are rejected.
 - FlowScript statement order maps to the normal execution path only when the previous node has one
-  execution output or an explicit continuation policy in the reconciler. Multi-output nodes are
-  not guessed by pin order; API Call/httpFetch continues from `exec_success`, never `exec_error`.
-  If no policy exists, validation reports a diagnostic instead of queueing an unsafe edge.
+  execution output, a `done` / `exec_done` output, or an explicit continuation policy in the
+  reconciler. Multi-output nodes are not guessed by pin order; API Call/httpFetch continues from
+  `exec_success`, never `exec_error`. If no policy exists, validation reports a diagnostic instead
+  of queueing an unsafe edge.
 - Existing multi-output execution graphs render back to FlowScript as labelled branch blocks, so
   board -> FlowScript -> board preserves those branches rather than flattening them.
+- Streaming calls with `on_stream` plus `exec_done` may place `.chunk` consumers immediately after
+  the call; those consumers wire from `on_stream`, while later `.response` / `.stats` consumers
+  continue from `exec_done`.
 - For loops, the body is the `exec_out` path and the next statement continues from `done` /
   `exec_done`; make sure the loop's `array` input receives the array being iterated.
 - Object/call-argument fields use colon syntax (`{ host: "imap.gmail.com" }`), never assignment
@@ -1426,6 +1511,10 @@ RULES:
                     "flowscript": {
                         "type": "string",
                         "description": "The full edited FlowScript source for the board, with anchors preserved."
+                    },
+                    "allow_deletions": {
+                        "type": "boolean",
+                        "description": "Set true only when the user explicitly requested deletion of existing board items. Defaults false to prevent incomplete FlowScript from deleting nodes."
                     }
                 },
                 "required": ["flowscript"]
@@ -1449,6 +1538,7 @@ RULES:
             &args.flowscript,
             &result,
             board_has_no_nodes(&self.board),
+            args.allow_deletions,
         ))
     }
 }
@@ -1703,6 +1793,7 @@ pub fn get_tool_description(name: &str, arguments: &serde_json::Value) -> String
                 "Looking up FlowScript declarations...".to_string()
             }
         }
+        "get_current_flowscript" => "Reading current board FlowScript...".to_string(),
         "edit_flowscript" => "Applying FlowScript edits to the board...".to_string(),
         _ => format!("Running {}...", name),
     }
@@ -1729,6 +1820,7 @@ mod tests {
             "// Implementation plan: call openLocalDb later",
             &result,
             true,
+            false,
         );
 
         assert!(output.contains("\"status\":\"validation_errors\""));
@@ -1743,6 +1835,7 @@ mod tests {
             "run() {\n    const db = openLocalDb({ name: \"gmail_vectors\" })\n}",
             &result,
             false,
+            false,
         );
 
         assert!(output.starts_with("<flowscript_workspace>"));
@@ -1753,7 +1846,7 @@ mod tests {
     #[test]
     fn edit_flowscript_result_flags_empty_function_shells() {
         let result = ReconcileResult::default();
-        let output = render_edit_flowscript_result("run() {\n}", &result, true);
+        let output = render_edit_flowscript_result("run() {\n}", &result, true, false);
 
         assert!(output.contains("\"status\":\"validation_errors\""));
         assert!(output.contains("no executable catalog calls"));
@@ -1772,6 +1865,7 @@ mod tests {
             "run() {\n    emailImapConnect({ host = \"imap.gmail.com\" })\n}",
             &result,
             true,
+            false,
         );
 
         assert!(output.contains("\"status\":\"validation_errors\""));
@@ -1792,6 +1886,7 @@ mod tests {
             "run() {\n    const row = { id: \"x\" }\n}",
             &result,
             true,
+            false,
         );
 
         assert!(output.contains("\"status\":\"validation_errors\""));
@@ -1819,6 +1914,7 @@ mod tests {
             "run() {\n    for (const item of controlForEach({ array: rows })) {\n        log({ text: item.value })\n    }\n}",
             &result,
             true,
+            false,
         );
 
         assert!(output.contains("\"status\":\"validation_errors\""));
@@ -1827,9 +1923,25 @@ mod tests {
     }
 
     #[test]
+    fn edit_flowscript_result_blocks_deletions_by_default() {
+        let result = ReconcileResult {
+            commands: vec![BoardCommand::RemoveNode {
+                node_id: "old_node".to_string(),
+                summary: None,
+            }],
+            diagnostics: Vec::new(),
+        };
+        let output = render_edit_flowscript_result("run() {\n}", &result, false, false);
+
+        assert!(output.contains("\"status\":\"validation_errors\""));
+        assert!(output.contains("Deletions are blocked by default"));
+        assert!(!output.contains("<commands>"));
+    }
+
+    #[test]
     fn edit_flowscript_result_keeps_true_no_changes_non_error() {
         let result = ReconcileResult::default();
-        let output = render_edit_flowscript_result("run() {\n}", &result, false);
+        let output = render_edit_flowscript_result("run() {\n}", &result, false, false);
 
         assert!(output.contains("\"status\":\"no_changes\""));
     }

--- a/packages/core/src/flow/copilot/types.rs
+++ b/packages/core/src/flow/copilot/types.rs
@@ -402,7 +402,17 @@ pub enum BoardCommand {
     // Layer/grouping management
     CreateLayer {
         name: String,
+        /// Reference ID like "$0" for same-batch references. FlowScript reconcile uses this when
+        /// creating a new function layer and placing its body nodes inside it.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        ref_id: Option<String>,
+        /// Layer kind. Omitted/default means "Collapsed"; FlowScript functions use "Function".
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        layer_type: Option<String>,
+        #[serde(default)]
         node_ids: Vec<String>, // Nodes to include in the layer
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pins: Option<Vec<PlaceholderPinDef>>,
         position: Option<NodePosition>,
         color: Option<String>,
         /// Parent layer ID. If None, creates at root or current layer.

--- a/packages/core/src/flow/copilot/validation.rs
+++ b/packages/core/src/flow/copilot/validation.rs
@@ -298,7 +298,7 @@ pub async fn validate_emit_commands(
                     continue;
                 };
 
-                if source_pin.direction != PinDirection::Output {
+                if source_pin.direction != PinDirection::Output && !from_entity.is_layer {
                     errors.push(issue(
                         "error",
                         "invalid-source-direction",
@@ -310,7 +310,7 @@ pub async fn validate_emit_commands(
                     ));
                 }
 
-                if target_pin.direction != PinDirection::Input {
+                if target_pin.direction != PinDirection::Input && !to_entity.is_layer {
                     errors.push(issue(
                         "error",
                         "invalid-target-direction",
@@ -460,7 +460,10 @@ pub async fn validate_emit_commands(
             }
             BoardCommand::CreateLayer {
                 name,
+                ref_id,
+                layer_type,
                 node_ids,
+                pins,
                 position,
                 target_layer,
                 summary,
@@ -499,6 +502,26 @@ pub async fn validate_emit_commands(
                     }
                 }
                 validate_target_layer(index, target_layer, &known_layer_refs, &mut errors);
+                validate_placeholder_pins(index, pins.as_deref(), &mut errors);
+
+                let key = ref_id
+                    .clone()
+                    .unwrap_or_else(|| format!("__new_layer_{}", index));
+                if entities.contains_key(&key) {
+                    errors.push(issue(
+                        "error",
+                        "duplicate-ref",
+                        Some(index),
+                        format!("Reference '{}' is already in use", key),
+                    ));
+                } else {
+                    entities.insert(key.clone(), entity_from_layer(&key, name, pins));
+                    known_layer_refs.insert(key.clone());
+                    known_layer_refs.insert(name.clone());
+                    if matches!(layer_type.as_deref(), Some("Function")) {
+                        entities_to_check.insert(key);
+                    }
+                }
             }
             BoardCommand::RemoveLayer { layer_id, .. } => {
                 if !known_layer_refs.contains(layer_id) {
@@ -919,6 +942,31 @@ fn entity_from_placeholder(
         display_name: name.to_string(),
         is_layer: true,
         pins: known_pins,
+    }
+}
+
+fn entity_from_layer(key: &str, name: &str, pins: &Option<Vec<PlaceholderPinDef>>) -> KnownEntity {
+    KnownEntity {
+        key: key.to_string(),
+        display_name: name.to_string(),
+        is_layer: true,
+        pins: pins
+            .as_ref()
+            .map(|pins| {
+                pins.iter()
+                    .map(|pin| KnownPin {
+                        name: pin.name.clone(),
+                        data_type: pin.data_type.clone(),
+                        direction: if pin.pin_type == "Input" {
+                            PinDirection::Input
+                        } else {
+                            PinDirection::Output
+                        },
+                        has_default_value: false,
+                    })
+                    .collect()
+            })
+            .unwrap_or_default(),
     }
 }
 

--- a/packages/ui/components/flow/flow-board.tsx
+++ b/packages/ui/components/flow/flow-board.tsx
@@ -660,6 +660,7 @@ export function FlowBoard({
 	const {
 		executeCommand,
 		executeCommands,
+		applyFlowScript,
 		awarenessRef: commandAwarenessRef,
 	} = useCommandExecution({
 		appId,
@@ -2884,9 +2885,16 @@ export function FlowBoard({
 	const { handleExecuteCommands } = useCopilotCommands({
 		board,
 		catalog,
-		executeCommand,
+		executeCommands,
 		currentLayer,
 	});
+	const handleApplyFlowScript = useCallback(
+		(
+			flowscript: string,
+			options?: { allowDeletions?: boolean; suppressBlockedToast?: boolean },
+		) => applyFlowScript(flowscript, currentLayer, catalog.data, options),
+		[applyFlowScript, currentLayer, catalog.data],
+	);
 
 	return (
 		<div className="w-full flex flex-1 grow flex-col min-h-0 relative overflow-hidden">
@@ -2911,6 +2919,7 @@ export function FlowBoard({
 							onSelectNodes={selectNodes}
 							onGhostNodesChange={handleGhostNodesChange}
 							onExecuteCommands={handleExecuteCommands}
+							onApplyFlowScript={handleApplyFlowScript}
 							runContext={currentMetadata}
 							onClearRunContext={() => setCurrentMetadata(undefined)}
 							onClose={() => {
@@ -3531,6 +3540,7 @@ export function FlowBoard({
 								onSelectNodes={selectNodes}
 								onGhostNodesChange={handleGhostNodesChange}
 								onExecuteCommands={handleExecuteCommands}
+								onApplyFlowScript={handleApplyFlowScript}
 								runContext={currentMetadata}
 								onClearRunContext={() => setCurrentMetadata(undefined)}
 								onClose={() => {

--- a/packages/ui/components/flow/flow-copilot/FlowCopilotWrapper.tsx
+++ b/packages/ui/components/flow/flow-copilot/FlowCopilotWrapper.tsx
@@ -20,6 +20,7 @@ export function FlowCopilotWrapper({
 	selectedNodeIds,
 	onAcceptSuggestion,
 	onExecuteCommands,
+	onApplyFlowScript,
 	onFocusNode,
 	onSelectNodes,
 	runContext,
@@ -41,6 +42,7 @@ export function FlowCopilotWrapper({
 			selectedNodeIds={selectedNodeIds}
 			onAcceptSuggestion={onAcceptSuggestion}
 			onExecuteCommands={onExecuteCommands}
+			onApplyFlowScript={onApplyFlowScript}
 			onFocusNode={onFocusNode}
 			onSelectNodes={onSelectNodes}
 			runContext={

--- a/packages/ui/components/flow/flow-copilot/types.ts
+++ b/packages/ui/components/flow/flow-copilot/types.ts
@@ -31,13 +31,31 @@ export interface CopilotMessage {
 	planSteps?: PlanStep[];
 }
 
+export interface FlowScriptApplyResultLike {
+	commands?: unknown[];
+	board_commands?: BoardCommand[];
+	diagnostics?: string[];
+}
+
+export interface FlowScriptApplyOptions {
+	allowDeletions?: boolean;
+	suppressBlockedToast?: boolean;
+}
+
 export interface FlowCopilotProps {
 	appId?: string;
 	board: IBoard | null | undefined;
 	catalogNodes?: INode[];
 	selectedNodeIds: string[];
 	onAcceptSuggestion: (suggestion: Suggestion) => void;
-	onExecuteCommands?: (commands: BoardCommand[]) => void;
+	onExecuteCommands?: (commands: BoardCommand[]) => void | Promise<void>;
+	onApplyFlowScript?: (
+		flowscript: string,
+		options?: FlowScriptApplyOptions,
+	) =>
+		| undefined
+		| FlowScriptApplyResultLike
+		| Promise<undefined | FlowScriptApplyResultLike>;
 	onGhostNodesChange?: (suggestions: Suggestion[]) => void;
 	onClearRunContext?: () => void;
 	onClose?: () => void;

--- a/packages/ui/components/flowpilot/FlowPilot.tsx
+++ b/packages/ui/components/flowpilot/FlowPilot.tsx
@@ -3014,9 +3014,7 @@ ${userMsg}`;
 		!flowscriptWorkspaceBlocksApply &&
 		flowscriptWorkspace !== appliedFlowScriptWorkspace;
 	const showFlowScriptWorkspace = hasFlowScriptWorkspace && showWorkspace;
-	const flowScriptWorkspaceIsPending =
-		hasFlowScriptWorkspace && flowscriptWorkspace !== appliedFlowScriptWorkspace;
-	const visiblePendingCommands = flowScriptWorkspaceIsPending
+	const visiblePendingCommands = hasUnappliedFlowScriptWorkspace
 		? []
 		: pendingCommands;
 

--- a/packages/ui/components/flowpilot/FlowPilot.tsx
+++ b/packages/ui/components/flowpilot/FlowPilot.tsx
@@ -115,8 +115,43 @@ const ALLOWED_ATTACHED_IMAGE_TYPES = new Set([
 	"image/webp",
 	"image/gif",
 ]);
+const DESTRUCTIVE_FLOWSCRIPT_DIAGNOSTIC_PREFIX =
+	"FlowScript edit would delete ";
 const FLOWSCRIPT_LANGUAGE_ID = "flowscript";
 let flowScriptLanguageRegistered = false;
+
+function applyResultDiagnostics(applyResult: unknown): string[] {
+	if (!applyResult || typeof applyResult !== "object") return [];
+	const diagnostics = (applyResult as { diagnostics?: unknown }).diagnostics;
+	return Array.isArray(diagnostics)
+		? diagnostics.filter((diagnostic): diagnostic is string => {
+				return typeof diagnostic === "string";
+			})
+		: [];
+}
+
+function applyResultCommandCount(applyResult: unknown): number | undefined {
+	if (!applyResult || typeof applyResult !== "object") return undefined;
+	const commands = (applyResult as { commands?: unknown }).commands;
+	return Array.isArray(commands) ? commands.length : undefined;
+}
+
+function applyResultBoardCommands(applyResult: unknown): BoardCommand[] {
+	if (!applyResult || typeof applyResult !== "object") return [];
+	const boardCommands = (applyResult as { board_commands?: unknown })
+		.board_commands;
+	return Array.isArray(boardCommands)
+		? (boardCommands as BoardCommand[])
+		: [];
+}
+
+function destructiveFlowScriptDiagnostic(diagnostics: string[]): string | null {
+	return (
+		diagnostics.find((diagnostic) =>
+			diagnostic.startsWith(DESTRUCTIVE_FLOWSCRIPT_DIAGNOSTIC_PREFIX),
+		) ?? null
+	);
+}
 
 function registerFlowScriptLanguage(monaco: Monaco, isDark: boolean) {
 	const hasRegisteredLanguage = monaco.languages
@@ -306,7 +341,9 @@ function parseStreamJson(payload: string): Record<string, unknown> | null {
 	}
 }
 
-function normalizeEnabledAIProvider(provider?: AIProvider): NormalizedAIProvider {
+function normalizeEnabledAIProvider(
+	provider?: AIProvider,
+): NormalizedAIProvider {
 	const normalized = normalizeAIProvider(provider);
 	return normalized === "claude-code" ? "codex" : normalized;
 }
@@ -317,6 +354,8 @@ function getProcessToolLabel(toolName?: string): string {
 		case "think":
 		case "analyze":
 			return "Thinking";
+		case "get_current_flowscript":
+			return "Reading current FlowScript";
 		case "get_declarations":
 			return "Looking up FlowScript declarations";
 		case "edit_flowscript":
@@ -443,7 +482,10 @@ interface FrontendToolQueuedDialog {
 }
 
 type TauriCoreModule = {
-	invoke: <T = unknown>(command: string, args?: Record<string, unknown>) => Promise<T>;
+	invoke: <T = unknown>(
+		command: string,
+		args?: Record<string, unknown>,
+	) => Promise<T>;
 };
 
 type TauriEventModule = {
@@ -519,7 +561,9 @@ function resolveToolAppId(
 ): string {
 	const appId = getArgString(args, "app_id", "appId") ?? defaultAppId;
 	if (!appId) {
-		throw new Error("Missing app_id. Provide app_id or open FlowPilot from an app context.");
+		throw new Error(
+			"Missing app_id. Provide app_id or open FlowPilot from an app context.",
+		);
 	}
 	return appId;
 }
@@ -670,6 +714,7 @@ export function FlowPilot({
 	selectedNodeIds = [],
 	onAcceptSuggestion,
 	onExecuteCommands,
+	onApplyFlowScript,
 	onFocusNode,
 	onSelectNodes,
 	runContext,
@@ -711,6 +756,16 @@ export function FlowPilot({
 	const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
 	const [currentToolCall, setCurrentToolCall] = useState<string | null>(null);
 	const [flowscriptWorkspace, setFlowscriptWorkspace] = useState("");
+	const [flowscriptWorkspaceStatus, setFlowscriptWorkspaceStatus] = useState<
+		string | undefined
+	>();
+	const [appliedFlowScriptWorkspace, setAppliedFlowScriptWorkspace] =
+		useState("");
+	const [destructiveApplyRequest, setDestructiveApplyRequest] = useState<{
+		flowscript: string;
+		diagnostic: string;
+	} | null>(null);
+	const [destructiveApplyPending, setDestructiveApplyPending] = useState(false);
 	const [showWorkspace, setShowWorkspace] = useState(false);
 	const [processEvents, setProcessEvents] = useState<FlowPilotProcessEvent[]>(
 		[],
@@ -744,9 +799,9 @@ export function FlowPilot({
 	const executionService = useExecutionServiceOptional();
 	const activeAppId = appId ?? runContext?.app_id;
 	const approvedFrontendToolKeysRef = useRef<Set<string>>(new Set());
-	const frontendToolDialogResolverRef = useRef<
-		((value: any) => void) | null
-	>(null);
+	const frontendToolDialogResolverRef = useRef<((value: any) => void) | null>(
+		null,
+	);
 	const frontendToolDialogQueueRef = useRef<FrontendToolQueuedDialog[]>([]);
 	const [frontendToolDialog, setFrontendToolDialog] =
 		useState<FrontendToolDialogState | null>(null);
@@ -823,10 +878,13 @@ export function FlowPilot({
 	);
 
 	const requestFrontendToolApproval = useCallback(
-		(request: FrontendToolRequest): Promise<{ approved: boolean; remember: boolean }> => {
+		(
+			request: FrontendToolRequest,
+		): Promise<{ approved: boolean; remember: boolean }> => {
 			const approval = request.approval;
 			const sessionKey =
-				approval?.sessionKey || `${request.toolName}:${approval?.kind ?? "none"}`;
+				approval?.sessionKey ||
+				`${request.toolName}:${approval?.kind ?? "none"}`;
 			if (
 				approval?.kind === "none" ||
 				approvedFrontendToolKeysRef.current.has(sessionKey)
@@ -894,41 +952,48 @@ export function FlowPilot({
 		[openFrontendToolDialog],
 	);
 
-	const runInternetSearchTool = useCallback(async (args: Record<string, unknown>) => {
-		const query = getArgString(args, "query");
-		if (!query) throw new Error("internet_search requires query.");
-		const language = getArgString(args, "language") ?? "en-US";
-		const page = Math.max(1, getArgNumber(args, "page", "page", 1));
-		const limit = clampToolLimit(getArgNumber(args, "limit", "limit", 8), 8, 20);
-		const url = new URL("https://search.flow-like.com/search");
-		url.searchParams.set("q", query);
-		url.searchParams.set("format", "json");
-		url.searchParams.set("pageno", String(page));
-		url.searchParams.set("language", language);
+	const runInternetSearchTool = useCallback(
+		async (args: Record<string, unknown>) => {
+			const query = getArgString(args, "query");
+			if (!query) throw new Error("internet_search requires query.");
+			const language = getArgString(args, "language") ?? "en-US";
+			const page = Math.max(1, getArgNumber(args, "page", "page", 1));
+			const limit = clampToolLimit(
+				getArgNumber(args, "limit", "limit", 8),
+				8,
+				20,
+			);
+			const url = new URL("https://search.flow-like.com/search");
+			url.searchParams.set("q", query);
+			url.searchParams.set("format", "json");
+			url.searchParams.set("pageno", String(page));
+			url.searchParams.set("language", language);
 
-		const json = (await fetchJsonViaTauri(url.toString())) as Record<
-			string,
-			unknown
-		>;
-		const results = Array.isArray(json.results) ? json.results : [];
-		return {
-			status: "ok",
-			query,
-			page,
-			results: results.slice(0, limit).map((result) => {
-				const item = result as Record<string, unknown>;
-				return {
-					title: item.title,
-					url: item.url,
-					content: item.content,
-					publishedDate: item.publishedDate,
-					engine: item.engine,
-					category: item.category,
-					score: item.score,
-				};
-			}),
-		};
-	}, []);
+			const json = (await fetchJsonViaTauri(url.toString())) as Record<
+				string,
+				unknown
+			>;
+			const results = Array.isArray(json.results) ? json.results : [];
+			return {
+				status: "ok",
+				query,
+				page,
+				results: results.slice(0, limit).map((result) => {
+					const item = result as Record<string, unknown>;
+					return {
+						title: item.title,
+						url: item.url,
+						content: item.content,
+						publishedDate: item.publishedDate,
+						engine: item.engine,
+						category: item.category,
+						score: item.score,
+					};
+				}),
+			};
+		},
+		[],
+	);
 
 	const runDatabaseTool = useCallback(
 		async (args: Record<string, unknown>) => {
@@ -938,7 +1003,12 @@ export function FlowPilot({
 			const userScoped = getArgBool(args, "user_scoped", "userScoped", false);
 			const offset = Math.max(0, getArgNumber(args, "offset", "offset", 0));
 			const limit = clampToolLimit(
-				getArgNumber(args, "limit", "limit", operation === "describe_table" ? 10 : 50),
+				getArgNumber(
+					args,
+					"limit",
+					"limit",
+					operation === "describe_table" ? 10 : 50,
+				),
 				operation === "describe_table" ? 10 : 50,
 				200,
 			);
@@ -957,7 +1027,8 @@ export function FlowPilot({
 					};
 				}
 				case "describe_table": {
-					if (!tableName) throw new Error("describe_table requires table_name.");
+					if (!tableName)
+						throw new Error("describe_table requires table_name.");
 					const [schema, indices, rowCount, sample] = await Promise.all([
 						backendContext.dbState.getSchema(toolAppId, tableName, userScoped),
 						backendContext.dbState.getIndices(toolAppId, tableName, userScoped),
@@ -1006,14 +1077,19 @@ export function FlowPilot({
 				case "add_items": {
 					if (!tableName) throw new Error("insert requires table_name.");
 					const items = Array.isArray(args.items) ? args.items : [];
-					if (items.length === 0) throw new Error("insert requires non-empty items.");
+					if (items.length === 0)
+						throw new Error("insert requires non-empty items.");
 					await backendContext.dbState.addItems(
 						toolAppId,
 						tableName,
 						items,
 						userScoped,
 					);
-					return { status: "ok", inserted: items.length, table_name: tableName };
+					return {
+						status: "ok",
+						inserted: items.length,
+						table_name: tableName,
+					};
 				}
 				case "delete":
 				case "remove_items": {
@@ -1087,10 +1163,15 @@ export function FlowPilot({
 					if (!tableName) throw new Error("add_column requires table_name.");
 					const column =
 						args.column_definition && typeof args.column_definition === "object"
-							? (args.column_definition as { name: string; sql_expression: string })
+							? (args.column_definition as {
+									name: string;
+									sql_expression: string;
+								})
 							: undefined;
 					if (!column?.name || !column?.sql_expression) {
-						throw new Error("add_column requires column_definition.name and sql_expression.");
+						throw new Error(
+							"add_column requires column_definition.name and sql_expression.",
+						);
 					}
 					await backendContext.dbState.addColumn(
 						toolAppId,
@@ -1103,9 +1184,12 @@ export function FlowPilot({
 				case "drop_columns": {
 					if (!tableName) throw new Error("drop_columns requires table_name.");
 					const columns = Array.isArray(args.columns)
-						? args.columns.filter((value): value is string => typeof value === "string")
+						? args.columns.filter(
+								(value): value is string => typeof value === "string",
+							)
 						: [];
-					if (columns.length === 0) throw new Error("drop_columns requires columns.");
+					if (columns.length === 0)
+						throw new Error("drop_columns requires columns.");
 					await backendContext.dbState.dropColumns(
 						toolAppId,
 						tableName,
@@ -1128,7 +1212,9 @@ export function FlowPilot({
 					return { status: "ok", table_name: tableName, column };
 				}
 				default:
-					throw new Error(`Unsupported database_tool operation '${operation}'.`);
+					throw new Error(
+						`Unsupported database_tool operation '${operation}'.`,
+					);
 			}
 		},
 		[activeAppId, backendContext.dbState],
@@ -1174,7 +1260,9 @@ export function FlowPilot({
 					);
 					const [file] = await download(toolAppId, [path]);
 					if (!file || file.error) {
-						throw new Error(file?.error ?? `Unable to resolve storage path '${path}'.`);
+						throw new Error(
+							file?.error ?? `Unable to resolve storage path '${path}'.`,
+						);
 					}
 					if (!file.url) {
 						return {
@@ -1198,9 +1286,11 @@ export function FlowPilot({
 					const path = getArgString(args, "path");
 					if (!path) throw new Error("create_file requires path.");
 					const content = String(args.content ?? "");
-					const mimeType = getArgString(args, "mime_type", "mimeType") ?? "text/plain";
+					const mimeType =
+						getArgString(args, "mime_type", "mimeType") ?? "text/plain";
 					const { prefix, fileName } = splitStoragePath(path);
-					if (!fileName) throw new Error("create_file path must include a file name.");
+					if (!fileName)
+						throw new Error("create_file path must include a file name.");
 					const file = new File([content], fileName, { type: mimeType });
 					await upload(toolAppId, prefix, [file]);
 					return {
@@ -1212,11 +1302,14 @@ export function FlowPilot({
 				}
 				case "delete_files": {
 					const paths = Array.isArray(args.paths)
-						? args.paths.filter((value): value is string => typeof value === "string")
+						? args.paths.filter(
+								(value): value is string => typeof value === "string",
+							)
 						: getArgString(args, "path")
 							? [getArgString(args, "path") as string]
 							: [];
-					if (paths.length === 0) throw new Error("delete_files requires paths.");
+					if (paths.length === 0)
+						throw new Error("delete_files requires paths.");
 					await remove(toolAppId, paths);
 					return { status: "ok", deleted: paths, user_scoped: userScoped };
 				}
@@ -1241,7 +1334,10 @@ export function FlowPilot({
 			);
 			const payload =
 				args.payload && typeof args.payload === "object"
-					? ({ id: eventId, ...(args.payload as Record<string, unknown>) } as any)
+					? ({
+							id: eventId,
+							...(args.payload as Record<string, unknown>),
+						} as any)
 					: { id: eventId, payload: {} };
 			const logs: unknown[] = [];
 			let runId: string | undefined;
@@ -1366,7 +1462,8 @@ export function FlowPilot({
 						if (disposed) return;
 						const request = event.payload;
 						if (!request?.requestId || !request.toolName) return;
-						const response = await executeFrontendToolRequestRef.current(request);
+						const response =
+							await executeFrontendToolRequestRef.current(request);
 						if (disposed) return;
 						try {
 							await coreApi.invoke("flowpilot_frontend_tool_result", {
@@ -1389,7 +1486,10 @@ export function FlowPilot({
 					unlisten = stop;
 				}
 			} catch (error) {
-				console.warn("Failed to install FlowPilot frontend tool bridge:", error);
+				console.warn(
+					"Failed to install FlowPilot frontend tool bridge:",
+					error,
+				);
 			}
 		}
 
@@ -1441,8 +1541,7 @@ export function FlowPilot({
 			let preferredModel = currentModels[0];
 			if (normalizedProvider === "codex") {
 				preferredModel =
-					currentModels.find((m) => m.id === "default") ||
-					currentModels[0];
+					currentModels.find((m) => m.id === "default") || currentModels[0];
 			} else if (normalizedProvider === "claude-code") {
 				preferredModel =
 					currentModels.find((m) => m.id.includes("sonnet")) ||
@@ -1517,6 +1616,10 @@ export function FlowPilot({
 		setValidationWarnings([]);
 		setSuggestions([]);
 		setFlowscriptWorkspace("");
+		setFlowscriptWorkspaceStatus(undefined);
+		setAppliedFlowScriptWorkspace("");
+		setDestructiveApplyRequest(null);
+		setDestructiveApplyPending(false);
 		setShowWorkspace(false);
 		setProcessEvents([]);
 		setCurrentConversationId(undefined);
@@ -1547,6 +1650,10 @@ export function FlowPilot({
 					.find((message) => message.flowscriptWorkspace)?.flowscriptWorkspace;
 				setMessages(loadedMessages);
 				setFlowscriptWorkspace(latestWorkspace ?? "");
+				setFlowscriptWorkspaceStatus(undefined);
+				setAppliedFlowScriptWorkspace(latestWorkspace ?? "");
+				setDestructiveApplyRequest(null);
+				setDestructiveApplyPending(false);
 				setShowWorkspace(Boolean(latestWorkspace));
 				setCurrentConversationId(conversation.id);
 				setPlanSteps([]);
@@ -1660,17 +1767,15 @@ export function FlowPilot({
 		}
 	}, []);
 
-	// Board mode handlers
-	const handleExecuteCommands = useCallback(() => {
-		if (onExecuteCommands && pendingCommands.length > 0) {
+	const recordExecutedBoardCommands = useCallback(
+		(appliedBoardCommands: BoardCommand[]) => {
 			const lastAssistantMessage = [...messages]
 				.reverse()
 				.find((message) => message.role === "assistant");
 			const nextExecutedCommands = [
 				...(lastAssistantMessage?.executedCommands ?? []),
-				...pendingCommands,
+				...appliedBoardCommands,
 			];
-			onExecuteCommands(pendingCommands);
 			setMessages((prev) => {
 				const newMessages = [...prev];
 				for (let i = newMessages.length - 1; i >= 0; i--) {
@@ -1678,7 +1783,10 @@ export function FlowPilot({
 						const existingCommands = newMessages[i].executedCommands || [];
 						newMessages[i] = {
 							...newMessages[i],
-							executedCommands: [...existingCommands, ...pendingCommands],
+							executedCommands: [
+								...existingCommands,
+								...appliedBoardCommands,
+							],
 						};
 						break;
 					}
@@ -1690,12 +1798,73 @@ export function FlowPilot({
 					executedCommands: nextExecutedCommands,
 				});
 			}
+		},
+		[messages],
+	);
+
+	// Board mode handlers
+	const handleExecuteCommands = useCallback(async () => {
+		const shouldApplyFlowScript =
+			Boolean(onApplyFlowScript) &&
+			flowscriptWorkspace.trim().length > 0 &&
+			flowscriptWorkspaceStatus !== "validation_errors" &&
+			flowscriptWorkspaceStatus !== "no_changes" &&
+			flowscriptWorkspace !== appliedFlowScriptWorkspace;
+		if (
+			shouldApplyFlowScript ||
+			(onExecuteCommands && pendingCommands.length > 0)
+		) {
+			let appliedBoardCommands: BoardCommand[] = pendingCommands;
+			try {
+				let applyResult: unknown;
+				if (shouldApplyFlowScript && onApplyFlowScript) {
+					applyResult = await onApplyFlowScript(flowscriptWorkspace, {
+						suppressBlockedToast: true,
+					});
+					if (!applyResult) return;
+
+					appliedBoardCommands = applyResultBoardCommands(applyResult);
+				} else if (onExecuteCommands) {
+					await onExecuteCommands(pendingCommands);
+				}
+				const diagnostics = applyResultDiagnostics(applyResult);
+				if (applyResultCommandCount(applyResult) === 0 && diagnostics.length > 0) {
+					const destructiveDiagnostic =
+						destructiveFlowScriptDiagnostic(diagnostics);
+					if (shouldApplyFlowScript && destructiveDiagnostic) {
+						setDestructiveApplyRequest({
+							flowscript: flowscriptWorkspace,
+							diagnostic: destructiveDiagnostic,
+						});
+						return;
+					}
+					setFlowscriptWorkspaceStatus("validation_errors");
+					return;
+				}
+				if (shouldApplyFlowScript) {
+					setAppliedFlowScriptWorkspace(flowscriptWorkspace);
+					setFlowscriptWorkspaceStatus("applied");
+				}
+			} catch (error) {
+				console.error("Failed to apply FlowPilot commands:", error);
+				return;
+			}
+			recordExecutedBoardCommands(appliedBoardCommands);
 			setPendingCommands([]);
+			setDestructiveApplyRequest(null);
 		}
-	}, [messages, onExecuteCommands, pendingCommands]);
+	}, [
+		appliedFlowScriptWorkspace,
+		flowscriptWorkspace,
+		flowscriptWorkspaceStatus,
+		onApplyFlowScript,
+		onExecuteCommands,
+		pendingCommands,
+		recordExecutedBoardCommands,
+	]);
 
 	const handleExecuteSingle = useCallback(
-		(index: number) => {
+		async (index: number) => {
 			if (onExecuteCommands && pendingCommands[index]) {
 				const command = pendingCommands[index];
 				const lastAssistantMessage = [...messages]
@@ -1705,7 +1874,12 @@ export function FlowPilot({
 					...(lastAssistantMessage?.executedCommands ?? []),
 					command,
 				];
-				onExecuteCommands([command]);
+				try {
+					await onExecuteCommands([command]);
+				} catch (error) {
+					console.error("Failed to apply FlowPilot command:", error);
+					return;
+				}
 				setMessages((prev) => {
 					const newMessages = [...prev];
 					for (let i = newMessages.length - 1; i >= 0; i--) {
@@ -1732,8 +1906,47 @@ export function FlowPilot({
 	);
 
 	const handleDismissCommands = useCallback(() => {
+		if (flowscriptWorkspace) {
+			setAppliedFlowScriptWorkspace(flowscriptWorkspace);
+			setFlowscriptWorkspaceStatus("dismissed");
+		}
 		setPendingCommands([]);
-	}, []);
+		setDestructiveApplyRequest(null);
+	}, [flowscriptWorkspace]);
+
+	const handleApproveFlowScriptDeletion = useCallback(async () => {
+		if (!destructiveApplyRequest || !onApplyFlowScript) return;
+
+		setDestructiveApplyPending(true);
+		try {
+			const applyResult = await onApplyFlowScript(
+				destructiveApplyRequest.flowscript,
+				{ allowDeletions: true },
+			);
+			if (!applyResult) return;
+
+			const diagnostics = applyResultDiagnostics(applyResult);
+			if (applyResultCommandCount(applyResult) === 0 && diagnostics.length > 0) {
+				setFlowscriptWorkspaceStatus("validation_errors");
+				setDestructiveApplyRequest(null);
+				return;
+			}
+
+			recordExecutedBoardCommands(applyResultBoardCommands(applyResult));
+			setAppliedFlowScriptWorkspace(destructiveApplyRequest.flowscript);
+			setFlowscriptWorkspaceStatus("applied");
+			setPendingCommands([]);
+			setDestructiveApplyRequest(null);
+		} catch (error) {
+			console.error("Failed to apply destructive FlowScript edit:", error);
+		} finally {
+			setDestructiveApplyPending(false);
+		}
+	}, [
+		destructiveApplyRequest,
+		onApplyFlowScript,
+		recordExecutedBoardCommands,
+	]);
 
 	// UI mode handlers
 	const handleApplyComponents = useCallback(() => {
@@ -2015,12 +2228,15 @@ export function FlowPilot({
 					return found;
 				};
 
-				const applyFlowScriptWorkspace = (workspace: string) => {
+				const applyFlowScriptWorkspace = (workspace: string, status?: string) => {
 					const source = workspace;
 					if (!source.trim()) return;
 					const previousWorkspace = latestFlowScriptWorkspace;
 					latestFlowScriptWorkspace = source;
 					setFlowscriptWorkspace(source);
+					setFlowscriptWorkspaceStatus((previousStatus) =>
+						status ?? (previousWorkspace === source ? previousStatus : "queued"),
+					);
 					setShowWorkspace(true);
 					if (previousWorkspace !== source) {
 						appendProcessEvent({
@@ -2085,7 +2301,10 @@ export function FlowPilot({
 							workspaceMatch[1],
 						);
 						if (workspaceEvent) {
-							applyFlowScriptWorkspace(workspaceEvent.source);
+							applyFlowScriptWorkspace(
+								workspaceEvent.source,
+								workspaceEvent.status,
+							);
 						}
 						token = token.replace(
 							/<flowscript_workspace>[\s\S]*?<\/flowscript_workspace>/g,
@@ -2338,13 +2557,25 @@ export function FlowPilot({
 						try {
 							const commands = JSON.parse(commandsMatch[1]);
 							if (Array.isArray(commands) && commands.length > 0) {
-								setPendingCommands((prev) => [...prev, ...commands]);
+								const flowScriptOwnsApply =
+									latestFlowScriptWorkspace.trim().length > 0;
+								if (!flowScriptOwnsApply) {
+									setPendingCommands((prev) => [...prev, ...commands]);
+								}
 								appendProcessEvent({
 									id: `commands-${Date.now()}`,
 									kind: "commands",
 									status: "done",
-									title: "Queued board changes",
-									summary: `${commands.length} change${commands.length === 1 ? "" : "s"} ready for review`,
+									title: flowScriptOwnsApply
+										? "Derived FlowScript changes"
+										: "Queued board changes",
+									summary: `${commands.length} change${
+										commands.length === 1 ? "" : "s"
+									} ${
+										flowScriptOwnsApply
+											? "derived from FlowScript"
+											: "ready for review"
+									}`,
 									commands,
 								});
 							}
@@ -2553,7 +2784,10 @@ ${userMsg}`;
 				});
 
 				// Handle board commands
-				if (response.commands.length > 0) {
+				if (
+					response.commands.length > 0 &&
+					latestFlowScriptWorkspace.trim().length === 0
+				) {
 					setPendingCommands(response.commands);
 				}
 
@@ -2771,7 +3005,20 @@ ${userMsg}`;
 	const hasFlowScriptWorkspace =
 		Boolean(flowscriptWorkspace) &&
 		(agentMode === "board" || agentMode === "both");
+	const flowscriptWorkspaceBlocksApply =
+		flowscriptWorkspaceStatus === "validation_errors" ||
+		flowscriptWorkspaceStatus === "no_changes";
+	const hasUnappliedFlowScriptWorkspace =
+		hasFlowScriptWorkspace &&
+		Boolean(onApplyFlowScript) &&
+		!flowscriptWorkspaceBlocksApply &&
+		flowscriptWorkspace !== appliedFlowScriptWorkspace;
 	const showFlowScriptWorkspace = hasFlowScriptWorkspace && showWorkspace;
+	const flowScriptWorkspaceIsPending =
+		hasFlowScriptWorkspace && flowscriptWorkspace !== appliedFlowScriptWorkspace;
+	const visiblePendingCommands = flowScriptWorkspaceIsPending
+		? []
+		: pendingCommands;
 
 	useEffect(() => {
 		onWorkspaceVisibleChange?.(showFlowScriptWorkspace);
@@ -2898,10 +3145,12 @@ ${userMsg}`;
 
 					{/* Pending commands (board mode or both mode) */}
 					{(agentMode === "board" || agentMode === "both") &&
-						pendingCommands.length > 0 && (
+						(visiblePendingCommands.length > 0 ||
+							hasUnappliedFlowScriptWorkspace) && (
 							<div className="px-3 pb-2">
 								<PendingCommandsView
-									commands={pendingCommands}
+									commands={visiblePendingCommands}
+									flowscriptReady={hasUnappliedFlowScriptWorkspace}
 									onExecute={handleExecuteCommands}
 									onExecuteSingle={handleExecuteSingle}
 									onDismiss={handleDismissCommands}
@@ -3077,6 +3326,50 @@ ${userMsg}`;
 				onResolve={resolveFrontendToolDialog}
 			/>
 
+			<Dialog
+				open={Boolean(destructiveApplyRequest)}
+				onOpenChange={(open) => {
+					if (!open && !destructiveApplyPending) {
+						setDestructiveApplyRequest(null);
+					}
+				}}
+			>
+				<DialogContent className="max-w-md">
+					<DialogHeader>
+						<DialogTitle>Approve deletion</DialogTitle>
+						<DialogDescription>
+							FlowScript apply needs to delete existing board items before it can
+							continue.
+						</DialogDescription>
+					</DialogHeader>
+					<DialogBody>
+						<div className="max-h-36 overflow-y-auto rounded-md border border-destructive/30 bg-destructive/10 p-3 text-xs text-foreground">
+							{destructiveApplyRequest?.diagnostic}
+						</div>
+					</DialogBody>
+					<DialogFooter>
+						<Button
+							variant="secondary"
+							disabled={destructiveApplyPending}
+							onClick={() => setDestructiveApplyRequest(null)}
+						>
+							Cancel
+						</Button>
+						<Button
+							variant="destructive"
+							className="gap-2"
+							disabled={destructiveApplyPending}
+							onClick={handleApproveFlowScriptDeletion}
+						>
+							{destructiveApplyPending ? (
+								<Loader2 className="h-3.5 w-3.5 animate-spin" />
+							) : null}
+							Delete and apply
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
 			{/* History Panel */}
 			<HistoryPanel
 				mode={agentMode}
@@ -3113,7 +3406,8 @@ const FrontendToolRequestDialog = memo(function FrontendToolRequestDialog({
 		"FlowPilot request";
 	const description =
 		dialog.type === "approval"
-			? (dialog.request.approval?.description ?? "Approve this FlowPilot action?")
+			? (dialog.request.approval?.description ??
+				"Approve this FlowPilot action?")
 			: getArgString(args, "description") ||
 				getArgString(args, "placeholder") ||
 				"Provide the value FlowPilot needs to continue.";
@@ -3136,7 +3430,9 @@ const FrontendToolRequestDialog = memo(function FrontendToolRequestDialog({
 		);
 	};
 
-	const updateAsk = (patch: Partial<Extract<FrontendToolDialogState, { type: "ask" }>>) => {
+	const updateAsk = (
+		patch: Partial<Extract<FrontendToolDialogState, { type: "ask" }>>,
+	) => {
 		if (dialog.type !== "ask") return;
 		onDialogChange({ ...dialog, ...patch });
 	};
@@ -3146,7 +3442,11 @@ const FrontendToolRequestDialog = memo(function FrontendToolRequestDialog({
 			open
 			onOpenChange={(open) => {
 				if (!open) {
-					onResolve(dialog.type === "approval" ? { approved: false, remember: false } : null);
+					onResolve(
+						dialog.type === "approval"
+							? { approved: false, remember: false }
+							: null,
+					);
 				}
 			}}
 		>
@@ -3189,7 +3489,9 @@ const FrontendToolRequestDialog = memo(function FrontendToolRequestDialog({
 					) : dialog.mode === "freeform" ? (
 						<Textarea
 							value={dialog.answer}
-							placeholder={getArgString(args, "placeholder") ?? "Enter value..."}
+							placeholder={
+								getArgString(args, "placeholder") ?? "Enter value..."
+							}
 							className="min-h-28 resize-none"
 							onChange={(event) => updateAsk({ answer: event.target.value })}
 						/>

--- a/packages/ui/components/flowpilot/PendingCommandsView.tsx
+++ b/packages/ui/components/flowpilot/PendingCommandsView.tsx
@@ -21,19 +21,22 @@ import type { BoardCommand } from "../../lib/schema/flow/copilot";
 
 interface PendingCommandsViewProps {
 	commands: BoardCommand[];
-	onExecute: () => void;
-	onExecuteSingle: (index: number) => void;
+	flowscriptReady?: boolean;
+	onExecute: () => void | Promise<void>;
+	onExecuteSingle: (index: number) => void | Promise<void>;
 	onDismiss: () => void;
 }
 
 export const PendingCommandsView = memo(function PendingCommandsView({
 	commands,
+	flowscriptReady = false,
 	onExecute,
 	onExecuteSingle,
 	onDismiss,
 }: PendingCommandsViewProps) {
 	const [expanded, setExpanded] = useState(false);
 	const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
+	const hasCommandDetails = commands.length > 0;
 
 	const toggleExpanded = useCallback(() => setExpanded((prev) => !prev), []);
 
@@ -48,7 +51,7 @@ export const PendingCommandsView = memo(function PendingCommandsView({
 		[commands],
 	);
 
-	if (commands.length === 0) return null;
+	if (commands.length === 0 && !flowscriptReady) return null;
 
 	return (
 		<motion.div
@@ -84,30 +87,33 @@ export const PendingCommandsView = memo(function PendingCommandsView({
 									Ready to Apply
 								</div>
 								<div className="text-[11px] text-muted-foreground">
-									{commands.length} change{commands.length > 1 ? "s" : ""}{" "}
-									pending
+									{flowscriptReady && commands.length === 0
+										? "FlowScript workspace pending"
+										: `${commands.length} change${commands.length > 1 ? "s" : ""} pending`}
 								</div>
 							</div>
 						</div>
 
 						<div className="flex items-center gap-1.5">
-							<Tooltip>
-								<TooltipTrigger asChild>
-									<Button
-										size="sm"
-										variant="ghost"
-										className="h-8 w-8 p-0 rounded-lg hover:bg-background/60"
-										onClick={toggleExpanded}
-									>
-										<ChevronDown
-											className={`w-4 h-4 transition-transform duration-200 ${expanded ? "rotate-180" : ""}`}
-										/>
-									</Button>
-								</TooltipTrigger>
-								<TooltipContent side="top" className="text-xs">
-									{expanded ? "Collapse" : "Expand"} details
-								</TooltipContent>
-							</Tooltip>
+							{hasCommandDetails && (
+								<Tooltip>
+									<TooltipTrigger asChild>
+										<Button
+											size="sm"
+											variant="ghost"
+											className="h-8 w-8 p-0 rounded-lg hover:bg-background/60"
+											onClick={toggleExpanded}
+										>
+											<ChevronDown
+												className={`w-4 h-4 transition-transform duration-200 ${expanded ? "rotate-180" : ""}`}
+											/>
+										</Button>
+									</TooltipTrigger>
+									<TooltipContent side="top" className="text-xs">
+										{expanded ? "Collapse" : "Expand"} details
+									</TooltipContent>
+								</Tooltip>
+							)}
 
 							<Button
 								size="sm"
@@ -138,6 +144,16 @@ export const PendingCommandsView = memo(function PendingCommandsView({
 
 					{/* Command type badges */}
 					<div className="flex flex-wrap gap-1.5">
+						{flowscriptReady && (
+							<motion.span
+								initial={{ scale: 0 }}
+								animate={{ scale: 1 }}
+								className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium bg-cyan-500/15 text-cyan-600 dark:text-cyan-400 border border-cyan-500/20"
+							>
+								<PencilIcon className="w-3 h-3" />
+								FlowScript
+							</motion.span>
+						)}
 						{commandCounts.add > 0 && (
 							<motion.span
 								initial={{ scale: 0 }}
@@ -190,7 +206,7 @@ export const PendingCommandsView = memo(function PendingCommandsView({
 
 			{/* Expanded command list */}
 			<AnimatePresence>
-				{expanded && (
+				{expanded && hasCommandDetails && (
 					<motion.div
 						initial={{ height: 0, opacity: 0 }}
 						animate={{ height: "auto", opacity: 1 }}

--- a/packages/ui/components/flowpilot/types.ts
+++ b/packages/ui/components/flowpilot/types.ts
@@ -218,6 +218,17 @@ export interface FlowPilotProcessEvent {
 	updatedAt?: number;
 }
 
+export interface FlowScriptApplyResultLike {
+	commands?: unknown[];
+	board_commands?: BoardCommand[];
+	diagnostics?: string[];
+}
+
+export interface FlowScriptApplyOptions {
+	allowDeletions?: boolean;
+	suppressBlockedToast?: boolean;
+}
+
 /**
  * Unified message format for the copilot chat
  */
@@ -284,7 +295,16 @@ export interface FlowPilotProps {
 	onAcceptSuggestion?: (suggestion: Suggestion) => void;
 
 	/** Callback when commands should be executed (board mode) */
-	onExecuteCommands?: (commands: BoardCommand[]) => void;
+	onExecuteCommands?: (commands: BoardCommand[]) => void | Promise<void>;
+
+	/** Callback when the FlowScript workspace should be reconciled and applied server-side. */
+	onApplyFlowScript?: (
+		flowscript: string,
+		options?: FlowScriptApplyOptions,
+	) =>
+		| undefined
+		| FlowScriptApplyResultLike
+		| Promise<undefined | FlowScriptApplyResultLike>;
 
 	/** Callback to focus on a specific node (board mode) */
 	onFocusNode?: (nodeId: string) => void;

--- a/packages/ui/hooks/use-command-execution.tsx
+++ b/packages/ui/hooks/use-command-execution.tsx
@@ -5,7 +5,14 @@ import { getErrorMessage } from "../lib/error-message";
 import { toastError } from "../lib/messages";
 import type { IGenericCommand } from "../lib/schema";
 import type { IBoard } from "../lib/schema/flow/board";
+import type { INode } from "../lib/schema/flow/node";
 import { useBackendStore } from "../state/backend-state";
+
+interface ExecuteCommandsOptions {
+	refetch?: boolean;
+	allowDeletions?: boolean;
+	suppressBlockedToast?: boolean;
+}
 
 interface UseCommandExecutionProps {
 	appId: string;
@@ -70,7 +77,10 @@ export function useCommandExecution({
 	);
 
 	const executeCommands = useCallback(
-		async (commands: IGenericCommand[]) => {
+		async (
+			commands: IGenericCommand[],
+			options: ExecuteCommandsOptions = {},
+		) => {
 			const backend = useBackendStore.getState().backend;
 			if (!backend) {
 				console.error("[executeCommands] No backend available");
@@ -91,7 +101,9 @@ export function useCommandExecution({
 					commands,
 				);
 				await pushCommands(result);
-				await board.refetch();
+				if (options.refetch !== false) {
+					await board.refetch();
+				}
 
 				if (awarenessRef.current) {
 					awarenessRef.current.setLocalStateField("boardUpdate", Date.now());
@@ -110,9 +122,73 @@ export function useCommandExecution({
 		[board.refetch, appId, boardId, pushCommands, version],
 	);
 
+	const applyFlowScript = useCallback(
+		async (
+			flowscript: string,
+			currentLayer?: string,
+			catalogNodes?: INode[],
+			options: ExecuteCommandsOptions = {},
+		) => {
+			const backend = useBackendStore.getState().backend;
+			if (!backend) {
+				console.error("[applyFlowScript] No backend available");
+				toastError("Backend not initialized", <XIcon />);
+				return;
+			}
+			if (typeof version !== "undefined") {
+				console.error("[applyFlowScript] Cannot modify old version:", version);
+				toastError("Cannot change old version", <XIcon />);
+				return;
+			}
+			if (!flowscript.trim()) return;
+
+			try {
+				const result = await backend.boardState.applyFlowScript(
+					appId,
+					boardId,
+					flowscript,
+					currentLayer,
+					catalogNodes,
+					options.allowDeletions === true,
+				);
+
+				if (result.commands.length > 0) {
+					await pushCommands(result.commands);
+					if (options.refetch !== false) {
+						await board.refetch();
+					}
+
+					if (awarenessRef.current) {
+						awarenessRef.current.setLocalStateField("boardUpdate", Date.now());
+					}
+				} else if (result.diagnostics.length > 0) {
+					const suppressToast =
+						options.suppressBlockedToast === true &&
+						result.diagnostics[0]?.startsWith("FlowScript edit would delete ");
+					if (suppressToast) return result;
+					toastError(
+						`FlowScript apply blocked: ${result.diagnostics[0]}`,
+						<XIcon />,
+					);
+				}
+
+				return result;
+			} catch (error) {
+				console.error("[applyFlowScript] Failed:", error);
+				toastError(
+					`FlowScript apply failed: ${getErrorMessage(error, "Unknown error")}`,
+					<XIcon />,
+				);
+				throw error;
+			}
+		},
+		[board.refetch, appId, boardId, pushCommands, version],
+	);
+
 	return {
 		executeCommand,
 		executeCommands,
+		applyFlowScript,
 		awarenessRef,
 	};
 }

--- a/packages/ui/hooks/use-copilot-commands.tsx
+++ b/packages/ui/hooks/use-copilot-commands.tsx
@@ -359,7 +359,7 @@ export function useCopilotCommands({
 				resolveNode(ref)?.id ?? nodeReferenceMap.get(ref)?.id ?? ref;
 
 			const resolveLayerId = (ref?: string | null): string | undefined => {
-				if (!ref) return ref ?? undefined;
+				if (!ref) return undefined;
 				if (latestBoardLayers[ref]) return ref;
 				return nodeReferenceMap.get(ref)?.id ?? ref;
 			};

--- a/packages/ui/hooks/use-copilot-commands.tsx
+++ b/packages/ui/hooks/use-copilot-commands.tsx
@@ -33,32 +33,237 @@ import { type IPin, IPinType } from "../lib/schema/flow/pin";
 import type { ILayer } from "../lib/schema/flow/run";
 import { convertJsonToUint8Array } from "../lib/uint8";
 
+const MAX_COPILOT_BATCH_COMMANDS = 100;
+const MAX_COPILOT_BATCH_BYTES = 4 * 1024 * 1024;
+const DEFAULT_OUTPUT_PIN_ALIASES = new Set([
+	"result",
+	"value",
+	"output",
+	"out",
+]);
+
 interface UseCopilotCommandsProps {
 	board: UseQueryResult<IBoard | undefined, Error>;
 	catalog: UseQueryResult<INode[] | undefined, Error>;
-	executeCommand: (
-		command: IGenericCommand,
-		append?: boolean,
+	executeCommands: (
+		commands: IGenericCommand[],
+		options?: { refetch?: boolean },
 	) => Promise<unknown>;
 	currentLayer: string | undefined;
+}
+
+type UpdateNodePinCommand = Extract<
+	BoardCommand,
+	{ command_type: "UpdateNodePin" }
+>;
+
+function cloneNode(node: INode): INode {
+	return JSON.parse(JSON.stringify(node)) as INode;
+}
+
+function jsonByteLength(value: unknown): number {
+	const json = JSON.stringify(value);
+	if (typeof TextEncoder === "undefined") return json.length;
+	return new TextEncoder().encode(json).length;
+}
+
+function encodedJsonValue(value: unknown): number[] | null {
+	if (value === null || value === undefined) return null;
+	return Array.from(convertJsonToUint8Array(value) || []);
+}
+
+function layerTypeFromCommand(value?: string): ILayerType {
+	switch (value) {
+		case "Function":
+			return ILayerType.Function;
+		case "Macro":
+			return ILayerType.Macro;
+		default:
+			return ILayerType.Collapsed;
+	}
+}
+
+function pinsFromDefs(
+	pinDefs:
+		| Array<{
+				name: string;
+				friendly_name: string;
+				description?: string;
+				pin_type: "Input" | "Output";
+				data_type: string;
+				value_type?: string;
+		  }>
+		| undefined,
+	includeDefaultExec: boolean,
+): Record<string, IPin> {
+	const pins: Record<string, IPin> = {};
+	let pinIndex = 0;
+
+	const addPin = (
+		name: string,
+		friendlyName: string,
+		pinType: IPinType,
+		dataType: IVariableType,
+		valueType = IValueType.Normal,
+		description = "",
+	) => {
+		const pin: IPin = {
+			id: createId(),
+			name,
+			friendly_name: friendlyName,
+			connected_to: [],
+			depends_on: [],
+			description,
+			index: pinIndex++,
+			pin_type: pinType,
+			value_type: valueType,
+			data_type: dataType,
+			default_value: null,
+		};
+		pins[pin.id] = pin;
+	};
+
+	if (includeDefaultExec) {
+		addPin("exec_in", "Exec In", IPinType.Input, IVariableType.Execution);
+		addPin("exec_out", "Exec Out", IPinType.Output, IVariableType.Execution);
+	}
+
+	for (const pinDef of pinDefs ?? []) {
+		addPin(
+			pinDef.name,
+			pinDef.friendly_name,
+			pinDef.pin_type as IPinType,
+			pinDef.data_type as IVariableType,
+			(pinDef.value_type as IValueType) || IValueType.Normal,
+			pinDef.description || "",
+		);
+	}
+
+	return pins;
+}
+
+function isSetupLayerCommand(cmd: BoardCommand): boolean {
+	return (
+		cmd.command_type === "CreateLayer" &&
+		((cmd.node_ids ?? []).length === 0 ||
+			Boolean(cmd.ref_id) ||
+			Boolean(cmd.pins?.length) ||
+			cmd.layer_type === "Function")
+	);
+}
+
+function normalizePinValue(value: unknown): unknown {
+	if (
+		typeof value === "string" &&
+		value.startsWith('"') &&
+		value.endsWith('"')
+	) {
+		return value.slice(1, -1);
+	}
+
+	return value;
+}
+
+function toFlowScriptCamelCase(input: string): string {
+	let output = "";
+	let uppercaseNext = false;
+	let first = true;
+
+	for (const char of input) {
+		if (/^[a-zA-Z0-9]$/.test(char)) {
+			if (first) {
+				output += char.toLowerCase();
+				first = false;
+			} else if (uppercaseNext) {
+				output += char.toUpperCase();
+			} else {
+				output += char;
+			}
+			uppercaseNext = false;
+		} else if (!first) {
+			uppercaseNext = true;
+		}
+	}
+
+	return output || "node";
+}
+
+function pinLookupKeys(value: string | null | undefined): string[] {
+	if (!value) return [];
+	const camelCase = toFlowScriptCamelCase(value);
+	return [
+		...new Set([
+			value,
+			value.toLowerCase(),
+			camelCase,
+			camelCase.toLowerCase(),
+		]),
+	];
+}
+
+function addPinLookup(
+	pinMap: Map<string, string>,
+	key: string | null | undefined,
+	pinId: string,
+) {
+	for (const lookupKey of pinLookupKeys(key)) {
+		if (!pinMap.has(lookupKey)) {
+			pinMap.set(lookupKey, pinId);
+		}
+	}
+}
+
+function pinMatchesRef(pin: IPin, pinRef: string): boolean {
+	const requestedKeys = new Set(pinLookupKeys(pinRef));
+	return [...pinLookupKeys(pin.name), ...pinLookupKeys(pin.friendly_name)].some(
+		(key) => requestedKeys.has(key),
+	);
+}
+
+function pinMatchesDirection(
+	pin: IPin | undefined,
+	expectedPinType?: IPinType,
+): pin is IPin {
+	return Boolean(pin && (!expectedPinType || pin.pin_type === expectedPinType));
+}
+
+function dataOutputPins(node: INode): IPin[] {
+	return Object.values(node.pins ?? {})
+		.filter(
+			(pin) =>
+				pin.pin_type === IPinType.Output &&
+				pin.data_type !== IVariableType.Execution,
+		)
+		.sort((a, b) => a.index - b.index);
+}
+
+function defaultDataOutputPin(node: INode): IPin | undefined {
+	const outputs = dataOutputPins(node);
+	if (outputs.length === 1) return outputs[0];
+	return outputs.find((pin) =>
+		DEFAULT_OUTPUT_PIN_ALIASES.has(pin.name.toLowerCase()),
+	);
 }
 
 export function useCopilotCommands({
 	board,
 	catalog,
-	executeCommand,
+	executeCommands,
 	currentLayer,
 }: UseCopilotCommandsProps) {
 	const handleExecuteCommands = useCallback(
 		async (commands: BoardCommand[]) => {
-			let latestBoardNodes = board.data?.nodes ?? {};
-			let latestBoardLayers = board.data?.layers ?? {};
+			let latestBoardNodes: Record<string, INode> = board.data?.nodes ?? {};
+			let latestBoardLayers: Record<string, ILayer> = board.data?.layers ?? {};
+			let latestBoardVariables: Record<string, IVariable> =
+				board.data?.variables ?? {};
+			let latestBoardComments: Record<string, IComment> =
+				board.data?.comments ?? {};
 
-			// ===== MAPPING TABLES =====
 			const nodeReferenceMap = new Map<string, INode>();
+			const ambiguousNodeRefs = new Set<string>();
 			const pinIdMap = new Map<string, Map<string, string>>();
 
-			// ===== POSITION CALCULATION =====
 			const existingNodes = Object.values(latestBoardNodes);
 			let baseX = 100;
 			let baseY = 100;
@@ -72,7 +277,6 @@ export function useCopilotCommands({
 				baseY = rightmostNode.coordinates?.[1] ?? 100;
 			}
 
-			// Helper to convert a layer to node-like structure for pin resolution
 			const layerAsNode = (layer: ILayer): INode =>
 				({
 					id: layer.id,
@@ -82,37 +286,132 @@ export function useCopilotCommands({
 					coordinates: layer.coordinates,
 				}) as unknown as INode;
 
-			// ===== HELPER FUNCTIONS =====
+			const buildPinMapping = (nodeRef: string, node: INode) => {
+				if (ambiguousNodeRefs.has(nodeRef)) return;
+				const pinMap = new Map<string, string>();
+				for (const pin of Object.values(node.pins ?? {})) {
+					addPinLookup(pinMap, pin.name, pin.id);
+					addPinLookup(pinMap, pin.friendly_name, pin.id);
+				}
+
+				const defaultOutputPin = defaultDataOutputPin(node);
+				if (defaultOutputPin) {
+					for (const alias of DEFAULT_OUTPUT_PIN_ALIASES) {
+						addPinLookup(pinMap, alias, defaultOutputPin.id);
+					}
+				}
+				pinIdMap.set(nodeRef, pinMap);
+			};
+
+			const registerNodeRef = (ref: string, node: INode) => {
+				if (ambiguousNodeRefs.has(ref)) return;
+
+				const mapped = nodeReferenceMap.get(ref);
+				if (mapped && mapped.id !== node.id) {
+					nodeReferenceMap.delete(ref);
+					pinIdMap.delete(ref);
+					ambiguousNodeRefs.add(ref);
+					return;
+				}
+
+				nodeReferenceMap.set(ref, node);
+				buildPinMapping(ref, node);
+			};
+
+			const registerNodeRefs = (
+				refs: Array<string | null | undefined>,
+				node: INode,
+			) => {
+				for (const ref of [...new Set(refs.filter(Boolean) as string[])]) {
+					registerNodeRef(ref, node);
+				}
+			};
+
+			const replaceMappedNode = (node: INode) => {
+				buildPinMapping(node.id, node);
+				for (const [ref, mapped] of Array.from(nodeReferenceMap.entries())) {
+					if (mapped.id === node.id) {
+						nodeReferenceMap.set(ref, node);
+						buildPinMapping(ref, node);
+					}
+				}
+			};
+
+			const removeMappedNode = (nodeId: string) => {
+				pinIdMap.delete(nodeId);
+				for (const [ref, mapped] of Array.from(nodeReferenceMap.entries())) {
+					if (mapped.id === nodeId) {
+						nodeReferenceMap.delete(ref);
+						pinIdMap.delete(ref);
+					}
+				}
+			};
+
 			const resolveNode = (ref: string): INode | undefined => {
-				// Check regular nodes first
 				if (latestBoardNodes[ref]) return latestBoardNodes[ref];
-				// Check reference map (newly created nodes/layers)
+				if (ambiguousNodeRefs.has(ref)) return undefined;
 				if (nodeReferenceMap.has(ref)) return nodeReferenceMap.get(ref);
-				// Check existing layers (placeholders) - they can be connected to like nodes
 				if (latestBoardLayers[ref]) return layerAsNode(latestBoardLayers[ref]);
 				return undefined;
 			};
 
+			const resolveNodeId = (ref: string): string =>
+				resolveNode(ref)?.id ?? nodeReferenceMap.get(ref)?.id ?? ref;
+
+			const resolveLayerId = (ref?: string | null): string | undefined => {
+				if (!ref) return ref ?? undefined;
+				if (latestBoardLayers[ref]) return ref;
+				return nodeReferenceMap.get(ref)?.id ?? ref;
+			};
+
+			const resolveLayer = (ref: string): ILayer | undefined => {
+				const layerId = resolveLayerId(ref);
+				return layerId ? latestBoardLayers[layerId] : undefined;
+			};
+
+			const resolveNodeIds = (refs: string[] = []): string[] =>
+				refs.map((ref) => resolveNodeId(ref));
+
 			const resolvePinId = (
 				nodeRef: string,
 				pinRef: string,
+				expectedPinType?: IPinType,
 			): string | undefined => {
 				const nodePinMap = pinIdMap.get(nodeRef);
 				if (nodePinMap) {
-					if (nodePinMap.has(pinRef)) return nodePinMap.get(pinRef);
-					if (nodePinMap.has(pinRef.toLowerCase()))
-						return nodePinMap.get(pinRef.toLowerCase());
+					const node = resolveNode(nodeRef);
+					for (const lookupKey of pinLookupKeys(pinRef)) {
+						const mappedPinId = nodePinMap.get(lookupKey);
+						const mappedPin = mappedPinId ? node?.pins[mappedPinId] : undefined;
+						if (pinMatchesDirection(mappedPin, expectedPinType)) {
+							return mappedPinId;
+						}
+					}
 				}
 
 				const node = resolveNode(nodeRef);
 				if (!node) return undefined;
 
-				if (node.pins[pinRef]) return pinRef;
+				const pinById = node.pins[pinRef];
+				if (pinMatchesDirection(pinById, expectedPinType)) return pinRef;
 
 				for (const pin of Object.values(node.pins)) {
-					if (pin.name.toLowerCase() === pinRef.toLowerCase()) return pin.id;
-					if (pin.friendly_name?.toLowerCase() === pinRef.toLowerCase())
+					if (
+						pinMatchesDirection(pin, expectedPinType) &&
+						pinMatchesRef(pin, pinRef)
+					) {
 						return pin.id;
+					}
+				}
+
+				if (
+					expectedPinType !== IPinType.Input &&
+					DEFAULT_OUTPUT_PIN_ALIASES.has(pinRef.toLowerCase())
+				) {
+					const defaultOutputPin = defaultDataOutputPin(node);
+					if (pinMatchesDirection(defaultOutputPin, expectedPinType)) {
+						return defaultOutputPin.id;
+					}
 				}
 
 				console.warn(
@@ -126,33 +425,14 @@ export function useCopilotCommands({
 				return undefined;
 			};
 
-			const buildPinMapping = (nodeRef: string, node: INode) => {
-				const pinMap = new Map<string, string>();
-				for (const pin of Object.values(node.pins)) {
-					pinMap.set(pin.name, pin.id);
-					pinMap.set(pin.name.toLowerCase(), pin.id);
-					if (pin.friendly_name && pin.friendly_name !== pin.name) {
-						pinMap.set(pin.friendly_name, pin.id);
-						pinMap.set(pin.friendly_name.toLowerCase(), pin.id);
-					}
-				}
-				pinIdMap.set(nodeRef, pinMap);
-				return pinMap;
-			};
-
-			const refreshBoardSnapshot = async () => {
-				const freshBoard = await board.refetch();
-				latestBoardNodes = freshBoard.data?.nodes ?? latestBoardNodes;
-				latestBoardLayers = freshBoard.data?.layers ?? latestBoardLayers;
-
+			const rebuildPinMappings = () => {
+				pinIdMap.clear();
 				for (const [nodeId, node] of Object.entries(latestBoardNodes)) {
 					buildPinMapping(nodeId, node);
 				}
-
 				for (const [layerId, layer] of Object.entries(latestBoardLayers)) {
 					buildPinMapping(layerId, layerAsNode(layer));
 				}
-
 				for (const [ref, node] of Array.from(nodeReferenceMap.entries())) {
 					const freshNode = latestBoardNodes[node.id];
 					if (freshNode) {
@@ -163,30 +443,184 @@ export function useCopilotCommands({
 
 					const freshLayer = latestBoardLayers[node.id];
 					if (freshLayer) {
-						const layerNode = layerAsNode(freshLayer);
-						nodeReferenceMap.set(ref, layerNode);
-						buildPinMapping(ref, layerNode);
+						const freshLayerNode = layerAsNode(freshLayer);
+						nodeReferenceMap.set(ref, freshLayerNode);
+						buildPinMapping(ref, freshLayerNode);
+						continue;
 					}
+
+					buildPinMapping(ref, node);
 				}
 			};
 
-			// Build pin mappings for existing board nodes
-			for (const [nodeId, node] of Object.entries(latestBoardNodes)) {
-				buildPinMapping(nodeId, node);
-			}
+			const refreshBoardSnapshot = async () => {
+				const freshBoard = await board.refetch();
+				const data = freshBoard.data ?? board.data;
+				latestBoardNodes = data?.nodes ?? latestBoardNodes;
+				latestBoardLayers = data?.layers ?? latestBoardLayers;
+				latestBoardVariables = data?.variables ?? latestBoardVariables;
+				latestBoardComments = data?.comments ?? latestBoardComments;
+				rebuildPinMappings();
+			};
 
-			// Build pin mappings for existing layers (placeholders) so they can be connected to
-			for (const [layerId, layer] of Object.entries(latestBoardLayers)) {
-				buildPinMapping(layerId, layerAsNode(layer));
-			}
+			const applyExecutedCommandsToSnapshot = (
+				executedCommands: IGenericCommand[],
+			) => {
+				for (const command of executedCommands) {
+					switch (command.command_type) {
+						case "AddNode":
+						case "UpdateNode":
+						case "MoveNode":
+							if (command.node) {
+								latestBoardNodes[command.node.id] = command.node;
+								replaceMappedNode(command.node);
+							}
+							break;
+						case "RemoveNode":
+							if (command.node?.id) {
+								delete latestBoardNodes[command.node.id];
+								removeMappedNode(command.node.id);
+							}
+							break;
+						case "UpsertLayer":
+							if (command.layer) {
+								latestBoardLayers[command.layer.id] = command.layer;
+								registerNodeRefs(
+									[command.layer.id, command.layer.name],
+									layerAsNode(command.layer),
+								);
+							}
+							break;
+						case "RemoveLayer":
+							if (command.layer?.id) {
+								delete latestBoardLayers[command.layer.id];
+								removeMappedNode(command.layer.id);
+							}
+							break;
+						case "UpsertVariable":
+							if (command.variable) {
+								latestBoardVariables[command.variable.id] = command.variable;
+							}
+							break;
+						case "RemoveVariable":
+							if (command.variable?.id) {
+								delete latestBoardVariables[command.variable.id];
+							}
+							break;
+						case "UpsertComment":
+							if (command.comment) {
+								latestBoardComments[command.comment.id] = command.comment;
+							}
+							break;
+						case "RemoveComment":
+							if (command.comment?.id) {
+								delete latestBoardComments[command.comment.id];
+							}
+							break;
+					}
+				}
+				rebuildPinMappings();
+			};
 
-			// ===== FIRST PASS: ADD NODES =====
+			rebuildPinMappings();
+			let executedAnyCommands = false;
+			let refreshedAfterLastExecution = false;
+
+			const executeInBatches = async (
+				genericCommands: IGenericCommand[],
+				label: string,
+				options: { refetch?: boolean } = {},
+			): Promise<IGenericCommand[]> => {
+				if (genericCommands.length === 0) return [];
+
+				let batch: IGenericCommand[] = [];
+				let batchBytes = 2;
+				let batchIndex = 0;
+				const executedCommands: IGenericCommand[] = [];
+
+				const flush = async () => {
+					if (batch.length === 0) return;
+					batchIndex++;
+					console.log(`[FlowPilot] Executing ${label} batch ${batchIndex}`, {
+						commands: batch.length,
+						approxBytes: batchBytes,
+					});
+					const result = await executeCommands([...batch], {
+						refetch: options.refetch ?? false,
+					});
+					if (Array.isArray(result)) {
+						executedCommands.push(...(result as IGenericCommand[]));
+					}
+					batch = [];
+					batchBytes = 2;
+				};
+
+				for (const command of genericCommands) {
+					const commandBytes = jsonByteLength(command) + 1;
+					if (
+						batch.length > 0 &&
+						(batch.length >= MAX_COPILOT_BATCH_COMMANDS ||
+							batchBytes + commandBytes > MAX_COPILOT_BATCH_BYTES)
+					) {
+						await flush();
+					}
+					batch.push(command);
+					batchBytes += commandBytes;
+				}
+
+				await flush();
+				applyExecutedCommandsToSnapshot(executedCommands);
+				return executedCommands;
+			};
+
+			const nodeCreateCommands: IGenericCommand[] = [];
 			let nodeIndex = 0;
 
 			for (const cmd of commands) {
+				if (cmd.command_type === "CreateLayer" && isSetupLayerCommand(cmd)) {
+					const layerId = createId();
+					const position = cmd.position || {
+						x: baseX + (nodeIndex % 3) * 300,
+						y: baseY + Math.floor(nodeIndex / 3) * 200,
+					};
+					const targetLayer = resolveLayerId(cmd.target_layer) ?? currentLayer;
+					const layer: ILayer = {
+						id: layerId,
+						name: cmd.name,
+						type: layerTypeFromCommand(cmd.layer_type),
+						color: cmd.color || null,
+						coordinates: [position.x, position.y, 0],
+						nodes: {},
+						variables: {},
+						comments: {},
+						pins: pinsFromDefs(cmd.pins, false),
+						parent_id: targetLayer,
+					};
+
+					nodeCreateCommands.push(
+						upsertLayerCommand({
+							layer,
+							node_ids: [],
+							current_layer: targetLayer,
+						}),
+					);
+					latestBoardLayers[layerId] = layer;
+					registerNodeRefs(
+						[cmd.ref_id, `$${nodeIndex}`, cmd.name, layerId],
+						layerAsNode(layer),
+					);
+					console.log(`[CreateLayer] Queued "${cmd.name}" (${layerId})`, {
+						refs: [cmd.ref_id, `$${nodeIndex}`, cmd.name, layerId].filter(
+							Boolean,
+						),
+					});
+					nodeIndex++;
+					continue;
+				}
+
 				if (cmd.command_type === "AddNode") {
 					const catalogNode = catalog.data?.find(
-						(n) => n.name === cmd.node_type,
+						(node) => node.name === cmd.node_type,
 					);
 					if (!catalogNode) {
 						toastError(
@@ -200,121 +634,46 @@ export function useCopilotCommands({
 						x: baseX + (nodeIndex % 3) * 300,
 						y: baseY + Math.floor(nodeIndex / 3) * 200,
 					};
-
-					const targetLayer = cmd.target_layer ?? currentLayer;
+					const targetLayer = resolveLayerId(cmd.target_layer) ?? currentLayer;
 
 					const result = addNodeCommand({
 						node: {
-							...catalogNode,
+							...cloneNode(catalogNode),
 							coordinates: [position.x, position.y, 0],
-							friendly_name: catalogNode.friendly_name,
+							friendly_name: cmd.friendly_name ?? catalogNode.friendly_name,
 						},
 						current_layer: targetLayer,
 					});
+					const plannedNode = result.node as INode;
 
-					const executedCommand = await executeCommand(result.command);
-
-					if (!executedCommand) {
-						console.error(
-							`[AddNode] Command execution returned undefined - command may not have been executed`,
-						);
-						toastError(
-							`Failed to add node "${catalogNode.friendly_name}" - check if you're editing the latest version`,
-							<XIcon />,
-						);
-						continue;
-					}
-
-					const actualNode =
-						((executedCommand as Record<string, unknown> | undefined)
-							?.node as INode) ?? result.node;
-
-					const refs = [
-						cmd.ref_id,
-						`$${nodeIndex}`,
-						cmd.node_type,
-						actualNode.id,
-					].filter(Boolean) as string[];
-
-					for (const ref of refs) {
-						nodeReferenceMap.set(ref, actualNode);
-						buildPinMapping(ref, actualNode);
-					}
-
-					console.log(
-						`[AddNode] Created "${actualNode.friendly_name}" (${actualNode.id})`,
-						{
-							refs,
-							pins: Object.values(actualNode.pins).map(
-								(p) => `${p.name}:${p.id.slice(0, 8)}`,
-							),
-						},
+					nodeCreateCommands.push(result.command);
+					registerNodeRefs(
+						[cmd.ref_id, `$${nodeIndex}`, cmd.node_type, plannedNode.id],
+						plannedNode,
 					);
 
+					console.log(
+						`[AddNode] Queued "${plannedNode.friendly_name}" (${plannedNode.id})`,
+						{
+							refs: [
+								cmd.ref_id,
+								`$${nodeIndex}`,
+								cmd.node_type,
+								plannedNode.id,
+							].filter(Boolean),
+						},
+					);
 					nodeIndex++;
+					continue;
 				}
 
-				// Handle AddPlaceholder in first pass (creates layer nodes)
 				if (cmd.command_type === "AddPlaceholder") {
 					const layerId = createId();
 					const position = cmd.position || {
 						x: baseX + (nodeIndex % 3) * 300,
 						y: baseY + Math.floor(nodeIndex / 3) * 200,
 					};
-
-					const targetLayer = cmd.target_layer ?? currentLayer;
-
-					// Create default execution pins
-					const execInPin: IPin = {
-						id: createId(),
-						name: "exec_in",
-						friendly_name: "Exec In",
-						connected_to: [],
-						depends_on: [],
-						description: "",
-						index: 0,
-						pin_type: IPinType.Input,
-						value_type: IValueType.Normal,
-						data_type: IVariableType.Execution,
-						default_value: null,
-					};
-
-					const execOutPin: IPin = {
-						...execInPin,
-						id: createId(),
-						pin_type: IPinType.Output,
-						name: "exec_out",
-						friendly_name: "Exec Out",
-						index: 1,
-					};
-
-					// Build pins object starting with exec pins
-					const pins: Record<string, IPin> = {
-						[execInPin.id]: execInPin,
-						[execOutPin.id]: execOutPin,
-					};
-
-					// Add custom pins if provided
-					if (cmd.pins && cmd.pins.length > 0) {
-						let pinIndex = 2;
-						for (const pinDef of cmd.pins) {
-							const pin: IPin = {
-								id: createId(),
-								name: pinDef.name,
-								friendly_name: pinDef.friendly_name,
-								description: pinDef.description || "",
-								connected_to: [],
-								depends_on: [],
-								index: pinIndex++,
-								pin_type: pinDef.pin_type as IPinType,
-								value_type:
-									(pinDef.value_type as IValueType) || IValueType.Normal,
-								data_type: pinDef.data_type as IVariableType,
-								default_value: null,
-							};
-							pins[pin.id] = pin;
-						}
-					}
+					const targetLayer = resolveLayerId(cmd.target_layer) ?? currentLayer;
 
 					const layer: ILayer = {
 						id: layerId,
@@ -324,67 +683,48 @@ export function useCopilotCommands({
 						nodes: {},
 						variables: {},
 						comments: {},
-						pins,
+						pins: pinsFromDefs(cmd.pins, true),
 						parent_id: targetLayer,
 					};
 
-					const result = await executeCommand(
+					nodeCreateCommands.push(
 						upsertLayerCommand({
 							layer,
 							node_ids: [],
 							current_layer: targetLayer,
 						}),
 					);
+					latestBoardLayers[layerId] = layer;
 
-					if (result) {
-						// Treat the layer as a "node" for reference purposes
-						const layerAsNode = {
-							id: layerId,
-							name: cmd.name,
-							friendly_name: cmd.name,
-							pins,
-							coordinates: [position.x, position.y, 0],
-						} as unknown as INode;
-
-						const refs = [
-							cmd.ref_id,
-							`$${nodeIndex}`,
-							cmd.name,
-							layerId,
-						].filter(Boolean) as string[];
-
-						for (const ref of refs) {
-							nodeReferenceMap.set(ref, layerAsNode);
-							buildPinMapping(ref, layerAsNode);
-						}
-
-						console.log(`[AddPlaceholder] Created "${cmd.name}" (${layerId})`, {
-							refs,
-							pins: Object.values(pins).map(
-								(p) => `${p.name}:${p.id.slice(0, 8)}`,
-							),
-						});
-					}
-
+					const placeholderNode = layerAsNode(layer);
+					registerNodeRefs(
+						[cmd.ref_id, `$${nodeIndex}`, cmd.name, layerId],
+						placeholderNode,
+					);
+					console.log(`[AddPlaceholder] Queued "${cmd.name}" (${layerId})`, {
+						refs: [cmd.ref_id, `$${nodeIndex}`, cmd.name, layerId].filter(
+							Boolean,
+						),
+					});
 					nodeIndex++;
 				}
 			}
 
-			const delay = (ms: number) =>
-				new Promise((resolve) => setTimeout(resolve, ms));
+			const executedNodeCreateCommands = await executeInBatches(
+				nodeCreateCommands,
+				"node creation",
+			);
+			if (executedNodeCreateCommands.length > 0) {
+				executedAnyCommands = true;
+				refreshedAfterLastExecution = false;
+			}
 
-			type CreateVariableCommand = Extract<
-				BoardCommand,
-				{ command_type: "CreateVariable" }
-			>;
-			type UpdateNodePinCommand = Extract<
-				BoardCommand,
-				{ command_type: "UpdateNodePin" }
-			>;
+			const variableCreateCommands: IGenericCommand[] = [];
+			for (const cmd of commands) {
+				if (cmd.command_type !== "CreateVariable") continue;
 
-			const applyCreateVariable = async (cmd: CreateVariableCommand) => {
 				const variableId = cmd.variable_id || createId();
-				const targetLayer = cmd.target_layer ?? null;
+				const targetLayer = resolveLayerId(cmd.target_layer) ?? null;
 				const variable: IVariable = {
 					id: variableId,
 					name: cmd.name,
@@ -392,7 +732,7 @@ export function useCopilotCommands({
 					value_type: (cmd.value_type as IValueType) || IValueType.Normal,
 					default_value:
 						"default_value" in cmd
-							? Array.from(convertJsonToUint8Array(cmd.default_value) || [])
+							? (encodedJsonValue(cmd.default_value) ?? [])
 							: null,
 					description: cmd.description || null,
 					category: cmd.category || null,
@@ -403,21 +743,31 @@ export function useCopilotCommands({
 					runtime_configured: cmd.runtime_configured ?? false,
 				};
 
-				console.log(`[CreateVariable] ${cmd.name} (${cmd.data_type})`);
-				await executeCommand(
+				console.log(`[CreateVariable] Queued ${cmd.name} (${cmd.data_type})`);
+				variableCreateCommands.push(
 					upsertVariableCommand({ variable, layer_id: targetLayer }),
 				);
-			};
+				latestBoardVariables[variable.id] = variable;
+			}
 
-			const applyUpdateNodePin = async (cmd: UpdateNodePinCommand) => {
-				await refreshBoardSnapshot();
+			const executedVariableCreateCommands = await executeInBatches(
+				variableCreateCommands,
+				"variable creation",
+			);
+			if (executedVariableCreateCommands.length > 0) {
+				executedAnyCommands = true;
+				refreshedAfterLastExecution = false;
+			}
 
-				const nodeId = nodeReferenceMap.get(cmd.node_id)?.id ?? cmd.node_id;
+			const buildUpdateNodePinCommand = (
+				cmd: UpdateNodePinCommand,
+			): IGenericCommand | null => {
+				const nodeId = resolveNodeId(cmd.node_id);
 				const node = latestBoardNodes[nodeId] ?? resolveNode(cmd.node_id);
 
 				if (!node) {
 					console.error(
-						`[UpdateNodePin] ❌ FAILED - Node not found: ${cmd.node_id}`,
+						`[UpdateNodePin] FAILED - Node not found: ${cmd.node_id}`,
 						{
 							command: cmd,
 							availableNodeRefs: Array.from(nodeReferenceMap.keys()),
@@ -428,15 +778,15 @@ export function useCopilotCommands({
 						`Pin update failed: Node "${cmd.node_id}" not found`,
 						<XIcon />,
 					);
-					return;
+					return null;
 				}
 
-				const pinId = resolvePinId(cmd.node_id, cmd.pin_id);
+				const pinId = resolvePinId(cmd.node_id, cmd.pin_id, IPinType.Input);
 				const pin = pinId ? node.pins[pinId] : undefined;
 
 				if (!pin || !pinId) {
 					console.error(
-						`[UpdateNodePin] ❌ FAILED - Pin not found: ${cmd.pin_id} in ${node.friendly_name}`,
+						`[UpdateNodePin] FAILED - Pin not found: ${cmd.pin_id} in ${node.friendly_name}`,
 						{
 							command: cmd,
 							pin_requested: cmd.pin_id,
@@ -452,32 +802,25 @@ export function useCopilotCommands({
 						`Pin update failed: Pin "${cmd.pin_id}" not found in "${node.friendly_name}"`,
 						<XIcon />,
 					);
-					return;
+					return null;
 				}
 
 				let encodedValue: number[] | null = null;
 				if (cmd.value !== null && cmd.value !== undefined) {
-					let valueToEncode = cmd.value;
-					if (typeof cmd.value === "string") {
-						if (cmd.value.startsWith('"') && cmd.value.endsWith('"')) {
-							valueToEncode = cmd.value.slice(1, -1);
-						}
-					}
-					const encoded = convertJsonToUint8Array(valueToEncode);
-					if (encoded) {
-						encodedValue = encoded;
-					} else {
+					const encoded = convertJsonToUint8Array(normalizePinValue(cmd.value));
+					if (!encoded) {
 						console.error(
-							`[UpdateNodePin] ❌ FAILED - Could not encode value:`,
+							"[UpdateNodePin] FAILED - Could not encode value:",
 							cmd.value,
 						);
-						toastError(`Pin update failed: Could not encode value`, <XIcon />);
-						return;
+						toastError("Pin update failed: Could not encode value", <XIcon />);
+						return null;
 					}
+					encodedValue = Array.from(encoded);
 				}
 
 				console.log(
-					`[UpdateNodePin] ✓ Setting: ${node.friendly_name}.${cmd.pin_id} = ${JSON.stringify(cmd.value)}`,
+					`[UpdateNodePin] Queued ${node.friendly_name}.${cmd.pin_id} = ${JSON.stringify(cmd.value)}`,
 					{ encodedValue, originalValue: cmd.value, pinId },
 				);
 
@@ -492,75 +835,95 @@ export function useCopilotCommands({
 					},
 				};
 
-				try {
-					const result = await executeCommand(
-						updateNodeCommand({
-							node: updatedNode,
-							old_node: node,
-						}),
-					);
-					if (result) {
-						console.log(`[UpdateNodePin] ✓ SUCCESS:`, result);
-						await refreshBoardSnapshot();
-					} else {
-						console.error(
-							`[UpdateNodePin] ❌ FAILED - executeCommand returned undefined/null`,
-						);
-						toastError(
-							`Pin update failed: Command not executed (check version)`,
-							<XIcon />,
-						);
-					}
-				} catch (err) {
-					console.error(`[UpdateNodePin] ❌ FAILED - Exception:`, err);
-					toastError(`Pin update failed: ${err}`, <XIcon />);
-				}
+				latestBoardNodes[updatedNode.id] = updatedNode;
+				replaceMappedNode(updatedNode);
+
+				return updateNodeCommand({
+					node: updatedNode,
+					old_node: node,
+				});
 			};
 
-			await refreshBoardSnapshot();
+			const pendingPinUpdates = commands.filter(
+				(cmd): cmd is UpdateNodePinCommand =>
+					cmd.command_type === "UpdateNodePin",
+			);
 
-			for (const cmd of commands) {
-				if (cmd.command_type === "CreateVariable") {
-					await delay(50);
-					await applyCreateVariable(cmd);
+			let remainingPinUpdates = [...pendingPinUpdates];
+			while (remainingPinUpdates.length > 0) {
+				const usedNodeIds = new Set<string>();
+				const consumedIndexes = new Set<number>();
+				const pinUpdateBatch: IGenericCommand[] = [];
+
+				for (let index = 0; index < remainingPinUpdates.length; index++) {
+					const cmd = remainingPinUpdates[index];
+					const nodeId = resolveNodeId(cmd.node_id);
+					if (usedNodeIds.has(nodeId)) continue;
+
+					const genericCommand = buildUpdateNodePinCommand(cmd);
+					consumedIndexes.add(index);
+					if (!genericCommand) continue;
+
+					usedNodeIds.add(nodeId);
+					pinUpdateBatch.push(genericCommand);
 				}
+
+				if (consumedIndexes.size === 0) {
+					break;
+				}
+
+				if (pinUpdateBatch.length > 0) {
+					const executedPinUpdateCommands = await executeInBatches(
+						pinUpdateBatch,
+						"pin update",
+					);
+					if (executedPinUpdateCommands.length > 0) {
+						executedAnyCommands = true;
+						refreshedAfterLastExecution = false;
+					}
+					await refreshBoardSnapshot();
+					refreshedAfterLastExecution = true;
+				}
+
+				remainingPinUpdates = remainingPinUpdates.filter(
+					(_, index) => !consumedIndexes.has(index),
+				);
 			}
 
+			const layerWithNodeIds = (layer: ILayer, nodeIds: string[]): ILayer => ({
+				...layer,
+				nodes: Object.fromEntries(
+					nodeIds
+						.map((nodeId) => [
+							nodeId,
+							latestBoardNodes[nodeId] ?? layer.nodes?.[nodeId],
+						])
+						.filter((entry): entry is [string, INode] => Boolean(entry[1])),
+				),
+			});
+
+			const remainingGenericCommands: IGenericCommand[] = [];
+
 			for (const cmd of commands) {
-				if (cmd.command_type === "UpdateNodePin") {
-					await delay(50);
-					await applyUpdateNodePin(cmd);
-				}
-			}
-
-			await refreshBoardSnapshot();
-
-			// ===== SECOND PASS: CONNECTIONS & REMAINING COMMANDS =====
-			for (const cmd of commands) {
-				await delay(50);
-
 				switch (cmd.command_type) {
 					case "AddNode":
-						break;
-
 					case "AddPlaceholder":
-						// Already handled in first pass
-						break;
-
 					case "CreateVariable":
-						// Applied before node configuration so variable get/set nodes can be wired safely.
+					case "UpdateNodePin":
 						break;
 
 					case "RemoveNode": {
 						const node = resolveNode(cmd.node_id);
-						if (node) {
-							await executeCommand(
-								removeNodeCommand({
-									node,
-									connected_nodes: [],
-								}),
-							);
-						}
+						if (!node) break;
+
+						remainingGenericCommands.push(
+							removeNodeCommand({
+								node,
+								connected_nodes: [],
+							}),
+						);
+						delete latestBoardNodes[node.id];
+						removeMappedNode(node.id);
 						break;
 					}
 
@@ -571,7 +934,7 @@ export function useCopilotCommands({
 						if (!fromNode || !toNode) {
 							const missingNode = !fromNode ? cmd.from_node : cmd.to_node;
 							console.error(
-								`[ConnectPins] ❌ FAILED - Node not found: "${missingNode}"`,
+								`[ConnectPins] FAILED - Node not found: "${missingNode}"`,
 								{
 									command: cmd,
 									availableNodeRefs: Array.from(nodeReferenceMap.keys()),
@@ -585,15 +948,23 @@ export function useCopilotCommands({
 							break;
 						}
 
-						const fromPinId = resolvePinId(cmd.from_node, cmd.from_pin);
-						const toPinId = resolvePinId(cmd.to_node, cmd.to_pin);
+						const fromPinId = resolvePinId(
+							cmd.from_node,
+							cmd.from_pin,
+							IPinType.Output,
+						);
+						const toPinId = resolvePinId(
+							cmd.to_node,
+							cmd.to_pin,
+							IPinType.Input,
+						);
 
 						if (!fromPinId || !toPinId) {
 							const missingPin = !fromPinId
 								? `${fromNode.friendly_name}.${cmd.from_pin}`
 								: `${toNode.friendly_name}.${cmd.to_pin}`;
 							console.error(
-								`[ConnectPins] ❌ FAILED - Pin not found: "${missingPin}"`,
+								`[ConnectPins] FAILED - Pin not found: "${missingPin}"`,
 								{
 									command: cmd,
 									from_pin_requested: cmd.from_pin,
@@ -620,7 +991,7 @@ export function useCopilotCommands({
 						}
 
 						console.log(
-							`[ConnectPins] ✓ Connecting: ${fromNode.friendly_name}.${cmd.from_pin} -> ${toNode.friendly_name}.${cmd.to_pin}`,
+							`[ConnectPins] Queued ${fromNode.friendly_name}.${cmd.from_pin} -> ${toNode.friendly_name}.${cmd.to_pin}`,
 							{
 								from_node_id: fromNode.id,
 								from_pin_id: fromPinId,
@@ -628,32 +999,14 @@ export function useCopilotCommands({
 								to_pin_id: toPinId,
 							},
 						);
-
-						try {
-							const connectResult = await executeCommand(
-								connectPinsCommand({
-									from_node: fromNode.id,
-									from_pin: fromPinId,
-									to_node: toNode.id,
-									to_pin: toPinId,
-								}),
-							);
-							if (connectResult) {
-								console.log(`[ConnectPins] ✓ SUCCESS:`, connectResult);
-								await delay(100);
-							} else {
-								console.error(
-									`[ConnectPins] ❌ FAILED - executeCommand returned undefined/null`,
-								);
-								toastError(
-									`Connection failed: Command not executed (check version)`,
-									<XIcon />,
-								);
-							}
-						} catch (err) {
-							console.error(`[ConnectPins] ❌ FAILED - Exception:`, err);
-							toastError(`Connection failed: ${err}`, <XIcon />);
-						}
+						remainingGenericCommands.push(
+							connectPinsCommand({
+								from_node: fromNode.id,
+								from_pin: fromPinId,
+								to_node: toNode.id,
+								to_pin: toPinId,
+							}),
+						);
 						break;
 					}
 
@@ -662,11 +1015,19 @@ export function useCopilotCommands({
 						const toNode = resolveNode(cmd.to_node);
 						if (!fromNode || !toNode) break;
 
-						const fromPinId = resolvePinId(cmd.from_node, cmd.from_pin);
-						const toPinId = resolvePinId(cmd.to_node, cmd.to_pin);
+						const fromPinId = resolvePinId(
+							cmd.from_node,
+							cmd.from_pin,
+							IPinType.Output,
+						);
+						const toPinId = resolvePinId(
+							cmd.to_node,
+							cmd.to_pin,
+							IPinType.Input,
+						);
 						if (!fromPinId || !toPinId) break;
 
-						await executeCommand(
+						remainingGenericCommands.push(
 							disconnectPinsCommand({
 								from_node: fromNode.id,
 								from_pin: fromPinId,
@@ -677,29 +1038,31 @@ export function useCopilotCommands({
 						break;
 					}
 
-					case "UpdateNodePin": {
-						// Applied before connections so dynamic/configured pins exist.
-						break;
-					}
-
 					case "MoveNode": {
 						const node = resolveNode(cmd.node_id);
 						if (!node) break;
 
-						const targetLayer = cmd.target_layer ?? currentLayer;
+						const targetLayer =
+							resolveLayerId(cmd.target_layer) ?? currentLayer;
+						const movedNode: INode = {
+							...node,
+							coordinates: [cmd.position.x, cmd.position.y, 0],
+						};
 
-						await executeCommand(
+						remainingGenericCommands.push(
 							moveNodeCommand({
 								node_id: node.id,
 								to_coordinates: [cmd.position.x, cmd.position.y, 0],
 								current_layer: targetLayer,
 							}),
 						);
+						latestBoardNodes[node.id] = movedNode;
+						replaceMappedNode(movedNode);
 						break;
 					}
 
 					case "UpdateVariable": {
-						const existingVariable = board.data?.variables?.[cmd.variable_id];
+						const existingVariable = latestBoardVariables[cmd.variable_id];
 						if (!existingVariable) {
 							toastError(
 								`Cannot update variable: "${cmd.variable_id}" not found`,
@@ -720,9 +1083,9 @@ export function useCopilotCommands({
 							default_value: cmd.clear_default_value
 								? null
 								: "default_value" in cmd
-									? Array.from(convertJsonToUint8Array(cmd.default_value) || [])
+									? (encodedJsonValue(cmd.default_value) ?? [])
 									: "value" in cmd
-										? Array.from(convertJsonToUint8Array(cmd.value) || [])
+										? (encodedJsonValue(cmd.value) ?? [])
 										: existingVariable.default_value,
 							description: cmd.clear_description
 								? null
@@ -747,19 +1110,20 @@ export function useCopilotCommands({
 						};
 
 						console.log(
-							`[UpdateVariable] ${existingVariable.name} = ${JSON.stringify(cmd.value)}`,
+							`[UpdateVariable] Queued ${existingVariable.name} = ${JSON.stringify(cmd.value)}`,
 						);
-						await executeCommand(
+						remainingGenericCommands.push(
 							upsertVariableCommand({
 								variable: updatedVariable,
 								old_variable: existingVariable,
 							}),
 						);
+						latestBoardVariables[updatedVariable.id] = updatedVariable;
 						break;
 					}
 
 					case "DeleteVariable": {
-						const variableToDelete = board.data?.variables?.[cmd.variable_id];
+						const variableToDelete = latestBoardVariables[cmd.variable_id];
 						if (!variableToDelete) {
 							toastError(
 								`Cannot delete variable: "${cmd.variable_id}" not found`,
@@ -768,10 +1132,11 @@ export function useCopilotCommands({
 							break;
 						}
 
-						console.log(`[DeleteVariable] ${variableToDelete.name}`);
-						await executeCommand(
+						console.log(`[DeleteVariable] Queued ${variableToDelete.name}`);
+						remainingGenericCommands.push(
 							removeVariableCommand({ variable: variableToDelete }),
 						);
+						delete latestBoardVariables[cmd.variable_id];
 						break;
 					}
 
@@ -793,18 +1158,21 @@ export function useCopilotCommands({
 							},
 							author: "copilot",
 						};
+						const targetLayer =
+							resolveLayerId(cmd.target_layer) ?? currentLayer;
 
-						const targetLayer = cmd.target_layer ?? currentLayer;
-
-						console.log(`[CreateComment] "${cmd.content.slice(0, 30)}..."`);
-						await executeCommand(
+						console.log(
+							`[CreateComment] Queued "${cmd.content.slice(0, 30)}..."`,
+						);
+						remainingGenericCommands.push(
 							upsertCommentCommand({ comment, current_layer: targetLayer }),
 						);
+						latestBoardComments[comment.id] = comment;
 						break;
 					}
 
 					case "UpdateComment": {
-						const existingComment = board.data?.comments?.[cmd.comment_id];
+						const existingComment = latestBoardComments[cmd.comment_id];
 						if (!existingComment) {
 							toastError(
 								`Cannot update comment: "${cmd.comment_id}" not found`,
@@ -816,24 +1184,25 @@ export function useCopilotCommands({
 						const updatedComment: IComment = {
 							...existingComment,
 							content: cmd.content ?? existingComment.content,
-							color: cmd.color ?? existingComment.content,
+							color: cmd.color ?? existingComment.color,
 						};
 
 						console.log(
-							`[UpdateComment] "${updatedComment.content.slice(0, 30)}..."`,
+							`[UpdateComment] Queued "${updatedComment.content.slice(0, 30)}..."`,
 						);
-						await executeCommand(
+						remainingGenericCommands.push(
 							upsertCommentCommand({
 								comment: updatedComment,
 								current_layer: currentLayer,
 								old_comment: existingComment,
 							}),
 						);
+						latestBoardComments[updatedComment.id] = updatedComment;
 						break;
 					}
 
 					case "DeleteComment": {
-						const commentToDelete = board.data?.comments?.[cmd.comment_id];
+						const commentToDelete = latestBoardComments[cmd.comment_id];
 						if (!commentToDelete) {
 							toastError(
 								`Cannot delete comment: "${cmd.comment_id}" not found`,
@@ -843,46 +1212,58 @@ export function useCopilotCommands({
 						}
 
 						console.log(
-							`[DeleteComment] "${commentToDelete.content.slice(0, 30)}..."`,
+							`[DeleteComment] Queued "${commentToDelete.content.slice(0, 30)}..."`,
 						);
-						await executeCommand(
+						remainingGenericCommands.push(
 							removeCommentCommand({ comment: commentToDelete }),
 						);
+						delete latestBoardComments[cmd.comment_id];
 						break;
 					}
 
 					case "CreateLayer": {
+						if (isSetupLayerCommand(cmd)) {
+							break;
+						}
 						const layerId = createId();
-						const targetLayer = cmd.target_layer ?? currentLayer;
+						const targetLayer =
+							resolveLayerId(cmd.target_layer) ?? currentLayer;
+						const nodeIds = resolveNodeIds(cmd.node_ids || []);
+						const position = cmd.position ?? { x: baseX, y: baseY };
 
 						const layer: ILayer = {
 							id: layerId,
 							name: cmd.name,
-							type: ILayerType.Collapsed,
+							type: layerTypeFromCommand(cmd.layer_type),
 							color: cmd.color || null,
-							coordinates: [baseX, baseY, 0],
+							coordinates: [position.x, position.y, 0],
 							nodes: {},
 							variables: {},
 							comments: {},
-							pins: {},
+							pins: pinsFromDefs(cmd.pins, false),
 							parent_id: targetLayer,
 						};
 
 						console.log(
-							`[CreateLayer] "${cmd.name}" with ${cmd.node_ids?.length || 0} nodes`,
+							`[CreateLayer] Queued "${cmd.name}" with ${nodeIds.length} nodes`,
 						);
-						await executeCommand(
+						remainingGenericCommands.push(
 							upsertLayerCommand({
 								layer,
-								node_ids: cmd.node_ids || [],
+								node_ids: nodeIds,
 								current_layer: targetLayer,
 							}),
+						);
+						latestBoardLayers[layerId] = layerWithNodeIds(layer, nodeIds);
+						registerNodeRefs(
+							[cmd.ref_id, cmd.name, layerId],
+							layerAsNode(layer),
 						);
 						break;
 					}
 
 					case "AddNodesToLayer": {
-						const existingLayer = board.data?.layers?.[cmd.layer_id];
+						const existingLayer = resolveLayer(cmd.layer_id);
 						if (!existingLayer) {
 							toastError(
 								`Cannot add nodes to layer: "${cmd.layer_id}" not found`,
@@ -892,26 +1273,27 @@ export function useCopilotCommands({
 						}
 
 						const existingNodeIds = Object.keys(existingLayer.nodes || {});
-						const allNodeIds = [
-							...new Set([...existingNodeIds, ...cmd.node_ids]),
-						];
+						const nodeIds = resolveNodeIds(cmd.node_ids);
+						const allNodeIds = [...new Set([...existingNodeIds, ...nodeIds])];
+						const updatedLayer = layerWithNodeIds(existingLayer, allNodeIds);
 
 						console.log(
-							`[AddNodesToLayer] Adding ${cmd.node_ids.length} nodes to "${existingLayer.name}"`,
+							`[AddNodesToLayer] Queued ${nodeIds.length} nodes for "${existingLayer.name}"`,
 						);
-						await executeCommand(
+						remainingGenericCommands.push(
 							upsertLayerCommand({
-								layer: existingLayer,
+								layer: updatedLayer,
 								node_ids: allNodeIds,
 								current_layer: currentLayer,
 								old_layer: existingLayer,
 							}),
 						);
+						latestBoardLayers[existingLayer.id] = updatedLayer;
 						break;
 					}
 
 					case "RemoveNodesFromLayer": {
-						const layerToUpdate = board.data?.layers?.[cmd.layer_id];
+						const layerToUpdate = resolveLayer(cmd.layer_id);
 						if (!layerToUpdate) {
 							toastError(
 								`Cannot remove nodes from layer: "${cmd.layer_id}" not found`,
@@ -920,40 +1302,56 @@ export function useCopilotCommands({
 							break;
 						}
 
+						const nodeIds = resolveNodeIds(cmd.node_ids);
 						const currentNodeIds = Object.keys(layerToUpdate.nodes || {});
 						const remainingNodeIds = currentNodeIds.filter(
-							(id) => !cmd.node_ids.includes(id),
+							(id) => !nodeIds.includes(id),
+						);
+						const updatedLayer = layerWithNodeIds(
+							layerToUpdate,
+							remainingNodeIds,
 						);
 
 						console.log(
-							`[RemoveNodesFromLayer] Removing ${cmd.node_ids.length} nodes from "${layerToUpdate.name}"`,
+							`[RemoveNodesFromLayer] Queued ${nodeIds.length} nodes from "${layerToUpdate.name}"`,
 						);
-						await executeCommand(
+						remainingGenericCommands.push(
 							upsertLayerCommand({
-								layer: layerToUpdate,
+								layer: updatedLayer,
 								node_ids: remainingNodeIds,
 								current_layer: currentLayer,
 								old_layer: layerToUpdate,
 							}),
 						);
+						latestBoardLayers[layerToUpdate.id] = updatedLayer;
 						break;
 					}
 				}
 			}
 
-			console.log(
-				`[handleExecuteCommands] Completed ${commands.length} commands`,
+			const executedBoardEditCommands = await executeInBatches(
+				remainingGenericCommands,
+				"board edit",
 			);
+			if (executedBoardEditCommands.length > 0) {
+				executedAnyCommands = true;
+				refreshedAfterLastExecution = false;
+				await refreshBoardSnapshot();
+				refreshedAfterLastExecution = true;
+			}
 
-			await board.refetch();
+			if (executedAnyCommands && !refreshedAfterLastExecution) {
+				await refreshBoardSnapshot();
+			}
+
+			console.log(
+				`[handleExecuteCommands] Completed ${commands.length} FlowPilot commands`,
+			);
 		},
 		[
 			catalog.data,
-			executeCommand,
-			board.data?.nodes,
-			board.data?.variables,
-			board.data?.comments,
-			board.data?.layers,
+			executeCommands,
+			board.data,
 			currentLayer,
 			board.refetch,
 			board,

--- a/packages/ui/lib/flow-board-utils.tsx
+++ b/packages/ui/lib/flow-board-utils.tsx
@@ -62,6 +62,10 @@ function boardDataVersion(board: IBoard): string {
 	].join(":");
 }
 
+function renderedNodeCacheKey(id: string, hash: unknown): string {
+	return `${id}:${String(hash)}`;
+}
+
 interface ISerializedPin {
 	id: string;
 	name: string;
@@ -424,7 +428,7 @@ export function parseBoard(
 	const nodes: any[] = [];
 	const edges: any[] = [];
 	const cache = new Map<string, [IPin, INode | ILayer, boolean]>();
-	const oldNodesMap = new Map<number, any>();
+	const oldNodesMap = new Map<string, any>();
 	const oldEdgesMap = new Map<string, any>();
 	const addedNodeIds = new Set<string>(); // Track which node IDs have been added
 	const boardVersionToken = boardDataVersion(board);
@@ -435,9 +439,9 @@ export function parseBoard(
 		.join(";");
 
 	for (const oldNode of oldNodes ?? []) {
-		// Only add to oldNodesMap if we haven't seen this hash before (prevents duplicate hash collisions)
-		if (oldNode.data?.hash && !oldNodesMap.has(oldNode.data.hash)) {
-			oldNodesMap.set(oldNode.data.hash, oldNode);
+		const hash = oldNode.data?.hash;
+		if (typeof oldNode.id === "string" && hash !== undefined && hash !== null) {
+			oldNodesMap.set(renderedNodeCacheKey(oldNode.id, hash), oldNode);
 		}
 	}
 
@@ -474,7 +478,10 @@ export function parseBoard(
 					)
 				: !catalogLookup.nodeNames.has(node.name)
 			: false;
-		const oldNode = hash === -1 ? undefined : oldNodesMap.get(hash);
+		const oldNode =
+			hash === -1
+				? undefined
+				: oldNodesMap.get(renderedNodeCacheKey(node.id, hash));
 		const sel = selected.has(node.id);
 		if (
 			oldNode &&
@@ -895,7 +902,10 @@ export function parseBoard(
 			(comment.layer ?? "") === "" ? undefined : comment.layer;
 		if (commentLayer !== currentLayer) continue;
 		const hash = comment.hash ?? -1;
-		const oldNode = hash === -1 ? undefined : oldNodesMap.get(hash);
+		const oldNode =
+			hash === -1
+				? undefined
+				: oldNodesMap.get(renderedNodeCacheKey(comment.id, hash));
 		if (oldNode) {
 			nodes.push(oldNode);
 			continue;

--- a/packages/ui/lib/schema/flow/copilot.ts
+++ b/packages/ui/lib/schema/flow/copilot.ts
@@ -164,8 +164,12 @@ export type BoardCommand =
 	| {
 			command_type: "CreateLayer";
 			name: string;
+			ref_id?: string;
+			layer_type?: "Collapsed" | "Function" | "Macro";
 			color?: string;
 			node_ids?: string[];
+			pins?: PlaceholderPinDef[];
+			position?: { x: number; y: number };
 			/** Parent layer ID for nesting. If undefined, creates at current layer. */
 			target_layer?: string;
 			summary?: string;

--- a/packages/ui/state/backend-state.ts
+++ b/packages/ui/state/backend-state.ts
@@ -14,7 +14,10 @@ import type {
 	UpsertAppCommentResponse,
 } from "./backend-state/app-state";
 import type { IBitState } from "./backend-state/bit-state";
-import type { IBoardState } from "./backend-state/board-state";
+import type {
+	IApplyFlowScriptResponse,
+	IBoardState,
+} from "./backend-state/board-state";
 import type { IDatabaseState } from "./backend-state/db-state";
 import {
 	EmptyAIState,
@@ -78,6 +81,7 @@ export type {
 	IAppRouteState,
 	IBitState,
 	IBoardState,
+	IApplyFlowScriptResponse,
 	IEventState,
 	IHelperState,
 	IPageState,

--- a/packages/ui/state/backend-state/board-state.ts
+++ b/packages/ui/state/backend-state/board-state.ts
@@ -22,7 +22,14 @@ import type {
 	UnifiedChatMessage,
 	UnifiedCopilotResponse,
 } from "../../lib/schema/copilot";
+import type { BoardCommand } from "../../lib/schema/flow/copilot";
 import type { IPrerunBoardResponse } from "./types";
+
+export interface IApplyFlowScriptResponse {
+	commands: IGenericCommand[];
+	board_commands: BoardCommand[];
+	diagnostics: string[];
+}
 
 export interface IBoardState {
 	getBoards(appId: string): Promise<IBoard[]>;
@@ -124,6 +131,15 @@ export interface IBoardState {
 		boardId: string,
 		commands: IGenericCommand[],
 	): Promise<IGenericCommand[]>;
+
+	applyFlowScript(
+		appId: string,
+		boardId: string,
+		flowscript: string,
+		currentLayer?: string,
+		catalogNodes?: INode[],
+		allowDeletions?: boolean,
+	): Promise<IApplyFlowScriptResponse>;
 
 	getExecutionElements(
 		appId: string,

--- a/packages/ui/state/backend-state/empty-states/board-state.ts
+++ b/packages/ui/state/backend-state/empty-states/board-state.ts
@@ -1,4 +1,5 @@
 import type {
+	IApplyFlowScriptResponse,
 	IBoard,
 	IBoardState,
 	IConnectionMode,
@@ -140,6 +141,17 @@ export class EmptyBoardState implements IBoardState {
 		boardId: string,
 		commands: IGenericCommand[],
 	): Promise<IGenericCommand[]> {
+		throw new Error("Method not implemented.");
+	}
+
+	applyFlowScript(
+		appId: string,
+		boardId: string,
+		flowscript: string,
+		currentLayer?: string,
+		catalogNodes?: INode[],
+		allowDeletions?: boolean,
+	): Promise<IApplyFlowScriptResponse> {
 		throw new Error("Method not implemented.");
 	}
 


### PR DESCRIPTION
- Introduced a caching mechanism for rendered nodes in flow-board-utils to prevent duplicate hash collisions.
- Updated the parseBoard function to utilize the new caching mechanism for old nodes.
- Added new properties to the BoardCommand type in copilot.ts for enhanced layer management.
- Expanded the IBoardState interface to include applyFlowScript method for applying flow scripts.
- Implemented the applyFlowScript method in EmptyBoardState to throw an error when not implemented.