### PR TITLE
feat: add new nodes for directory diffing and manifest management

### DIFF
--- a/packages/catalog/data/src/data/path.rs
+++ b/packages/catalog/data/src/data/path.rs
@@ -35,6 +35,13 @@ impl FlowPath {
         }
     }
 
+    /// Clones this path, pointing at `path` within the same store/cache layer.
+    pub fn with_path(&self, path: &str) -> Self {
+        let mut clone = self.clone();
+        clone.path = path.to_string();
+        clone
+    }
+
     pub async fn get(
         &self,
         context: &mut ExecutionContext,

--- a/packages/catalog/data/src/data/path/operations/changed.rs
+++ b/packages/catalog/data/src/data/path/operations/changed.rs
@@ -1,4 +1,55 @@
+use crate::data::path::FlowPath;
 use flow_like_storage::object_store::path::Path;
+use flow_like_types::{
+    JsonSchema,
+    json::{Deserialize, Serialize},
+};
+
+pub mod apply_changed;
+pub mod get_changes;
+
+/// On-disk manifest format version. Bumped when [`DirManifest`] changes shape.
+pub const MANIFEST_VERSION: u32 = 1;
+
+/// A single tracked file inside a manifest.
+///
+/// Change detection prefers a `hash` when present, else the store `e_tag` (free
+/// from a single `list()` call, so file contents are never re-read). `hash` is
+/// populated in Checksum mode or when the store reports a missing/weak ETag.
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+pub struct ManifestEntry {
+    /// Object-store key of the file (path within the root's store).
+    pub path: String,
+    /// ETag reported by the store; used when no content hash is recorded.
+    pub e_tag: Option<String>,
+    /// Blake3 content hash; the strongest signal when present.
+    pub hash: Option<String>,
+    /// File size in bytes.
+    pub size: u64,
+    /// Last-modified timestamp as reported by the store.
+    pub last_modified: String,
+}
+
+/// Snapshot of every file found under a root folder at a point in time.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
+pub struct DirManifest {
+    #[serde(default)]
+    pub version: u32,
+    #[serde(default)]
+    pub entries: Vec<ManifestEntry>,
+}
+
+/// Hand-off produced by the diff node and consumed by the writer node.
+///
+/// Carries both the manifest destination and the fully-computed next manifest,
+/// so the writer only needs this session to persist the new state.
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+pub struct DirDiffSession {
+    /// Where the manifest lives / should be written.
+    pub manifest: FlowPath,
+    /// The next manifest to persist, reflecting the current directory state.
+    pub manifest_content: DirManifest,
+}
 
 #[derive(Clone, Debug)]
 pub enum PathChange {

--- a/packages/catalog/data/src/data/path/operations/changed.rs
+++ b/packages/catalog/data/src/data/path/operations/changed.rs
@@ -35,6 +35,11 @@ pub struct ManifestEntry {
 pub struct DirManifest {
     #[serde(default)]
     pub version: u32,
+    /// Whether the snapshot was taken recursively. Diffs against a manifest with a
+    /// different scope skip deletion detection to avoid falsely reporting
+    /// out-of-scope files as deleted.
+    #[serde(default)]
+    pub recursive: bool,
     #[serde(default)]
     pub entries: Vec<ManifestEntry>,
 }

--- a/packages/catalog/data/src/data/path/operations/changed/apply_changed.rs
+++ b/packages/catalog/data/src/data/path/operations/changed/apply_changed.rs
@@ -78,7 +78,7 @@ impl NodeLogic for WriteManifestNode {
         context.deactivate_exec_pin("exec_out").await?;
 
         let session: DirDiffSession = context.evaluate_pin("session").await?;
-        let bytes = flow_like_types::json::to_vec_pretty(&session.manifest_content)?;
+        let bytes = flow_like_types::json::to_vec(&session.manifest_content)?;
 
         session.manifest.put(context, bytes, false).await?;
 

--- a/packages/catalog/data/src/data/path/operations/changed/apply_changed.rs
+++ b/packages/catalog/data/src/data/path/operations/changed/apply_changed.rs
@@ -1,0 +1,92 @@
+use super::DirDiffSession;
+use crate::data::path::FlowPath;
+use flow_like::flow::{
+    execution::context::ExecutionContext,
+    node::{Node, NodeLogic, NodeScores},
+    pin::PinOptions,
+    variable::VariableType,
+};
+use flow_like_types::{async_trait, json::json};
+
+#[crate::register_node]
+#[derive(Default)]
+pub struct WriteManifestNode {}
+
+impl WriteManifestNode {
+    pub fn new() -> Self {
+        WriteManifestNode {}
+    }
+}
+
+#[async_trait]
+impl NodeLogic for WriteManifestNode {
+    fn get_node(&self) -> Node {
+        let mut node = Node::new(
+            "path_write_manifest",
+            "Write Directory Manifest",
+            "Persists the manifest carried by a diff session, so the next diff sees the current state",
+            "Data/Files/Operations",
+        );
+        node.add_icon("/flow/icons/path.svg");
+
+        node.add_input_pin(
+            "exec_in",
+            "Input",
+            "Initiate Execution",
+            VariableType::Execution,
+        );
+
+        node.add_input_pin(
+            "session",
+            "Session",
+            "Diff session produced by 'Diff Directory'",
+            VariableType::Struct,
+        )
+        .set_schema::<DirDiffSession>()
+        .set_options(PinOptions::new().set_enforce_schema(true).build());
+
+        node.add_output_pin(
+            "exec_out",
+            "Output",
+            "Done with the Execution",
+            VariableType::Execution,
+        );
+
+        node.add_output_pin(
+            "manifest",
+            "Manifest",
+            "FlowPath of the written manifest file",
+            VariableType::Struct,
+        )
+        .set_schema::<FlowPath>();
+
+        node.set_scores(
+            NodeScores::new()
+                .set_privacy(8)
+                .set_security(8)
+                .set_performance(9)
+                .set_governance(7)
+                .set_reliability(8)
+                .set_cost(9)
+                .build(),
+        );
+
+        node
+    }
+
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        context.deactivate_exec_pin("exec_out").await?;
+
+        let session: DirDiffSession = context.evaluate_pin("session").await?;
+        let bytes = flow_like_types::json::to_vec_pretty(&session.manifest_content)?;
+
+        session.manifest.put(context, bytes, false).await?;
+
+        context
+            .set_pin_value("manifest", json!(session.manifest))
+            .await?;
+        context.activate_exec_pin("exec_out").await?;
+
+        Ok(())
+    }
+}

--- a/packages/catalog/data/src/data/path/operations/changed/get_changes.rs
+++ b/packages/catalog/data/src/data/path/operations/changed/get_changes.rs
@@ -1,1 +1,301 @@
-// Get Edited, Removed, Added, Renamed and Moved Files
+use super::{DirDiffSession, DirManifest, MANIFEST_VERSION, ManifestEntry};
+use crate::data::path::FlowPath;
+use flow_like::flow::{
+    execution::{LogLevel, context::ExecutionContext},
+    node::{Node, NodeLogic, NodeScores},
+    pin::{PinOptions, ValueType},
+    variable::VariableType,
+};
+use flow_like_types::{Error, async_trait, json::json};
+use futures::{StreamExt, stream};
+use std::collections::HashMap;
+
+/// Bounded parallelism when Blake3-hashing file bodies (Checksum mode / weak ETags).
+const HASH_CONCURRENCY: usize = 16;
+
+#[crate::register_node]
+#[derive(Default)]
+pub struct GetChangesNode {}
+
+impl GetChangesNode {
+    pub fn new() -> Self {
+        GetChangesNode {}
+    }
+}
+
+#[async_trait]
+impl NodeLogic for GetChangesNode {
+    fn get_node(&self) -> Node {
+        let mut node = Node::new(
+            "path_get_changes",
+            "Diff Directory",
+            "Diffs a folder against a manifest, emitting added, updated and deleted files without rehashing unchanged content (ETag-based)",
+            "Data/Files/Operations",
+        );
+        node.add_icon("/flow/icons/path.svg");
+
+        node.add_input_pin(
+            "exec_in",
+            "Input",
+            "Initiate Execution",
+            VariableType::Execution,
+        );
+
+        node.add_input_pin(
+            "manifest",
+            "Manifest",
+            "FlowPath to the manifest file. May not exist yet — everything is then reported as added",
+            VariableType::Struct,
+        )
+        .set_schema::<FlowPath>()
+        .set_options(PinOptions::new().set_enforce_schema(true).build());
+
+        node.add_input_pin(
+            "root",
+            "Root",
+            "Root folder to scan for changes",
+            VariableType::Struct,
+        )
+        .set_schema::<FlowPath>()
+        .set_options(PinOptions::new().set_enforce_schema(true).build());
+
+        node.add_input_pin(
+            "recursive",
+            "Recursive",
+            "Scan the root folder recursively",
+            VariableType::Boolean,
+        )
+        .set_default_value(Some(json!(true)));
+
+        node.add_input_pin(
+            "mode",
+            "Change Detection",
+            "Auto: trust store ETags, hashing only files with a missing/weak ETag (fast). Checksum: always Blake3-hash contents, ignoring ETags (correct on backends with mtime-based ETags such as local disk)",
+            VariableType::String,
+        )
+        .set_default_value(Some(json!("Auto")))
+        .set_options(
+            PinOptions::new()
+                .set_valid_values(vec!["Auto".to_string(), "Checksum".to_string()])
+                .build(),
+        );
+
+        node.add_output_pin(
+            "exec_out",
+            "Output",
+            "Done with the Execution",
+            VariableType::Execution,
+        );
+
+        node.add_output_pin(
+            "added",
+            "Added",
+            "Files present in the folder but not in the manifest",
+            VariableType::Struct,
+        )
+        .set_schema::<FlowPath>()
+        .set_value_type(ValueType::Array);
+
+        node.add_output_pin(
+            "updated",
+            "Updated",
+            "Files whose ETag/hash changed since the manifest",
+            VariableType::Struct,
+        )
+        .set_schema::<FlowPath>()
+        .set_value_type(ValueType::Array);
+
+        node.add_output_pin(
+            "deleted",
+            "Deleted",
+            "Files in the manifest that no longer exist in the folder",
+            VariableType::Struct,
+        )
+        .set_schema::<FlowPath>()
+        .set_value_type(ValueType::Array);
+
+        node.add_output_pin(
+            "session",
+            "Session",
+            "Diff session carrying the next manifest, feed into 'Write Directory Manifest'",
+            VariableType::Struct,
+        )
+        .set_schema::<DirDiffSession>();
+
+        node.set_scores(
+            NodeScores::new()
+                .set_privacy(8)
+                .set_security(8)
+                .set_performance(9)
+                .set_governance(7)
+                .set_reliability(8)
+                .set_cost(9)
+                .build(),
+        );
+
+        node
+    }
+
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        context.deactivate_exec_pin("exec_out").await?;
+
+        let manifest_path: FlowPath = context.evaluate_pin("manifest").await?;
+        let root: FlowPath = context.evaluate_pin("root").await?;
+        let recursive: bool = context.evaluate_pin("recursive").await?;
+        let mode: String = context.evaluate_pin("mode").await?;
+        let checksum = mode.eq_ignore_ascii_case("checksum");
+
+        let previous_manifest = load_manifest(&manifest_path, context).await;
+        let mut previous: HashMap<String, ManifestEntry> = previous_manifest
+            .entries
+            .into_iter()
+            .map(|entry| (entry.path.clone(), entry))
+            .collect();
+
+        let runtime = root.to_runtime(context).await?;
+        let store = runtime.store.clone();
+        let generic = store.as_generic();
+
+        let objects = if recursive {
+            generic
+                .list(Some(&runtime.path))
+                .map(|result| result.map_err(Error::from))
+                .collect::<Vec<_>>()
+                .await
+                .into_iter()
+                .collect::<Result<Vec<_>, _>>()?
+        } else {
+            generic
+                .list_with_delimiter(Some(&runtime.path))
+                .await?
+                .objects
+        };
+
+        // Skip the manifest file itself when it lives inside the scanned root.
+        let candidates: Vec<_> = objects
+            .into_iter()
+            .filter(|object| object.location.as_ref() != manifest_path.path)
+            .collect();
+
+        // Only read file bodies when we cannot trust the ETag: Checksum mode, or
+        // a missing/weak ETag. Trusted ETags come for free from the single list().
+        let to_hash: Vec<(String, flow_like_storage::Path)> = candidates
+            .iter()
+            .filter(|object| checksum || !etag_trustworthy(&object.e_tag))
+            .map(|object| {
+                (
+                    object.location.as_ref().to_string(),
+                    object.location.clone(),
+                )
+            })
+            .collect();
+
+        let mut hashes: HashMap<String, String> = HashMap::with_capacity(to_hash.len());
+        if !to_hash.is_empty() {
+            let results: Vec<(String, flow_like_types::Result<String>)> = stream::iter(to_hash)
+                .map(|(key, location)| {
+                    let store = store.clone();
+                    async move { (key, store.content_hash(&location).await) }
+                })
+                .buffer_unordered(HASH_CONCURRENCY)
+                .collect()
+                .await;
+
+            for (key, result) in results {
+                match result {
+                    Ok(hash) => {
+                        hashes.insert(key, hash);
+                    }
+                    Err(err) => context
+                        .log_message(&format!("Failed to hash {}: {}", key, err), LogLevel::Warn),
+                }
+            }
+        }
+
+        let mut added = Vec::new();
+        let mut updated = Vec::new();
+        let mut entries = Vec::with_capacity(candidates.len());
+
+        for object in candidates {
+            let key = object.location.as_ref().to_string();
+            let entry = ManifestEntry {
+                path: key.clone(),
+                e_tag: object.e_tag,
+                hash: hashes.remove(&key),
+                size: object.size,
+                last_modified: object.last_modified.to_string(),
+            };
+
+            let flow_path = root.with_path(&key);
+            match previous.remove(&key) {
+                Some(prev) if entry_changed(&prev, &entry) => updated.push(flow_path),
+                Some(_) => {}
+                None => added.push(flow_path),
+            }
+
+            entries.push(entry);
+        }
+
+        let deleted = previous
+            .into_keys()
+            .map(|key| root.with_path(&key))
+            .collect::<Vec<FlowPath>>();
+
+        let session = DirDiffSession {
+            manifest: manifest_path,
+            manifest_content: DirManifest {
+                version: MANIFEST_VERSION,
+                entries,
+            },
+        };
+
+        context.set_pin_value("added", json!(added)).await?;
+        context.set_pin_value("updated", json!(updated)).await?;
+        context.set_pin_value("deleted", json!(deleted)).await?;
+        context.set_pin_value("session", json!(session)).await?;
+        context.activate_exec_pin("exec_out").await?;
+
+        Ok(())
+    }
+}
+
+/// Reads and parses the manifest, tolerating a missing or malformed file by
+/// returning an empty manifest (so every file is reported as added).
+async fn load_manifest(manifest: &FlowPath, context: &mut ExecutionContext) -> DirManifest {
+    let bytes = match manifest.get(context, false).await {
+        Ok(bytes) => bytes,
+        Err(_) => return DirManifest::default(),
+    };
+
+    match flow_like_types::json::from_slice::<DirManifest>(&bytes) {
+        Ok(manifest) => manifest,
+        Err(err) => {
+            context.log_message(
+                &format!("Failed to parse manifest, treating as empty: {}", err),
+                LogLevel::Warn,
+            );
+            DirManifest::default()
+        }
+    }
+}
+
+/// Whether a file changed between two manifest entries, preferring the strongest
+/// signal available: content hash, then ETag, then size/mtime as a last resort.
+fn entry_changed(previous: &ManifestEntry, current: &ManifestEntry) -> bool {
+    if let (Some(old), Some(new)) = (&previous.hash, &current.hash) {
+        return old != new;
+    }
+    if let (Some(old), Some(new)) = (&previous.e_tag, &current.e_tag) {
+        return old != new;
+    }
+    previous.size != current.size || previous.last_modified != current.last_modified
+}
+
+/// An ETag we can rely on for change detection: present, non-empty, and not a
+/// weak validator (`W/"…"`), which does not guarantee byte-level equality.
+fn etag_trustworthy(e_tag: &Option<String>) -> bool {
+    match e_tag {
+        Some(tag) => !tag.is_empty() && !tag.starts_with("W/"),
+        None => false,
+    }
+}

--- a/packages/catalog/data/src/data/path/operations/changed/get_changes.rs
+++ b/packages/catalog/data/src/data/path/operations/changed/get_changes.rs
@@ -8,7 +8,7 @@ use flow_like::flow::{
 };
 use flow_like_types::{Error, async_trait, json::json};
 use futures::{StreamExt, stream};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 /// Bounded parallelism when Blake3-hashing file bodies (Checksum mode / weak ETags).
 const HASH_CONCURRENCY: usize = 16;
@@ -29,7 +29,7 @@ impl NodeLogic for GetChangesNode {
         let mut node = Node::new(
             "path_get_changes",
             "Diff Directory",
-            "Diffs a folder against a manifest, emitting added, updated and deleted files without rehashing unchanged content (ETag-based)",
+            "Diffs a folder against a manifest, emitting added, updated and deleted files. Auto mode trusts store ETags (hashing only weak/missing ones); Checksum mode always Blake3-hashes contents",
             "Data/Files/Operations",
         );
         node.add_icon("/flow/icons/path.svg");
@@ -145,12 +145,25 @@ impl NodeLogic for GetChangesNode {
         let mode: String = context.evaluate_pin("mode").await?;
         let checksum = mode.eq_ignore_ascii_case("checksum");
 
-        let previous_manifest = load_manifest(&manifest_path, context).await;
-        let mut previous: HashMap<String, ManifestEntry> = previous_manifest
-            .entries
-            .into_iter()
-            .map(|entry| (entry.path.clone(), entry))
-            .collect();
+        let previous_manifest = load_manifest(&manifest_path, context).await?;
+        // Only diff against a manifest taken with the same scan scope; otherwise
+        // out-of-scope files would be reported as deleted (a data-loss footgun if
+        // the `deleted` pin drives a delete node).
+        let scope_matches =
+            previous_manifest.entries.is_empty() || previous_manifest.recursive == recursive;
+        let mut previous: HashMap<String, ManifestEntry> = if scope_matches {
+            previous_manifest
+                .entries
+                .into_iter()
+                .map(|entry| (entry.path.clone(), entry))
+                .collect()
+        } else {
+            context.log_message(
+                "Manifest scan scope (recursive) changed; treating all files as new to avoid false deletions",
+                LogLevel::Warn,
+            );
+            HashMap::new()
+        };
 
         let runtime = root.to_runtime(context).await?;
         let store = runtime.store.clone();
@@ -171,10 +184,15 @@ impl NodeLogic for GetChangesNode {
                 .objects
         };
 
-        // Skip the manifest file itself when it lives inside the scanned root.
+        // Skip the manifest file itself only when it lives in the same store as the
+        // scanned root; an identical path in a different store is a real file. Compare
+        // normalized object-store paths so a stray leading/trailing slash never leaks
+        // the manifest back into the scan as phantom churn.
+        let same_store = root.store_ref == manifest_path.store_ref;
+        let manifest_key = flow_like_storage::Path::from(manifest_path.path.as_str());
         let candidates: Vec<_> = objects
             .into_iter()
-            .filter(|object| object.location.as_ref() != manifest_path.path)
+            .filter(|object| !same_store || object.location != manifest_key)
             .collect();
 
         // Only read file bodies when we cannot trust the ETag: Checksum mode, or
@@ -191,6 +209,7 @@ impl NodeLogic for GetChangesNode {
             .collect();
 
         let mut hashes: HashMap<String, String> = HashMap::with_capacity(to_hash.len());
+        let mut hash_failed: HashSet<String> = HashSet::new();
         if !to_hash.is_empty() {
             let results: Vec<(String, flow_like_types::Result<String>)> = stream::iter(to_hash)
                 .map(|(key, location)| {
@@ -206,8 +225,13 @@ impl NodeLogic for GetChangesNode {
                     Ok(hash) => {
                         hashes.insert(key, hash);
                     }
-                    Err(err) => context
-                        .log_message(&format!("Failed to hash {}: {}", key, err), LogLevel::Warn),
+                    Err(err) => {
+                        context.log_message(
+                            &format!("Failed to hash {}: {}", key, err),
+                            LogLevel::Warn,
+                        );
+                        hash_failed.insert(key);
+                    }
                 }
             }
         }
@@ -226,9 +250,15 @@ impl NodeLogic for GetChangesNode {
                 last_modified: object.last_modified.to_string(),
             };
 
+            // A file selected for hashing whose read failed must never be reported as
+            // unchanged: treat it as changed rather than falling back to size/mtime,
+            // which can miss same-size same-mtime edits (the case Checksum mode and
+            // weak-ETag hashing exist to catch).
             let flow_path = root.with_path(&key);
             match previous.remove(&key) {
-                Some(prev) if entry_changed(&prev, &entry) => updated.push(flow_path),
+                Some(prev) if hash_failed.contains(&key) || entry_changed(&prev, &entry) => {
+                    updated.push(flow_path)
+                }
                 Some(_) => {}
                 None => added.push(flow_path),
             }
@@ -245,6 +275,7 @@ impl NodeLogic for GetChangesNode {
             manifest: manifest_path,
             manifest_content: DirManifest {
                 version: MANIFEST_VERSION,
+                recursive,
                 entries,
             },
         };
@@ -259,22 +290,44 @@ impl NodeLogic for GetChangesNode {
     }
 }
 
-/// Reads and parses the manifest, tolerating a missing or malformed file by
-/// returning an empty manifest (so every file is reported as added).
-async fn load_manifest(manifest: &FlowPath, context: &mut ExecutionContext) -> DirManifest {
-    let bytes = match manifest.get(context, false).await {
-        Ok(bytes) => bytes,
-        Err(_) => return DirManifest::default(),
-    };
+/// Reads and parses the manifest. A genuinely missing manifest (the store reports
+/// `NotFound`) yields an empty one, so every file is reported as added; malformed
+/// JSON is tolerated the same way with a warning. Any other store error (network,
+/// permission, throttling, …) is propagated instead of silently producing an empty
+/// baseline that would report every file as added.
+async fn load_manifest(
+    manifest: &FlowPath,
+    context: &mut ExecutionContext,
+) -> flow_like_types::Result<DirManifest> {
+    let runtime = manifest.to_runtime(context).await?;
+    match runtime.store.as_generic().head(&runtime.path).await {
+        Ok(_) => {}
+        Err(flow_like_storage::object_store::Error::NotFound { .. }) => {
+            return Ok(DirManifest::default());
+        }
+        Err(err) => return Err(Error::from(err)),
+    }
+
+    let bytes = manifest.get(context, false).await?;
 
     match flow_like_types::json::from_slice::<DirManifest>(&bytes) {
-        Ok(manifest) => manifest,
+        Ok(manifest) if manifest.version <= MANIFEST_VERSION => Ok(manifest),
+        Ok(manifest) => {
+            context.log_message(
+                &format!(
+                    "Manifest version {} is newer than supported {}, treating as empty",
+                    manifest.version, MANIFEST_VERSION
+                ),
+                LogLevel::Warn,
+            );
+            Ok(DirManifest::default())
+        }
         Err(err) => {
             context.log_message(
                 &format!("Failed to parse manifest, treating as empty: {}", err),
                 LogLevel::Warn,
             );
-            DirManifest::default()
+            Ok(DirManifest::default())
         }
     }
 }

--- a/packages/storage/src/files/store.rs
+++ b/packages/storage/src/files/store.rs
@@ -166,24 +166,27 @@ impl FlowLikeStore {
     }
 
     pub async fn hash(&self, path: &Path) -> Result<String> {
-        let store = self.as_generic();
-        let meta = store.head(path).await?;
+        let meta = self.as_generic().head(path).await?;
 
         if let Some(hash) = meta.e_tag {
             return Ok(hash);
         }
 
-        let mut hash = blake3::Hasher::new();
+        self.content_hash(path).await
+    }
+
+    /// Blake3 hash of the object's bytes, always reading the body regardless of
+    /// any ETag. Blake3 is chosen over SHA for throughput on large files.
+    pub async fn content_hash(&self, path: &Path) -> Result<String> {
+        let store = self.as_generic();
+        let mut hasher = blake3::Hasher::new();
         let mut reader = store.get(path).await?.into_stream();
 
         while let Some(data) = reader.next().await {
-            let data = data?;
-            hash.update(&data);
+            hasher.update(&data?);
         }
 
-        let finalized = hash.finalize();
-        let finalized = finalized.to_hex().to_lowercase().to_string();
-        Ok(finalized)
+        Ok(hasher.finalize().to_hex().to_lowercase().to_string())
     }
 
     pub async fn put(&self, path: &Path, data: impl Into<object_store::PutPayload>) -> Result<()> {


### PR DESCRIPTION
This pull request introduces a new directory change detection system for the data path operations, enabling efficient diffing of folder contents and manifest management. It adds new manifest types, nodes for diffing and persisting directory state, and supporting logic for reliable and performant file change tracking.

**Directory Change Detection and Manifest Management:**

* Added new manifest data structures (`ManifestEntry`, `DirManifest`, and `DirDiffSession`) to track and persist the state of files in a directory, supporting both ETag and content hash-based change detection.

* Implemented the `GetChangesNode` ("Diff Directory") node, which diffs a folder against a manifest, efficiently detecting added, updated, and deleted files without rehashing unchanged content, and outputs a session for manifest persistence.

* Implemented the `WriteManifestNode` ("Write Directory Manifest") node, which persists the manifest produced by the diff session, enabling subsequent diffs to see the current state.

**Supporting API and Utility Additions:**

* Added `FlowPath::with_path` to easily clone a path with a new file location within the same store/cache layer.

* Improved file hashing logic in `FlowLikeStore` by introducing a dedicated `content_hash` method that always computes a Blake3 hash of the file's contents, regardless of ETag, for robust change detection.