### PR TITLE
feat: update MiniMax provider models and regions

### DIFF
--- a/packages/catalog/llm/src/llm/provider/build_minimax.rs
+++ b/packages/catalog/llm/src/llm/provider/build_minimax.rs
@@ -15,6 +15,31 @@ use flow_like_types::{
     json::{json, to_value},
 };
 
+const GLOBAL_REGION: &str = "Global";
+const CHINA_REGION: &str = "China";
+const GLOBAL_ENDPOINT: &str = "https://api.minimax.io/v1";
+const CHINA_ENDPOINT: &str = "https://api.minimaxi.com/v1";
+const DEFAULT_MODEL_ID: &str = "MiniMax-M3";
+const SUPPORTED_MODEL_IDS: [&str; 2] = [DEFAULT_MODEL_ID, "MiniMax-M2.7"];
+
+fn endpoint_for_region(region: &str) -> &'static str {
+    match region {
+        CHINA_REGION => CHINA_ENDPOINT,
+        _ => GLOBAL_ENDPOINT,
+    }
+}
+
+fn context_length_for_model(model_id: &str) -> u32 {
+    match model_id {
+        "MiniMax-M2.7" => 204_800,
+        _ => 1_000_000,
+    }
+}
+
+fn is_multimodal_model(model_id: &str) -> bool {
+    model_id == DEFAULT_MODEL_ID
+}
+
 #[crate::register_node]
 #[derive(Default)]
 pub struct BuildMiniMaxNode {}
@@ -31,11 +56,11 @@ impl NodeLogic for BuildMiniMaxNode {
         let mut node = Node::new(
             "ai_generative_build_minimax",
             "MiniMax Model",
-            "Prepares a Bit for MiniMax's OpenAI-compatible API using the provided credentials",
+            "Prepares a Bit for the MiniMax API using the provided credentials",
             "AI/Generative/Provider",
         );
         node.add_icon("/flow/icons/find_model.svg");
-        node.set_version(1);
+        node.set_version(2);
 
         node.set_scores(
             NodeScores::new()
@@ -56,12 +81,25 @@ impl NodeLogic for BuildMiniMaxNode {
         );
 
         node.add_input_pin(
-            "endpoint",
-            "Endpoint",
-            "MiniMax OpenAI-compatible base URL (override only for a proxy)",
+            "region",
+            "Region",
+            "MiniMax API region used when no custom endpoint is provided",
             VariableType::String,
         )
-        .set_default_value(Some(json!("https://api.minimax.io/v1")));
+        .set_default_value(Some(json!(GLOBAL_REGION)))
+        .set_options(
+            PinOptions::new()
+                .set_valid_values(vec![GLOBAL_REGION.into(), CHINA_REGION.into()])
+                .build(),
+        );
+
+        node.add_input_pin(
+            "endpoint",
+            "Endpoint",
+            "Optional MiniMax API base URL override for a proxy",
+            VariableType::String,
+        )
+        .set_default_value(Some(json!("")));
 
         node.add_input_pin(
             "api_key",
@@ -78,7 +116,17 @@ impl NodeLogic for BuildMiniMaxNode {
             "MiniMax model identifier to request",
             VariableType::String,
         )
-        .set_default_value(Some(json!("MiniMax-M3")));
+        .set_default_value(Some(json!(DEFAULT_MODEL_ID)))
+        .set_options(
+            PinOptions::new()
+                .set_valid_values(
+                    SUPPORTED_MODEL_IDS
+                        .iter()
+                        .map(|value| (*value).into())
+                        .collect(),
+                )
+                .build(),
+        );
 
         node.add_output_pin(
             "exec_out",
@@ -106,8 +154,14 @@ impl NodeLogic for BuildMiniMaxNode {
         hasher.update(b"minimax");
 
         let api_key = context.evaluate_pin::<String>("api_key").await?;
-        let endpoint = context.evaluate_pin::<String>("endpoint").await?;
+        let region = context.evaluate_pin::<String>("region").await?;
+        let endpoint_override = context.evaluate_pin::<String>("endpoint").await?;
         let model_id = context.evaluate_pin::<String>("model_id").await?;
+        let endpoint = if endpoint_override.trim().is_empty() {
+            endpoint_for_region(&region).to_string()
+        } else {
+            endpoint_override
+        };
 
         let mut params = HashMap::new();
         params.insert("api_key".to_string(), json!(api_key));
@@ -122,15 +176,12 @@ impl NodeLogic for BuildMiniMaxNode {
 
         let bit_hash = hasher.finalize().to_hex().to_string();
 
-        // MiniMax is OpenAI-compatible, so it reuses the existing
-        // `custom:openai` model path (honors the `endpoint` / `api_key` /
-        // `model_id` params) — no new model client is required.
         let params_obj = VLMParameters {
-            context_length: 20000,
+            context_length: context_length_for_model(&model_id),
             model_classification: BitModelClassification::default(),
             provider: flow_like_model_provider::provider::ModelProvider {
                 provider_name: "custom:openai".into(),
-                model_id: Some(model_id),
+                model_id: Some(model_id.clone()),
                 version: None,
                 params: Some(params),
             },
@@ -139,7 +190,11 @@ impl NodeLogic for BuildMiniMaxNode {
 
         let mut bit = Bit::default();
         bit.id = bit_hash;
-        bit.bit_type = flow_like::bit::BitTypes::Vlm;
+        bit.bit_type = if is_multimodal_model(&model_id) {
+            flow_like::bit::BitTypes::Vlm
+        } else {
+            flow_like::bit::BitTypes::Llm
+        };
         bit.parameters = params;
 
         context
@@ -149,5 +204,48 @@ impl NodeLogic for BuildMiniMaxNode {
         context.activate_exec_pin("exec_out").await?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exposes_current_models_and_regions() {
+        let node = BuildMiniMaxNode::new().get_node();
+        let region = node.get_pin_by_name("region").expect("region pin");
+        let endpoint = node.get_pin_by_name("endpoint").expect("endpoint pin");
+        let model = node.get_pin_by_name("model_id").expect("model pin");
+
+        assert_eq!(node.version, Some(2));
+        assert_eq!(
+            region
+                .options
+                .as_ref()
+                .and_then(|options| options.valid_values.as_ref()),
+            Some(&vec![GLOBAL_REGION.into(), CHINA_REGION.into()])
+        );
+        assert_eq!(
+            endpoint.default_value,
+            Some(flow_like_types::json::to_vec(&json!("")).expect("endpoint default"))
+        );
+        assert_eq!(
+            model
+                .options
+                .as_ref()
+                .and_then(|options| options.valid_values.as_ref()),
+            Some(&SUPPORTED_MODEL_IDS.map(String::from).to_vec())
+        );
+    }
+
+    #[test]
+    fn maps_model_and_region_metadata() {
+        assert_eq!(endpoint_for_region(GLOBAL_REGION), GLOBAL_ENDPOINT);
+        assert_eq!(endpoint_for_region(CHINA_REGION), CHINA_ENDPOINT);
+        assert_eq!(context_length_for_model(DEFAULT_MODEL_ID), 1_000_000);
+        assert_eq!(context_length_for_model("MiniMax-M2.7"), 204_800);
+        assert!(is_multimodal_model(DEFAULT_MODEL_ID));
+        assert!(!is_multimodal_model("MiniMax-M2.7"));
     }
 }


### PR DESCRIPTION
Reason: Update the MiniMax provider node with current model and regional endpoint metadata.

- Adds Global and China endpoint selection while preserving custom endpoint overrides.
- Exposes MiniMax-M3 and MiniMax-M2.7 with model-specific context limits and modality.
- Bumps the node schema version and adds provider metadata tests.

Checks:
- `cargo fmt --package flow-like-catalog-llm -- --check`
- `cargo test --package flow-like-catalog-llm build_minimax --lib`