### PR TITLE
Fix/664 pages show up in all boards

### DIFF
--- a/apps/desktop/components/tauri-provider/db-state.ts
+++ b/apps/desktop/components/tauri-provider/db-state.ts
@@ -1,9 +1,9 @@
 import { invoke } from "@tauri-apps/api/core";
+import { IIndexType } from "@flow-like/flow-like-ui";
 import type {
 	IAddColumnPayload,
 	IDatabaseState,
 	IIndexConfig,
-	IIndexType,
 	IQueryTablePayload,
 } from "@flow-like/flow-like-ui";
 import { fetcher } from "../../lib/api";
@@ -24,6 +24,18 @@ function appendScope(url: string, userScoped?: boolean): string {
 
 export class DatabaseState implements IDatabaseState {
 	constructor(private readonly backend: TauriBackend) {}
+
+	private indexTypeToString(indexType: IIndexType): string {
+		const map: Record<IIndexType, string> = {
+			[IIndexType.FullText]: "FullText",
+			[IIndexType.BTree]: "BTree",
+			[IIndexType.Bitmap]: "Bitmap",
+			[IIndexType.LabelList]: "LabelList",
+			[IIndexType.Auto]: "Auto",
+		};
+		return map[indexType] ?? "Auto";
+	}
+
 	async buildIndex(
 		appId: string,
 		tableName: string,
@@ -45,8 +57,8 @@ export class DatabaseState implements IDatabaseState {
 					method: "POST",
 					body: JSON.stringify({
 						column,
-						indexType,
-						optimize,
+						index_type: this.indexTypeToString(indexType),
+						optimize: optimize ?? false,
 					}),
 				},
 				this.backend.auth,
@@ -362,7 +374,7 @@ export class DatabaseState implements IDatabaseState {
 				),
 				{
 					method: "POST",
-					body: JSON.stringify({ keepVersions: keepVersions ?? false }),
+					body: JSON.stringify({ keep_versions: keepVersions ?? false }),
 				},
 				this.backend.auth,
 			);

--- a/packages/api/src/routes/app/page/get_pages.rs
+++ b/packages/api/src/routes/app/page/get_pages.rs
@@ -11,8 +11,8 @@ use serde::{Deserialize, Serialize};
 use utoipa::{IntoParams, ToSchema};
 
 #[derive(Debug, Deserialize, IntoParams, ToSchema)]
-#[serde(rename_all = "camelCase")]
 pub struct GetPagesParams {
+    #[serde(alias = "boardId")]
     pub board_id: Option<String>,
 }
 

--- a/packages/api/src/routes/registry/server.rs
+++ b/packages/api/src/routes/registry/server.rs
@@ -250,6 +250,7 @@ pub struct PackageReview {
 
 /// Request to submit a review
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct ReviewRequest {
     pub action: String, // "approve", "reject", "request_changes", "comment", "flag"
     pub comment: Option<String>,


### PR DESCRIPTION
This pull request introduces several improvements and fixes related to API consistency, parameter handling, and internal data mapping. The main focus is on standardizing naming conventions between frontend and backend, improving code clarity, and ensuring compatibility with client expectations.

**API Consistency and Naming Conventions:**

* Standardized the naming convention for JSON payloads in `DatabaseState` by converting camelCase keys to snake_case (e.g., `indexType` to `index_type`, `keepVersions` to `keep_versions`) to align with backend expectations. [[1]](diffhunk://#diff-3370d858ff09c5655d7e4b3b67223a7ef62ac0420094a345d2964e523a952142L48-R61) [[2]](diffhunk://#diff-3370d858ff09c5655d7e4b3b67223a7ef62ac0420094a345d2964e523a952142L365-R377)
* Added a helper method `indexTypeToString` in `DatabaseState` to map `IIndexType` enum values to their corresponding string representations for API calls.

**Parameter Handling Improvements:**

* Updated the `GetPagesParams` struct in the backend to accept `boardId` as an alias for `board_id`, improving compatibility with frontend requests that may use camelCase.
* Ensured the `ReviewRequest` struct in the backend uses camelCase naming for serialization/deserialization, matching frontend conventions.

**Dependency and Import Adjustments:**

* Adjusted imports in `db-state.ts` to import `IIndexType` directly (not as a type-only import), ensuring proper usage in runtime code.