### PR TITLE
refactor: remove sysinfo dependency and simplify tray functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8394,7 +8394,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serenity",
- "sysinfo 0.37.2",
  "tauri",
  "tauri-build",
  "tauri-plugin",

--- a/apps/desktop/components/rpa/recording-dock.tsx
+++ b/apps/desktop/components/rpa/recording-dock.tsx
@@ -209,6 +209,25 @@ export function RecordingDock({
 		}
 	}, []);
 
+	// Finalize the session when the user stops recording from the tray
+	useEffect(() => {
+		if (!isRecordingMode) return;
+
+		let unlisten: UnlistenFn | null = null;
+
+		const setupListener = async () => {
+			unlisten = await listen("recording:stop-from-tray", () => {
+				stopRecording();
+			});
+		};
+
+		setupListener();
+
+		return () => {
+			unlisten?.();
+		};
+	}, [isRecordingMode, stopRecording]);
+
 	// Keyboard shortcut listener for stop recording
 	useEffect(() => {
 		if (!isRecordingMode) return;

--- a/apps/desktop/components/rpa/recording-dock.tsx
+++ b/apps/desktop/components/rpa/recording-dock.tsx
@@ -1,8 +1,5 @@
 "use client";
 
-import { invoke } from "@tauri-apps/api/core";
-import { type UnlistenFn, listen } from "@tauri-apps/api/event";
-import { getCurrentWindow } from "@tauri-apps/api/window";
 import {
 	Badge,
 	Button,
@@ -15,6 +12,9 @@ import {
 	TooltipTrigger,
 	cn,
 } from "@flow-like/flow-like-ui";
+import { invoke } from "@tauri-apps/api/core";
+import { type UnlistenFn, listen } from "@tauri-apps/api/event";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import { AnimatePresence, motion } from "framer-motion";
 import {
 	AlertCircle,
@@ -142,17 +142,21 @@ export function RecordingDock({
 	const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
 	useEffect(() => {
+		let cancelled = false;
 		let unlisten: UnlistenFn | null = null;
 
 		const setupListener = async () => {
-			unlisten = await listen<RecordedAction>("recording:action", (event) => {
+			const stop = await listen<RecordedAction>("recording:action", (event) => {
 				setActions((prev) => [...prev, event.payload]);
 			});
+			if (cancelled) stop();
+			else unlisten = stop;
 		};
 
 		setupListener();
 
 		return () => {
+			cancelled = true;
 			unlisten?.();
 		};
 	}, []);
@@ -213,17 +217,21 @@ export function RecordingDock({
 	useEffect(() => {
 		if (!isRecordingMode) return;
 
+		let cancelled = false;
 		let unlisten: UnlistenFn | null = null;
 
 		const setupListener = async () => {
-			unlisten = await listen("recording:stop-from-tray", () => {
+			const stop = await listen("recording:stop-from-tray", () => {
 				stopRecording();
 			});
+			if (cancelled) stop();
+			else unlisten = stop;
 		};
 
 		setupListener();
 
 		return () => {
+			cancelled = true;
 			unlisten?.();
 		};
 	}, [isRecordingMode, stopRecording]);

--- a/apps/desktop/components/tray-provider.tsx
+++ b/apps/desktop/components/tray-provider.tsx
@@ -7,6 +7,7 @@ import { listen } from "@tauri-apps/api/event";
 import { check } from "@tauri-apps/plugin-updater";
 import { useRouter } from "next/navigation";
 import { useEffect, useMemo } from "react";
+import { TauriBackend } from "./tauri-provider";
 
 interface TraySyncStatus {
 	status: string;
@@ -54,19 +55,23 @@ const TrayProvider: React.FC = () => {
 
 		const updateTrayMeta = async () => {
 			try {
-				const [overview, userInfo] = await Promise.all([
-					backend.userState.getNotifications().catch(() => null),
-					backend.userState.getInfo().catch(() => null),
-				]);
+				const overview = await backend.userState
+					.getNotifications()
+					.catch(() => null);
 
 				if (!mounted) return;
 
 				// Only report facts we positively know: a failed fetch must not
-				// flip the tray to signed-out/zero-unread (offline is a normal
-				// state for a signed-in user).
+				// flip the tray to zero-unread (offline is a normal state for a
+				// signed-in user). Auth state comes from the local OIDC context,
+				// not from network-call success, so it also resets on sign-out.
 				const update: TrayUpdate = {};
 				if (overview) update.unreadCount = overview.unread_count ?? 0;
-				if (userInfo) update.signedIn = true;
+				if (backend instanceof TauriBackend) {
+					update.signedIn = Boolean(
+						backend.auth?.isAuthenticated && backend.auth?.user?.access_token,
+					);
+				}
 				if (Object.keys(update).length > 0) await pushTrayUpdate(update);
 			} catch {
 				// Backend not ready yet (fallback state throws synchronously)

--- a/apps/desktop/components/tray-provider.tsx
+++ b/apps/desktop/components/tray-provider.tsx
@@ -1,27 +1,16 @@
 "use client";
 
+import { useBackend, useNetworkStatus } from "@flow-like/flow-like-ui";
+import { useSpotlightStore } from "@flow-like/flow-like-ui/state/spotlight-state";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { check } from "@tauri-apps/plugin-updater";
-import { useBackend, useNetworkStatus } from "@flow-like/flow-like-ui";
-import { useSpotlightStore } from "@flow-like/flow-like-ui/state/spotlight-state";
+import { useRouter } from "next/navigation";
 import { useEffect, useMemo } from "react";
-
-interface TrayNotification {
-	id: string;
-	title: string;
-	read: boolean;
-	createdAt?: string;
-}
 
 interface TraySyncStatus {
 	status: string;
 	detail?: string;
-}
-
-interface TrayAccountState {
-	label: string;
-	tier?: string;
 }
 
 interface TrayUpdateState {
@@ -29,16 +18,24 @@ interface TrayUpdateState {
 }
 
 interface TrayUpdate {
-	notifications?: TrayNotification[];
 	unreadCount?: number;
 	syncStatus?: TraySyncStatus;
 	updateState?: TrayUpdateState;
-	accountState?: TrayAccountState;
+	signedIn?: boolean;
 }
+
+const NOTIFICATION_POLL_INTERVAL = 60_000;
+const UPDATE_CHECK_INTERVAL = 30 * 60_000;
+
+const pushTrayUpdate = (update: TrayUpdate) =>
+	invoke("tray_update_state", { update }).catch((error) =>
+		console.warn("Failed to update tray state", error),
+	);
 
 const TrayProvider: React.FC = () => {
 	const backend = useBackend();
 	const isOnline = useNetworkStatus();
+	const router = useRouter();
 
 	const syncStatus = useMemo<TraySyncStatus>(
 		() => ({
@@ -49,74 +46,68 @@ const TrayProvider: React.FC = () => {
 	);
 
 	useEffect(() => {
-		invoke("tray_update_state", {
-			update: {
-				syncStatus,
-			},
-		}).catch((error) =>
-			console.warn("Failed to update tray sync status", error),
-		);
+		pushTrayUpdate({ syncStatus });
 	}, [syncStatus]);
 
 	useEffect(() => {
 		let mounted = true;
-		let intervalId: NodeJS.Timeout | undefined;
 
 		const updateTrayMeta = async () => {
 			try {
-				const [overview, notifications, userInfo, updateAvailable] =
-					await Promise.all([
-						backend.userState.getNotifications().catch(() => null),
-						backend.userState.listNotifications(false, 0, 5).catch(() => []),
-						backend.userState.getInfo().catch(() => null),
-						check().catch(() => null),
-					]);
+				const [overview, userInfo] = await Promise.all([
+					backend.userState.getNotifications().catch(() => null),
+					backend.userState.getInfo().catch(() => null),
+				]);
 
 				if (!mounted) return;
 
-				const trayNotifications = notifications.map((notification) => ({
-					id: notification.id,
-					title: notification.title,
-					read: notification.read,
-					createdAt: notification.created_at,
-				}));
-
-				const accountState: TrayAccountState = {
-					label:
-						userInfo?.name ??
-						userInfo?.email ??
-						userInfo?.username ??
-						"Signed out",
-					tier: userInfo?.tier ?? userInfo?.status ?? undefined,
-				};
-
-				const updateState: TrayUpdateState = {
-					available: Boolean(updateAvailable),
-				};
-
-				await invoke("tray_update_state", {
-					update: {
-						notifications: trayNotifications,
-						unreadCount: overview?.unread_count ?? 0,
-						accountState,
-						updateState,
-					},
-				});
-			} catch (error) {
-				console.warn("Failed to update tray metadata", error);
+				// Only report facts we positively know: a failed fetch must not
+				// flip the tray to signed-out/zero-unread (offline is a normal
+				// state for a signed-in user).
+				const update: TrayUpdate = {};
+				if (overview) update.unreadCount = overview.unread_count ?? 0;
+				if (userInfo) update.signedIn = true;
+				if (Object.keys(update).length > 0) await pushTrayUpdate(update);
+			} catch {
+				// Backend not ready yet (fallback state throws synchronously)
 			}
 		};
 
 		updateTrayMeta();
-		intervalId = setInterval(updateTrayMeta, 60000);
+		const intervalId = setInterval(updateTrayMeta, NOTIFICATION_POLL_INTERVAL);
 
 		return () => {
 			mounted = false;
-			if (intervalId) clearInterval(intervalId);
+			clearInterval(intervalId);
 		};
 	}, [backend]);
 
 	useEffect(() => {
+		let mounted = true;
+
+		const checkForUpdate = async () => {
+			try {
+				const update = await check();
+				if (!mounted) return;
+				await pushTrayUpdate({ updateState: { available: Boolean(update) } });
+			} catch {
+				// Keep the last known update state on transient check failures
+			}
+		};
+
+		checkForUpdate();
+		const intervalId = setInterval(checkForUpdate, UPDATE_CHECK_INTERVAL);
+
+		return () => {
+			mounted = false;
+			clearInterval(intervalId);
+		};
+	}, []);
+
+	useEffect(() => {
+		const unlistenNavigate = listen<string>("tray:navigate", (event) => {
+			if (typeof event.payload === "string") router.push(event.payload);
+		});
 		const unlistenOpenSpotlight = listen("tray:open-spotlight", () => {
 			useSpotlightStore.getState().open();
 		});
@@ -131,19 +122,18 @@ const TrayProvider: React.FC = () => {
 		});
 
 		return () => {
-			Promise.all([
+			Promise.allSettled([
+				unlistenNavigate,
 				unlistenOpenSpotlight,
 				unlistenQuickCreate,
 				unlistenUpdate,
-			])
-				.then((unlisteners) => {
-					for (const unlisten of unlisteners) {
-						unlisten();
-					}
-				})
-				.catch(() => undefined);
+			]).then((results) => {
+				for (const result of results) {
+					if (result.status === "fulfilled") result.value();
+				}
+			});
 		};
-	}, []);
+	}, [router]);
 
 	return null;
 };

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -91,7 +91,6 @@ axum = { version = "0.8.6", features = ["multipart"] }
 tower = "0.5.2"
 chrono-tz.workspace = true
 mimalloc.workspace = true
-sysinfo = "0.37.2"
 
 blake3.workspace = true
 tauri-plugin-flow-like-dexie-blob-offload.workspace = true

--- a/apps/desktop/src-tauri/src/event_bus.rs
+++ b/apps/desktop/src-tauri/src/event_bus.rs
@@ -168,6 +168,7 @@ impl EventBusEvent {
         let cancellation_token = CancellationToken::new();
         let board_name = internal_run.board.name.clone();
         let run_data = RunData::with_metadata(
+            Some(self.app_id.clone()),
             &board_id,
             &payload.id,
             Some(self.event_id.clone()),

--- a/apps/desktop/src-tauri/src/functions/flow/run.rs
+++ b/apps/desktop/src-tauri/src/functions/flow/run.rs
@@ -346,6 +346,7 @@ async fn execute_internal(
 
     let board_name = internal_run.board.name.clone();
     let run_data = RunData::with_metadata(
+        Some(app_id.clone()),
         &board_id,
         &payload.id,
         None,

--- a/apps/desktop/src-tauri/src/functions/recording/mod.rs
+++ b/apps/desktop/src-tauri/src/functions/recording/mod.rs
@@ -177,10 +177,23 @@ pub async fn resume_recording(handler: AppHandle) -> Result<(), TauriFunctionErr
 
 #[tauri::command(async)]
 pub async fn stop_recording(handler: AppHandle) -> Result<Vec<RecordedAction>, TauriFunctionError> {
+    let result = stop_recording_inner(&handler).await;
+
+    // Restore the tray even when stopping fails — otherwise the recording
+    // icon sticks and left-click stays detached from the menu.
+    #[cfg(desktop)]
+    crate::tray::restore_tray_icon(&handler).await;
+
+    result
+}
+
+async fn stop_recording_inner(
+    handler: &AppHandle,
+) -> Result<Vec<RecordedAction>, TauriFunctionError> {
     tracing::debug!(" ========== STOP RECORDING CALLED ==========");
     tracing::info!("[Recording] stop_recording called");
 
-    let recording_state = RecordingState::construct(&handler).await?;
+    let recording_state = RecordingState::construct(handler).await?;
 
     // First, deactivate the capture (stops recording new events)
     {
@@ -256,9 +269,6 @@ pub async fn stop_recording(handler: AppHandle) -> Result<Vec<RecordedAction>, T
         *capture_guard = None;
     }
     tracing::debug!(" ========== STOP RECORDING COMPLETE ==========");
-
-    #[cfg(desktop)]
-    crate::tray::restore_tray_icon(&handler).await;
 
     Ok(actions)
 }

--- a/apps/desktop/src-tauri/src/tray.rs
+++ b/apps/desktop/src-tauri/src/tray.rs
@@ -2,12 +2,9 @@ use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
 use flow_like_types::tokio::time::sleep;
-use sysinfo::{MemoryRefreshKind, RefreshKind, System};
-use tauri::menu::{
-    CheckMenuItem, IsMenuItem, Menu, MenuEvent, MenuItem, PredefinedMenuItem, Submenu,
-};
+use tauri::menu::{IsMenuItem, Menu, MenuEvent, MenuItem, PredefinedMenuItem};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
-use tauri::{AppHandle, Emitter, Manager};
+use tauri::{AppHandle, Emitter, Manager, Wry};
 use tauri_plugin_opener::OpenerExt;
 
 use crate::functions::TauriFunctionError;
@@ -16,43 +13,31 @@ use crate::state::{TauriFlowLikeState, TauriSettingsState, TauriTrayState};
 const TRAY_ID: &str = "flow_like_tray";
 
 const MENU_OPEN: &str = "tray_open";
-const MENU_OPEN_NOTIFICATIONS: &str = "tray_open_notifications";
+const MENU_STOP_RECORDING: &str = "tray_stop_recording";
+const MENU_STOP_ALL_RUNS: &str = "tray_stop_all_runs";
+const MENU_VIEW_FAILURES: &str = "tray_view_failures";
+const MENU_RESTART_UPDATE: &str = "tray_restart_update";
 const MENU_NEW_FLOW: &str = "tray_new_flow";
 const MENU_OPEN_RECENT: &str = "tray_open_recent";
 const MENU_SEARCH_FLOWS: &str = "tray_search_flows";
-const MENU_TOGGLE_THROTTLE: &str = "tray_toggle_throttle";
-const MENU_TOGGLE_DEBUG: &str = "tray_toggle_debug";
-const MENU_RESTART_UPDATE: &str = "tray_restart_update";
+const MENU_OPEN_NOTIFICATIONS: &str = "tray_open_notifications";
+const MENU_ACCOUNT: &str = "tray_account";
 const MENU_OPEN_LOGS: &str = "tray_open_logs";
-const MENU_MANAGE_ACCOUNT: &str = "tray_manage_account";
 const MENU_REPORT_ISSUE: &str = "tray_report_issue";
 const MENU_QUIT: &str = "tray_quit";
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
-pub enum TrayRunStatus {
-    Running,
-    Failed,
-    Succeeded,
-}
+const RUN_MENU_PREFIX: &str = "tray_run:";
 
-impl TrayRunStatus {
-    fn label(&self) -> &'static str {
-        match self {
-            TrayRunStatus::Running => "Running",
-            TrayRunStatus::Failed => "Failed",
-            TrayRunStatus::Succeeded => "Succeeded",
-        }
-    }
-}
+/// Native menus cannot scroll gracefully; keep the run list short.
+const MAX_RUN_ROWS: usize = 5;
+const STALLED_THRESHOLD_MS: u64 = 60_000;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone)]
 pub struct TrayRun {
     pub run_id: String,
+    pub app_id: Option<String>,
     pub board_id: String,
     pub node_id: String,
-    pub status: TrayRunStatus,
     pub elapsed_ms: Option<u64>,
     pub board_name: Option<String>,
     pub event_name: Option<String>,
@@ -61,84 +46,48 @@ pub struct TrayRun {
     pub last_node_update_ms: u64,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub struct TrayNotification {
-    pub id: String,
-    pub title: String,
-    pub read: bool,
-    pub created_at: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TraySyncStatus {
     pub status: String,
     pub detail: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub struct TrayResourceUsage {
-    pub cpu_percent: u32, // Use integer for reliable PartialEq
-    pub ram_used_mb: u64,
-    pub ram_total_mb: u64,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TrayFailure {
     pub id: String,
     pub title: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub struct TrayAccountState {
-    pub label: String,
-    pub tier: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct TrayUpdateState {
     pub available: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone)]
 pub struct TrayData {
     pub active_runs: Vec<TrayRun>,
-    pub notifications: Vec<TrayNotification>,
     pub unread_count: u64,
     pub sync_status: TraySyncStatus,
-    pub resource_usage: TrayResourceUsage,
-    pub throttling_enabled: bool,
     pub update_state: TrayUpdateState,
     pub background_failures: Vec<TrayFailure>,
-    pub account_state: TrayAccountState,
-    pub debug_enabled: bool,
+    pub signed_in: bool,
 }
 
 impl Default for TrayData {
     fn default() -> Self {
         Self {
             active_runs: Vec::new(),
-            notifications: Vec::new(),
             unread_count: 0,
             sync_status: TraySyncStatus {
                 status: "Unknown".to_string(),
                 detail: None,
             },
-            resource_usage: TrayResourceUsage::default(),
-            throttling_enabled: false,
-            update_state: TrayUpdateState { available: false },
+            update_state: TrayUpdateState::default(),
             background_failures: Vec::new(),
-            account_state: TrayAccountState {
-                label: "Signed out".to_string(),
-                tier: None,
-            },
-            debug_enabled: false,
+            signed_in: false,
         }
     }
 }
@@ -146,14 +95,33 @@ impl Default for TrayData {
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct TrayUpdate {
-    pub notifications: Option<Vec<TrayNotification>>,
     pub unread_count: Option<u64>,
     pub sync_status: Option<TraySyncStatus>,
-    pub throttling_enabled: Option<bool>,
     pub update_state: Option<TrayUpdateState>,
     pub background_failures: Option<Vec<TrayFailure>>,
-    pub account_state: Option<TrayAccountState>,
-    pub debug_enabled: Option<bool>,
+    pub signed_in: Option<bool>,
+}
+
+/// Menu rows that only exist for certain states. When this changes the menu
+/// must be rebuilt via `set_menu` (which dismisses an open menu on macOS —
+/// acceptable for rare, discrete transitions). Everything else is updated
+/// in place on retained item handles, which never dismisses the menu.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TrayMenuSignature {
+    recording: bool,
+    run_ids: Vec<String>,
+    has_failures: bool,
+    sync_degraded: bool,
+    update_available: bool,
+}
+
+struct TrayMenuHandles {
+    signature: TrayMenuSignature,
+    run_items: Vec<(String, MenuItem<Wry>, String)>,
+    failures_item: Option<(MenuItem<Wry>, String)>,
+    sync_item: Option<(MenuItem<Wry>, String)>,
+    notifications_item: (MenuItem<Wry>, String),
+    account_item: (MenuItem<Wry>, String),
 }
 
 #[derive(Default)]
@@ -161,12 +129,17 @@ pub struct TrayRuntimeState {
     pub tray: Option<tauri::tray::TrayIcon>,
     pub data: TrayData,
     pub recording: bool,
+    handles: Option<TrayMenuHandles>,
 }
 
 pub fn init_tray(app_handle: &AppHandle) -> tauri::Result<()> {
-    let menu = build_tray_menu(app_handle, &TrayData::default())?;
+    let data = TrayData::default();
+    let signature = menu_signature(&data, false);
+    let (menu, handles) = build_tray_menu(app_handle, &data, false, signature)?;
+
     let mut builder = TrayIconBuilder::with_id(TRAY_ID)
         .menu(&menu)
+        .show_menu_on_left_click(true)
         .tooltip("Flow-Like")
         .on_menu_event(|app: &AppHandle, event: MenuEvent| {
             handle_menu_event(app, event.id().as_ref());
@@ -187,22 +160,7 @@ pub fn init_tray(app_handle: &AppHandle) -> tauri::Result<()> {
                     };
 
                     if is_recording {
-                        // Deactivate capture immediately so the tray click isn't recorded
-                        if let Some(rec_state) =
-                            app.try_state::<crate::state::TauriRecordingState>()
-                        {
-                            let capture = rec_state.capture.read().await;
-                            if let Some(c) = capture.as_ref() {
-                                c.set_active(false);
-                            }
-                        }
-                        let _ = app.emit("recording:stop-from-tray", ());
-                        restore_tray_icon(&app).await;
-                        if let Some(main) = app.get_webview_window("main") {
-                            let _ = main.show();
-                            let _ = main.unminimize();
-                            let _ = main.set_focus();
-                        }
+                        stop_recording_from_tray(&app).await;
                     } else if let Some(main) = app.get_webview_window("main") {
                         let _ = main.show();
                         let _ = main.set_focus();
@@ -218,11 +176,10 @@ pub fn init_tray(app_handle: &AppHandle) -> tauri::Result<()> {
     let tray = builder.build(app_handle)?;
 
     if let Some(state) = app_handle.try_state::<TauriTrayState>() {
-        let runtime = state.0.clone();
-        tauri::async_runtime::spawn(async move {
-            let mut guard = runtime.lock().await;
-            guard.tray = Some(tray);
-        });
+        let mut guard = state.0.blocking_lock();
+        guard.tray = Some(tray);
+        guard.data = data;
+        guard.handles = Some(handles);
     }
 
     Ok(())
@@ -280,7 +237,12 @@ pub async fn set_recording_tray_icon(app_handle: &AppHandle) {
         let icon = tauri::image::Image::new_owned(rgba, 32, 32);
         let _ = tray.set_icon(Some(icon));
         let _ = tray.set_tooltip(Some("Flow-Like — Recording (click to stop)"));
+        // Let left clicks reach the click handler (stop recording) instead of
+        // opening the menu; macOS/Windows otherwise swallow the click event.
+        let _ = tray.set_show_menu_on_left_click(false);
     }
+
+    let _ = apply_tray_menu(app_handle, &mut guard);
 }
 
 pub async fn restore_tray_icon(app_handle: &AppHandle) {
@@ -295,37 +257,39 @@ pub async fn restore_tray_icon(app_handle: &AppHandle) {
             let _ = tray.set_icon(Some(icon.clone()));
         }
         let _ = tray.set_tooltip(Some("Flow-Like"));
+        let _ = tray.set_show_menu_on_left_click(true);
+    }
+
+    let _ = apply_tray_menu(app_handle, &mut guard);
+}
+
+async fn stop_recording_from_tray(app: &AppHandle) {
+    // Deactivate capture immediately so the tray click isn't recorded
+    if let Some(rec_state) = app.try_state::<crate::state::TauriRecordingState>() {
+        let capture = rec_state.capture.read().await;
+        if let Some(c) = capture.as_ref() {
+            c.set_active(false);
+        }
+    }
+    let _ = app.emit("recording:stop-from-tray", ());
+    restore_tray_icon(app).await;
+    if let Some(main) = app.get_webview_window("main") {
+        let _ = main.show();
+        let _ = main.unminimize();
+        let _ = main.set_focus();
     }
 }
 
 pub fn spawn_tray_refresh(app_handle: AppHandle) {
     tauri::async_runtime::spawn(async move {
-        let mut system = System::new();
-        let refresh_kind = RefreshKind::nothing().with_memory(MemoryRefreshKind::everything());
-
         loop {
-            let active_runs = fetch_active_runs(&app_handle).await.ok();
-
-            system.refresh_specifics(refresh_kind);
-            system.refresh_cpu_usage();
-
-            let cpu_percent = system.global_cpu_usage() as u32;
-            let ram_total_mb = system.total_memory() / 1024;
-            let ram_used_mb = system.used_memory() / 1024;
-
-            let _ = update_tray_data(&app_handle, move |data| {
-                if let Some(runs) = active_runs {
+            if let Ok(runs) = fetch_active_runs(&app_handle).await {
+                let _ = update_tray_data(&app_handle, move |data| {
                     data.active_runs = runs;
-                }
-                data.resource_usage = TrayResourceUsage {
-                    cpu_percent,
-                    ram_used_mb,
-                    ram_total_mb,
-                };
-            })
-            .await;
-
-            sleep(sysinfo::MINIMUM_CPU_UPDATE_INTERVAL.max(Duration::from_secs(5))).await;
+                })
+                .await;
+            }
+            sleep(Duration::from_secs(5)).await;
         }
     });
 }
@@ -333,13 +297,13 @@ pub fn spawn_tray_refresh(app_handle: AppHandle) {
 async fn fetch_active_runs(app_handle: &AppHandle) -> anyhow::Result<Vec<TrayRun>> {
     let state = TauriFlowLikeState::construct(app_handle).await?;
     let runs = state.list_runs()?;
-    let active = runs
+    let mut active: Vec<TrayRun> = runs
         .into_iter()
         .map(|(run_id, run)| TrayRun {
             run_id,
+            app_id: run.app_id.as_ref().map(|s| s.to_string()),
             board_id: run.board_id.to_string(),
             node_id: run.node_id.to_string(),
-            status: TrayRunStatus::Running,
             elapsed_ms: Some(run.elapsed().as_millis() as u64),
             board_name: run.board_name.as_ref().map(|s| s.to_string()),
             event_name: run.event_name.as_ref().map(|s| s.to_string()),
@@ -347,6 +311,9 @@ async fn fetch_active_runs(app_handle: &AppHandle) -> anyhow::Result<Vec<TrayRun
             last_node_update_ms: run.get_last_node_update_ms(),
         })
         .collect();
+    // DashMap iteration order is unstable; sort so identical run sets
+    // produce identical signatures.
+    active.sort_by(|a, b| a.run_id.cmp(&b.run_id));
     Ok(active)
 }
 
@@ -356,17 +323,11 @@ pub async fn tray_update_state(
     update: TrayUpdate,
 ) -> Result<(), TauriFunctionError> {
     update_tray_data(&app_handle, move |data| {
-        if let Some(notifications) = update.notifications {
-            data.notifications = notifications;
-        }
         if let Some(unread_count) = update.unread_count {
             data.unread_count = unread_count;
         }
         if let Some(sync_status) = update.sync_status {
             data.sync_status = sync_status;
-        }
-        if let Some(throttling_enabled) = update.throttling_enabled {
-            data.throttling_enabled = throttling_enabled;
         }
         if let Some(update_state) = update.update_state {
             data.update_state = update_state;
@@ -374,11 +335,8 @@ pub async fn tray_update_state(
         if let Some(background_failures) = update.background_failures {
             data.background_failures = background_failures;
         }
-        if let Some(account_state) = update.account_state {
-            data.account_state = account_state;
-        }
-        if let Some(debug_enabled) = update.debug_enabled {
-            data.debug_enabled = debug_enabled;
+        if let Some(signed_in) = update.signed_in {
+            data.signed_in = signed_in;
         }
     })
     .await
@@ -389,390 +347,375 @@ pub async fn tray_update_state(
 
 async fn update_tray_data<F>(app_handle: &AppHandle, updater: F) -> tauri::Result<()>
 where
-    F: FnOnce(&mut TrayData) + Send + 'static,
+    F: FnOnce(&mut TrayData),
 {
     let Some(state) = app_handle.try_state::<TauriTrayState>() else {
         return Ok(());
     };
 
-    let changed = {
-        let mut guard = state.0.lock().await;
-        let old_data = guard.data.clone();
-        updater(&mut guard.data);
-        old_data != guard.data
-    };
-
-    // Only refresh menu if data actually changed
-    if changed {
-        refresh_tray_menu(app_handle).await
-    } else {
-        Ok(())
-    }
+    let mut guard = state.0.lock().await;
+    updater(&mut guard.data);
+    apply_tray_menu(app_handle, &mut guard)
 }
 
-async fn refresh_tray_menu(app_handle: &AppHandle) -> tauri::Result<()> {
-    let Some(state) = app_handle.try_state::<TauriTrayState>() else {
+/// Reconcile the native menu with `runtime.data`. Structural changes rebuild
+/// the menu; label-only changes mutate retained handles in place so an open
+/// menu is never dismissed (see muda#129/#173 — `set_menu` closes it).
+fn apply_tray_menu(app_handle: &AppHandle, runtime: &mut TrayRuntimeState) -> tauri::Result<()> {
+    let Some(tray) = runtime.tray.clone() else {
         return Ok(());
     };
-    let tray = {
-        let guard = state.0.lock().await;
-        guard.tray.clone()
-    };
 
-    if let Some(tray) = tray {
-        let data = {
-            let guard = state.0.lock().await;
-            guard.data.clone()
-        };
-        let menu = build_tray_menu(app_handle, &data)?;
+    let signature = menu_signature(&runtime.data, runtime.recording);
+    let structure_unchanged = runtime
+        .handles
+        .as_ref()
+        .is_some_and(|handles| handles.signature == signature);
+
+    if structure_unchanged {
+        if let Some(handles) = runtime.handles.as_mut() {
+            update_dynamic_labels(handles, &runtime.data);
+        }
+    } else {
+        let (menu, handles) =
+            build_tray_menu(app_handle, &runtime.data, runtime.recording, signature)?;
         tray.set_menu(Some(menu))?;
+        runtime.handles = Some(handles);
     }
 
     Ok(())
 }
 
-fn build_tray_menu(app_handle: &AppHandle, data: &TrayData) -> tauri::Result<Menu<tauri::Wry>> {
-    let open_item = MenuItem::with_id(app_handle, MENU_OPEN, "Open Flow-Like", true, None::<&str>)?;
-
-    let runs_submenu = build_active_runs_menu(app_handle, data)?;
-    let notifications_submenu = build_notifications_menu(app_handle, data)?;
-    let shortcuts_submenu = build_shortcuts_menu(app_handle)?;
-    let sync_item = MenuItem::new(
-        app_handle,
-        format!("Sync: {}", data.sync_status.status),
-        false,
-        None::<&str>,
-    )?;
-    let resource_submenu = build_resource_menu(app_handle, data)?;
-    let update_submenu = build_update_menu(app_handle, data)?;
-    let failures_submenu = build_failures_menu(app_handle, data)?;
-    let account_submenu = build_account_menu(app_handle, data)?;
-    let diagnostics_submenu = build_diagnostics_menu(app_handle, data)?;
-    let quit_item = MenuItem::with_id(app_handle, MENU_QUIT, "Quit", true, None::<&str>)?;
-
-    Menu::with_items(
-        app_handle,
-        &[
-            &open_item,
-            &PredefinedMenuItem::separator(app_handle)?,
-            &runs_submenu,
-            &notifications_submenu,
-            &sync_item,
-            &shortcuts_submenu,
-            &resource_submenu,
-            &update_submenu,
-            &failures_submenu,
-            &account_submenu,
-            &diagnostics_submenu,
-            &PredefinedMenuItem::separator(app_handle)?,
-            &quit_item,
-        ],
-    )
+fn menu_signature(data: &TrayData, recording: bool) -> TrayMenuSignature {
+    TrayMenuSignature {
+        recording,
+        run_ids: data
+            .active_runs
+            .iter()
+            .take(MAX_RUN_ROWS)
+            .map(|run| run.run_id.clone())
+            .collect(),
+        has_failures: !data.background_failures.is_empty(),
+        sync_degraded: sync_degraded(data),
+        update_available: data.update_state.available,
+    }
 }
 
-fn build_active_runs_menu(
-    app_handle: &AppHandle,
-    data: &TrayData,
-) -> tauri::Result<Submenu<tauri::Wry>> {
-    let label = format!("Active runs ({})", data.active_runs.len());
-    let mut items: Vec<MenuItem<tauri::Wry>> = Vec::new();
+fn sync_degraded(data: &TrayData) -> bool {
+    data.sync_status.status != "Online" && data.sync_status.status != "Unknown"
+}
 
-    if data.active_runs.is_empty() {
-        items.push(MenuItem::new(
-            app_handle,
-            "No active runs",
-            false,
-            None::<&str>,
-        )?);
+fn current_time_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+fn format_elapsed(ms: u64) -> String {
+    let mins = ms / 60_000;
+    if mins == 0 {
+        "<1m".to_string()
+    } else if mins < 60 {
+        format!("{}m", mins)
     } else {
-        let now_ms = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_millis() as u64)
-            .unwrap_or(0);
+        format!("{}h {:02}m", mins / 60, mins % 60)
+    }
+}
 
-        for run in data.active_runs.iter().take(8) {
-            let elapsed = run
-                .elapsed_ms
-                .map(|ms| format!("{}s", ms / 1000))
-                .unwrap_or_default();
+fn run_label(run: &TrayRun, now_ms: u64) -> String {
+    let name = run
+        .event_name
+        .as_deref()
+        .or(run.board_name.as_deref())
+        .unwrap_or(&run.board_id);
 
-            let display_name = run
-                .event_name
-                .as_ref()
-                .or(run.board_name.as_ref())
-                .map(|s| s.as_str())
-                .unwrap_or(&run.board_id);
+    let type_suffix = run
+        .event_type
+        .as_deref()
+        .map(|t| format!(" [{}]", t))
+        .unwrap_or_default();
 
-            let event_type_label = run
-                .event_type
-                .as_ref()
-                .map(|t| format!(" [{}]", t))
-                .unwrap_or_default();
+    let stalled = run.last_node_update_ms > 0
+        && now_ms.saturating_sub(run.last_node_update_ms) >= STALLED_THRESHOLD_MS;
+    let state = if stalled { " — stalled" } else { "" };
 
-            // Calculate time since last node update
-            let last_update_label = if run.last_node_update_ms > 0 {
-                let since_update_secs = (now_ms.saturating_sub(run.last_node_update_ms)) / 1000;
-                if since_update_secs >= 60 {
-                    format!("⏱ {}s ⚠", since_update_secs) // Warning for >60s
-                } else if since_update_secs >= 30 {
-                    format!("⏱ {}s", since_update_secs) // Stale but ok
-                } else {
-                    format!("⏱ {}s", since_update_secs) // Fresh
-                }
-            } else {
-                "⏱ --".to_string() // No activity yet
-            };
+    match run.elapsed_ms.map(format_elapsed) {
+        Some(elapsed) => format!("{}{} · {}{}", name, type_suffix, elapsed, state),
+        None => format!("{}{}{}", name, type_suffix, state),
+    }
+}
 
-            items.push(MenuItem::new(
-                app_handle,
-                format!(
-                    "{}{} • {} • {}",
-                    display_name, event_type_label, last_update_label, elapsed
-                ),
-                false,
-                None::<&str>,
-            )?);
+fn notifications_label(data: &TrayData) -> String {
+    if data.unread_count > 0 {
+        format!("Notifications ({})…", data.unread_count)
+    } else {
+        "Notifications…".to_string()
+    }
+}
+
+fn account_label(data: &TrayData) -> String {
+    if data.signed_in {
+        "Account…".to_string()
+    } else {
+        "Sign In…".to_string()
+    }
+}
+
+fn failures_label(data: &TrayData) -> String {
+    let count = data.background_failures.len();
+    if count == 1 {
+        "1 Background Task Failed — View Logs".to_string()
+    } else {
+        format!("{} Background Tasks Failed — View Logs", count)
+    }
+}
+
+fn sync_label(data: &TrayData) -> String {
+    match data.sync_status.detail.as_deref() {
+        Some(detail) => format!("Sync: {} — {}", data.sync_status.status, detail),
+        None => format!("Sync: {}", data.sync_status.status),
+    }
+}
+
+fn update_dynamic_labels(handles: &mut TrayMenuHandles, data: &TrayData) {
+    let now_ms = current_time_ms();
+
+    for (run_id, item, last_label) in handles.run_items.iter_mut() {
+        if let Some(run) = data.active_runs.iter().find(|r| &r.run_id == run_id) {
+            let label = run_label(run, now_ms);
+            if &label != last_label {
+                let _ = item.set_text(&label);
+                *last_label = label;
+            }
         }
     }
 
-    let refs: Vec<&dyn IsMenuItem<tauri::Wry>> = items
-        .iter()
-        .map(|item| item as &dyn IsMenuItem<tauri::Wry>)
-        .collect();
-    Submenu::with_items(app_handle, label, true, &refs)
+    if let Some((item, last_label)) = handles.failures_item.as_mut() {
+        let label = failures_label(data);
+        if &label != last_label {
+            let _ = item.set_text(&label);
+            *last_label = label;
+        }
+    }
+
+    if let Some((item, last_label)) = handles.sync_item.as_mut() {
+        let label = sync_label(data);
+        if &label != last_label {
+            let _ = item.set_text(&label);
+            *last_label = label;
+        }
+    }
+
+    let (item, last_label) = &mut handles.notifications_item;
+    let label = notifications_label(data);
+    if &label != last_label {
+        let _ = item.set_text(&label);
+        *last_label = label;
+    }
+
+    let (item, last_label) = &mut handles.account_item;
+    let label = account_label(data);
+    if &label != last_label {
+        let _ = item.set_text(&label);
+        *last_label = label;
+    }
 }
 
-fn build_notifications_menu(
+fn build_tray_menu(
     app_handle: &AppHandle,
     data: &TrayData,
-) -> tauri::Result<Submenu<tauri::Wry>> {
-    let label = if data.unread_count > 0 {
-        format!("Notifications ({})", data.unread_count)
+    recording: bool,
+    signature: TrayMenuSignature,
+) -> tauri::Result<(Menu<Wry>, TrayMenuHandles)> {
+    let now_ms = current_time_ms();
+    let mut items: Vec<Box<dyn IsMenuItem<Wry>>> = Vec::new();
+
+    items.push(Box::new(MenuItem::with_id(
+        app_handle,
+        MENU_OPEN,
+        "Open Flow-Like",
+        true,
+        None::<&str>,
+    )?));
+    items.push(Box::new(PredefinedMenuItem::separator(app_handle)?));
+
+    let mut has_status_section = false;
+
+    if recording {
+        items.push(Box::new(MenuItem::with_id(
+            app_handle,
+            MENU_STOP_RECORDING,
+            "● Recording — Stop",
+            true,
+            None::<&str>,
+        )?));
+        has_status_section = true;
+    }
+
+    let mut run_items = Vec::new();
+    for run in data.active_runs.iter().take(MAX_RUN_ROWS) {
+        let label = run_label(run, now_ms);
+        let item = MenuItem::with_id(
+            app_handle,
+            format!("{}{}", RUN_MENU_PREFIX, run.run_id),
+            &label,
+            true,
+            None::<&str>,
+        )?;
+        items.push(Box::new(item.clone()));
+        run_items.push((run.run_id.clone(), item, label));
+        has_status_section = true;
+    }
+    if !data.active_runs.is_empty() {
+        items.push(Box::new(MenuItem::with_id(
+            app_handle,
+            MENU_STOP_ALL_RUNS,
+            "Stop All Runs",
+            true,
+            None::<&str>,
+        )?));
+    }
+
+    let failures_item = if data.background_failures.is_empty() {
+        None
     } else {
-        "Notifications".to_string()
+        let label = failures_label(data);
+        let item = MenuItem::with_id(app_handle, MENU_VIEW_FAILURES, &label, true, None::<&str>)?;
+        items.push(Box::new(item.clone()));
+        has_status_section = true;
+        Some((item, label))
     };
 
-    let mut items: Vec<MenuItem<tauri::Wry>> = Vec::new();
-    items.push(MenuItem::with_id(
-        app_handle,
-        MENU_OPEN_NOTIFICATIONS,
-        "Open notifications",
-        true,
-        None::<&str>,
-    )?);
-
-    if data.notifications.is_empty() {
-        items.push(MenuItem::new(
-            app_handle,
-            "No notifications",
-            false,
-            None::<&str>,
-        )?);
+    let sync_item = if signature.sync_degraded {
+        let label = sync_label(data);
+        let item = MenuItem::new(app_handle, &label, false, None::<&str>)?;
+        items.push(Box::new(item.clone()));
+        has_status_section = true;
+        Some((item, label))
     } else {
-        for notification in data.notifications.iter().take(6) {
-            let prefix = if notification.read { "" } else { "• " };
-            items.push(MenuItem::new(
-                app_handle,
-                format!("{}{}", prefix, notification.title),
-                false,
-                None::<&str>,
-            )?);
-        }
+        None
+    };
+
+    if data.update_state.available {
+        items.push(Box::new(MenuItem::with_id(
+            app_handle,
+            MENU_RESTART_UPDATE,
+            "Update Ready — Restart to Update",
+            true,
+            None::<&str>,
+        )?));
+        has_status_section = true;
     }
 
-    let refs: Vec<&dyn IsMenuItem<tauri::Wry>> = items
-        .iter()
-        .map(|item| item as &dyn IsMenuItem<tauri::Wry>)
-        .collect();
-    Submenu::with_items(app_handle, label, true, &refs)
-}
+    if has_status_section {
+        items.push(Box::new(PredefinedMenuItem::separator(app_handle)?));
+    }
 
-fn build_shortcuts_menu(app_handle: &AppHandle) -> tauri::Result<Submenu<tauri::Wry>> {
-    let new_flow = MenuItem::with_id(app_handle, MENU_NEW_FLOW, "New flow", true, None::<&str>)?;
-    let open_recent = MenuItem::with_id(
+    items.push(Box::new(MenuItem::with_id(
         app_handle,
-        MENU_OPEN_RECENT,
-        "Open recent",
+        MENU_NEW_FLOW,
+        "New Flow",
         true,
         None::<&str>,
-    )?;
-    let search_flows = MenuItem::with_id(
+    )?));
+    items.push(Box::new(MenuItem::with_id(
         app_handle,
         MENU_SEARCH_FLOWS,
-        "Search flows",
+        "Search Flows…",
+        true,
+        None::<&str>,
+    )?));
+    items.push(Box::new(MenuItem::with_id(
+        app_handle,
+        MENU_OPEN_RECENT,
+        "Open Recent",
+        true,
+        None::<&str>,
+    )?));
+    items.push(Box::new(PredefinedMenuItem::separator(app_handle)?));
+
+    let notifications_text = notifications_label(data);
+    let notifications_item = MenuItem::with_id(
+        app_handle,
+        MENU_OPEN_NOTIFICATIONS,
+        &notifications_text,
         true,
         None::<&str>,
     )?;
+    items.push(Box::new(notifications_item.clone()));
 
-    Submenu::with_items(
-        app_handle,
-        "Shortcuts",
-        true,
-        &[&new_flow, &open_recent, &search_flows],
-    )
-}
+    let account_text = account_label(data);
+    let account_item =
+        MenuItem::with_id(app_handle, MENU_ACCOUNT, &account_text, true, None::<&str>)?;
+    items.push(Box::new(account_item.clone()));
 
-fn build_resource_menu(
-    app_handle: &AppHandle,
-    data: &TrayData,
-) -> tauri::Result<Submenu<tauri::Wry>> {
-    let cpu = MenuItem::new(
-        app_handle,
-        format!("CPU: {}%", data.resource_usage.cpu_percent),
-        false,
-        None::<&str>,
-    )?;
-    let ram = MenuItem::new(
-        app_handle,
-        format!(
-            "RAM: {} / {} MB",
-            data.resource_usage.ram_used_mb, data.resource_usage.ram_total_mb
-        ),
-        false,
-        None::<&str>,
-    )?;
-    let throttle = CheckMenuItem::with_id(
-        app_handle,
-        MENU_TOGGLE_THROTTLE,
-        "Throttle background tasks",
-        true,
-        data.throttling_enabled,
-        None::<&str>,
-    )?;
-
-    Submenu::with_items(app_handle, "Resources", true, &[&cpu, &ram, &throttle])
-}
-
-fn build_update_menu(
-    app_handle: &AppHandle,
-    data: &TrayData,
-) -> tauri::Result<Submenu<tauri::Wry>> {
-    let status = if data.update_state.available {
-        "Update available"
-    } else {
-        "Up to date"
-    };
-    let status_item = MenuItem::new(app_handle, status, false, None::<&str>)?;
-    let restart_item = MenuItem::with_id(
-        app_handle,
-        MENU_RESTART_UPDATE,
-        "Restart to update",
-        data.update_state.available,
-        None::<&str>,
-    )?;
-
-    Submenu::with_items(app_handle, "Updates", true, &[&status_item, &restart_item])
-}
-
-fn build_failures_menu(
-    app_handle: &AppHandle,
-    data: &TrayData,
-) -> tauri::Result<Submenu<tauri::Wry>> {
-    let mut items: Vec<MenuItem<tauri::Wry>> = Vec::new();
-
-    if data.background_failures.is_empty() {
-        items.push(MenuItem::new(
-            app_handle,
-            "No failures",
-            false,
-            None::<&str>,
-        )?);
-    } else {
-        for failure in data.background_failures.iter().take(6) {
-            items.push(MenuItem::new(
-                app_handle,
-                failure.title.clone(),
-                false,
-                None::<&str>,
-            )?);
-        }
-    }
-
-    items.push(MenuItem::with_id(
+    items.push(Box::new(MenuItem::with_id(
         app_handle,
         MENU_OPEN_LOGS,
-        "Open logs",
+        "Open Logs",
         true,
         None::<&str>,
-    )?);
-
-    let refs: Vec<&dyn IsMenuItem<tauri::Wry>> = items
-        .iter()
-        .map(|item| item as &dyn IsMenuItem<tauri::Wry>)
-        .collect();
-    Submenu::with_items(app_handle, "Background tasks", true, &refs)
-}
-
-fn build_account_menu(
-    app_handle: &AppHandle,
-    data: &TrayData,
-) -> tauri::Result<Submenu<tauri::Wry>> {
-    let account_item = MenuItem::new(
-        app_handle,
-        format!("Account: {}", data.account_state.label),
-        false,
-        None::<&str>,
-    )?;
-    let tier_item = MenuItem::new(
-        app_handle,
-        format!(
-            "Tier: {}",
-            data.account_state
-                .tier
-                .clone()
-                .unwrap_or_else(|| "Unknown".to_string())
-        ),
-        false,
-        None::<&str>,
-    )?;
-    let manage_item = MenuItem::with_id(
-        app_handle,
-        MENU_MANAGE_ACCOUNT,
-        "Manage account",
-        true,
-        None::<&str>,
-    )?;
-
-    Submenu::with_items(
-        app_handle,
-        "Account",
-        true,
-        &[&account_item, &tier_item, &manage_item],
-    )
-}
-
-fn build_diagnostics_menu(
-    app_handle: &AppHandle,
-    data: &TrayData,
-) -> tauri::Result<Submenu<tauri::Wry>> {
-    let debug_toggle = CheckMenuItem::with_id(
-        app_handle,
-        MENU_TOGGLE_DEBUG,
-        "Enable diagnostics",
-        true,
-        data.debug_enabled,
-        None::<&str>,
-    )?;
-    let report_issue = MenuItem::with_id(
+    )?));
+    items.push(Box::new(MenuItem::with_id(
         app_handle,
         MENU_REPORT_ISSUE,
-        "Report issue",
+        "Report Issue…",
         true,
         None::<&str>,
-    )?;
-
-    Submenu::with_items(
+    )?));
+    items.push(Box::new(PredefinedMenuItem::separator(app_handle)?));
+    items.push(Box::new(MenuItem::with_id(
         app_handle,
-        "Diagnostics",
+        MENU_QUIT,
+        "Quit Flow-Like",
         true,
-        &[&debug_toggle, &report_issue],
-    )
+        None::<&str>,
+    )?));
+
+    let refs: Vec<&dyn IsMenuItem<Wry>> = items.iter().map(|item| item.as_ref()).collect();
+    let menu = Menu::with_items(app_handle, &refs)?;
+
+    Ok((
+        menu,
+        TrayMenuHandles {
+            signature,
+            run_items,
+            failures_item,
+            sync_item,
+            notifications_item: (notifications_item, notifications_text),
+            account_item: (account_item, account_text),
+        },
+    ))
 }
 
 fn handle_menu_event(app_handle: &AppHandle, id: &str) {
+    if let Some(run_id) = id.strip_prefix(RUN_MENU_PREFIX) {
+        open_run(app_handle, run_id.to_string());
+        return;
+    }
+
     match id {
         MENU_OPEN => {
             open_main_window(app_handle);
+        }
+        MENU_STOP_RECORDING => {
+            let app = app_handle.clone();
+            tauri::async_runtime::spawn(async move {
+                stop_recording_from_tray(&app).await;
+            });
+        }
+        MENU_STOP_ALL_RUNS => {
+            let app = app_handle.clone();
+            tauri::async_runtime::spawn(async move {
+                if let Ok(state) = TauriFlowLikeState::construct(&app).await
+                    && let Ok(runs) = state.list_runs()
+                {
+                    for (run_id, _) in runs {
+                        let _ = state.remove_and_cancel_run(&run_id);
+                    }
+                }
+            });
         }
         MENU_OPEN_NOTIFICATIONS => {
             open_route(app_handle, "/notifications");
@@ -788,22 +731,10 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str) {
             let _ = app_handle.emit("tray:open-spotlight", "search-flows");
             open_main_window(app_handle);
         }
-        MENU_TOGGLE_THROTTLE => {
-            toggle_tray_flag(app_handle, |data| {
-                data.throttling_enabled = !data.throttling_enabled;
-            });
-            let _ = app_handle.emit("tray:toggle-throttling", ());
-        }
-        MENU_TOGGLE_DEBUG => {
-            toggle_tray_flag(app_handle, |data| {
-                data.debug_enabled = !data.debug_enabled;
-            });
-            let _ = app_handle.emit("tray:toggle-debug", ());
-        }
         MENU_RESTART_UPDATE => {
             let _ = app_handle.emit("tray:restart-update", ());
         }
-        MENU_OPEN_LOGS => {
+        MENU_VIEW_FAILURES | MENU_OPEN_LOGS => {
             let app_handle = app_handle.clone();
             tauri::async_runtime::spawn(async move {
                 if let Ok(settings) = TauriSettingsState::construct(&app_handle).await {
@@ -815,7 +746,7 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str) {
                 }
             });
         }
-        MENU_MANAGE_ACCOUNT => {
+        MENU_ACCOUNT => {
             open_route(app_handle, "/account");
         }
         MENU_REPORT_ISSUE => {
@@ -831,6 +762,36 @@ fn handle_menu_event(app_handle: &AppHandle, id: &str) {
     }
 }
 
+fn open_run(app_handle: &AppHandle, run_id: String) {
+    let app = app_handle.clone();
+    tauri::async_runtime::spawn(async move {
+        let route = {
+            let Some(state) = app.try_state::<TauriTrayState>() else {
+                return;
+            };
+            let guard = state.0.lock().await;
+            guard
+                .data
+                .active_runs
+                .iter()
+                .find(|run| run.run_id == run_id)
+                .and_then(|run| {
+                    run.app_id.as_ref().map(|app_id| {
+                        format!(
+                            "/flow?id={}&app={}&node={}",
+                            run.board_id, app_id, run.node_id
+                        )
+                    })
+                })
+        };
+
+        match route {
+            Some(route) => open_route(&app, &route),
+            None => open_main_window(&app),
+        }
+    });
+}
+
 fn open_main_window(app_handle: &AppHandle) {
     if let Some(main) = app_handle.get_webview_window("main") {
         let _ = main.show();
@@ -839,26 +800,6 @@ fn open_main_window(app_handle: &AppHandle) {
 }
 
 fn open_route(app_handle: &AppHandle, route: &str) {
-    if let Some(main) = app_handle.get_webview_window("main") {
-        let _ = main.show();
-        let _ = main.set_focus();
-        let _ = main.eval(format!("window.location.assign('{}')", route));
-    }
-}
-
-fn toggle_tray_flag<F>(app_handle: &AppHandle, update: F)
-where
-    F: FnOnce(&mut TrayData) + Send + 'static,
-{
-    if let Some(state) = app_handle.try_state::<TauriTrayState>() {
-        let runtime = state.0.clone();
-        let app_handle = app_handle.clone();
-        tauri::async_runtime::spawn(async move {
-            {
-                let mut guard = runtime.lock().await;
-                update(&mut guard.data);
-            }
-            let _ = refresh_tray_menu(&app_handle).await;
-        });
-    }
+    open_main_window(app_handle);
+    let _ = app_handle.emit("tray:navigate", route);
 }

--- a/packages/core/src/state.rs
+++ b/packages/core/src/state.rs
@@ -272,6 +272,7 @@ use std::sync::atomic::AtomicU64;
 #[derive(Clone)]
 pub struct RunData {
     pub start_time: Instant,
+    pub app_id: Option<Arc<str>>,
     pub board_id: Arc<str>,
     pub node_id: Arc<str>,
     pub event_id: Option<Arc<str>>,
@@ -292,6 +293,7 @@ impl RunData {
     ) -> Self {
         RunData {
             start_time: Instant::now(),
+            app_id: None,
             board_id: Arc::from(board_id),
             node_id: Arc::from(node_id),
             event_id: event_id.map(|s| Arc::from(s.as_str())),
@@ -303,7 +305,9 @@ impl RunData {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn with_metadata(
+        app_id: Option<String>,
         board_id: &str,
         node_id: &str,
         event_id: Option<String>,
@@ -314,6 +318,7 @@ impl RunData {
     ) -> Self {
         RunData {
             start_time: Instant::now(),
+            app_id: app_id.map(|s| Arc::from(s.as_str())),
             board_id: Arc::from(board_id),
             node_id: Arc::from(node_id),
             event_id: event_id.map(|s| Arc::from(s.as_str())),
@@ -356,6 +361,7 @@ impl RunData {
     pub fn from_event(event: &Event, cancellation_token: CancellationToken) -> Self {
         RunData {
             start_time: Instant::now(),
+            app_id: None,
             board_id: Arc::from(event.board_id.as_str()),
             node_id: Arc::from(event.node_id.as_str()),
             event_id: Some(Arc::from(event.id.as_str())),


### PR DESCRIPTION
- Removed the sysinfo crate from Cargo.toml.
- Refactored tray.rs to eliminate unnecessary resource usage tracking.
- Updated tray menu to handle recording and run statuses more efficiently.
- Introduced app_id to RunData for better context in event handling.
- Simplified the stop_recording command to ensure tray icon restoration on failure.
- Enhanced menu item updates to reflect current application state without unnecessary rebuilds.