### PR TITLE
Feature/766 caching needs to be added to flowpilot

### DIFF
--- a/apps/desktop/src-tauri/gen/apple/flow-like-desktop_iOS/Info.plist
+++ b/apps/desktop/src-tauri/gen/apple/flow-like-desktop_iOS/Info.plist
@@ -23,12 +23,12 @@
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
+			<key>CFBundleURLName</key>
+			<string>flow-like</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>flow-like</string>
 			</array>
-			<key>CFBundleURLName</key>
-			<string>flow-like</string>
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>

--- a/apps/desktop/src-tauri/gen/apple/flow-like-desktop_iOS/Info.plist
+++ b/apps/desktop/src-tauri/gen/apple/flow-like-desktop_iOS/Info.plist
@@ -23,12 +23,12 @@
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
-			<key>CFBundleURLName</key>
-			<string>flow-like</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>flow-like</string>
 			</array>
+			<key>CFBundleURLName</key>
+			<string>flow-like</string>
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>

--- a/apps/desktop/src-tauri/src/functions/ai/copilot.rs
+++ b/apps/desktop/src-tauri/src/functions/ai/copilot.rs
@@ -18,7 +18,7 @@ use flow_like::flow::board::Board;
 use flow_like::flow::board::commands::GenericCommand;
 use flow_like::flow::copilot::memory::{AssistantMemory, MemoryEntry, MemoryStatus};
 use flow_like::flow::copilot::platform::PlatformToolBridge;
-use flow_like::flow::copilot::tool_spec::MAX_DELEGATED_RUN_DISPATCH_SECS;
+use flow_like::flow::copilot::tool_spec::{MAX_DELEGATED_RUN_DISPATCH_SECS, RESEARCH_AGENT_TOOL};
 use flow_like::flow::copilot::{
     AttachmentManifestEntry, BoardCommand, BoardContextManifest, BoardScopePlan, CatalogProvider,
     EmitCommandsArgs, FlowScriptCandidateRegression, FlowScriptPendingDelivery,
@@ -12611,6 +12611,11 @@ fn flowpilot_mcp_server_instructions<'a>(
         || names.contains("write_flowscript");
     let has_ui = names.contains("emit_ui");
     let has_data = names.contains("graph_overlay_tool") || names.contains("graph_query_tool");
+    let has_global = names.contains("list_apps") && names.contains("flowpilot_board");
+
+    if has_global {
+        return "You are the FlowPilot platform orchestrator. Search this server for tools in three modes. DIRECT: execute ordinary one-call, one-app, or simple two-app tasks without planning. COMPLEX SOLVE: make a dependency plan only when likely to need at least three apps/interfaces or intrinsic multi-stage, reconciliation, approval, verification, or recovery complexity. For either mode, begin app work with list_apps, prefer matching local chat/page/headless interfaces, and use the sealed no-argument research_agent only after a complete inventory has no suitable local app or useful local research candidates returned no answer. BUILD: use project_scout for prior art, then create/fork/acquire a base and coordinate flowpilot_widget, data_studio_agent, flowpilot_board, Events, and safe runtime verification by dependency wave. Board logic, UI, and data are strict specialist boundaries. Preserve exact returned IDs, approvals, partial/manual work, and the user's full acceptance contract; never claim success from a requested, declined, timed-out, or unknown operation. Do not use shell or file-edit tools for FlowPilot artifacts.";
+    }
 
     if workflow_mutation && has_ui {
         return "This is an explicit combined root FlowPilot surface, not a widget or board specialist. Keep UI changes in emit_ui and executable workflow behavior in the FlowScript lifecycle; never let UI generation author FlowScript or let board generation emit components. For the board portion, read get_current_flowscript once, make one bounded get_declarations batch for the highest-leverage catalog calls, call plan_board_scope exactly once, then retain the accepted active segment with write_flowscript. After a plan is accepted, do not call plan_board_scope again unless its tool result explicitly authorizes one revision. Do not enumerate every utility or chase omitted queries before that checkpoint. Repair the retained source with patch_flowscript, use structured compiler diagnostics for focused declaration follow-ups, run check_flowscript, and finish with commit_flowscript at the latest revision. Before the first write, use at most six ancillary database/UI/storage inspections.";
@@ -13176,6 +13181,7 @@ struct ExternalAgentInvocation {
     prompt: String,
     final_output_path: Option<std::path::PathBuf>,
     envs: Vec<(String, String)>,
+    env_removals: Vec<String>,
 }
 
 /// Normalize the optional UI override. An omitted/blank value, or the explicit
@@ -13308,6 +13314,7 @@ impl ExternalAgentInvocation {
             prompt,
             final_output_path: None,
             envs: Vec::new(),
+            env_removals: Vec::new(),
         })
     }
 
@@ -13325,17 +13332,25 @@ impl ExternalAgentInvocation {
             "flowpilot-claude-mcp-{}.json",
             uuid::Uuid::new_v4()
         ));
+        // The global surface is large and includes the sealed research fallback. Let Claude's
+        // native MCP ToolSearch keep those schemas deferred. Small role-scoped specialists retain
+        // eager loading because their exact lifecycle tools are all immediately relevant.
+        let defer_tool_schemas = tool_names.iter().any(|name| name == RESEARCH_AGENT_TOOL);
+        let server_config = if defer_tool_schemas {
+            serde_json::json!({
+                "type": "http",
+                "url": mcp_url,
+            })
+        } else {
+            serde_json::json!({
+                "type": "http",
+                "url": mcp_url,
+                "alwaysLoad": true,
+            })
+        };
         let mcp_config = serde_json::json!({
             "mcpServers": {
-                "flowpilot": {
-                    "type": "http",
-                    "url": mcp_url,
-                    // This is a small, session-local reviewed toolset. Preload it so Claude does
-                    // not spend turns repeatedly invoking its built-in ToolSearch just to reveal
-                    // get_current_flowscript/get_declarations and the retained FlowScript source
-                    // lifecycle schemas.
-                    "alwaysLoad": true
-                }
+                "flowpilot": server_config
             }
         });
         std::fs::write(
@@ -13418,6 +13433,23 @@ impl ExternalAgentInvocation {
             line
         };
 
+        let mut envs = vec![
+            (
+                "MCP_TOOL_TIMEOUT".to_string(),
+                (MAX_DELEGATED_RUN_DISPATCH_SECS * 1000).to_string(),
+            ),
+            // Disable Claude's independent no-progress watchdog for long nested FlowPilot calls;
+            // FlowPilot still owns explicit cancellation and per-tool lifecycle bounds.
+            (
+                "CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT".to_string(),
+                "0".to_string(),
+            ),
+        ];
+        if !defer_tool_schemas {
+            // Preserve the existing eager path for small role-scoped specialist surfaces.
+            envs.push(("ENABLE_TOOL_SEARCH".to_string(), "auto".to_string()));
+        }
+
         Ok(Self {
             backend,
             executable: cli.executable,
@@ -13431,26 +13463,12 @@ impl ExternalAgentInvocation {
             // Claude Code applies MCP_TOOL_TIMEOUT as the overall MCP-call bound. A delegated board
             // run earns wall clock by proving progress and can run for hours, so this tracks the
             // same shared dispatch ceiling as the Codex path above.
-            envs: vec![
-                (
-                    "MCP_TOOL_TIMEOUT".to_string(),
-                    (MAX_DELEGATED_RUN_DISPATCH_SECS * 1000).to_string(),
-                ),
-                // Claude Code also has an independent no-progress watchdog for MCP calls. A
-                // nested FlowPilot board run can legitimately stay silent while the delegated
-                // model reasons or waits for a frontend operation, so the 300s default would
-                // cancel a healthy request even though MCP_TOOL_TIMEOUT permits it. Disable this
-                // session-local idle watchdog; FlowPilot still owns explicit cancellation and
-                // its individual frontend/tool lifecycle bounds.
-                (
-                    "CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT".to_string(),
-                    "0".to_string(),
-                ),
-                // Auto preloads tool definitions when they fit comfortably in context and falls
-                // back to ToolSearch only for genuinely large surfaces. `alwaysLoad` above keeps
-                // this session-local FlowPilot server on the preload path.
-                ("ENABLE_TOOL_SEARCH".to_string(), "auto".to_string()),
-            ],
+            envs,
+            // The global surface relies on Claude's supported-model default ToolSearch behavior.
+            // Do not let an ambient desktop/shell override force eager loading or disable it.
+            env_removals: defer_tool_schemas
+                .then(|| vec!["ENABLE_TOOL_SEARCH".to_string()])
+                .unwrap_or_default(),
             final_output_path: Some(mcp_config_path),
         })
     }
@@ -13920,6 +13938,9 @@ async fn run_external_agent_invocation(
         .kill_on_drop(true);
     for (key, value) in &invocation.envs {
         command.env(key, value);
+    }
+    for key in &invocation.env_removals {
+        command.env_remove(key);
     }
 
     let mut child = command.spawn().map_err(|e| {
@@ -15823,11 +15844,7 @@ impl FlowPilotAgentCapabilitySet {
     }
 
     fn add_global_orchestrator_tools(&mut self) {
-        self.tool_names.extend([
-            "internet_search".to_string(),
-            "open_url".to_string(),
-            "archive_lookup".to_string(),
-        ]);
+        self.tool_names.push(RESEARCH_AGENT_TOOL.to_string());
         self.tool_names.sort_unstable();
         self.tool_names.dedup();
     }
@@ -16108,7 +16125,12 @@ fn build_flowpilot_agent_surface(
             CopilotScope::Frontend => flow_like::copilot::prompts::frontend_sdk_system_prompt(),
             CopilotScope::DataStudio => flow_like::copilot::prompts::data_studio_system_prompt(""),
             CopilotScope::Scout => flow_like::copilot::prompts::scout_system_prompt(""),
-            CopilotScope::Research => flow_like::copilot::prompts::research_system_prompt(""),
+            CopilotScope::Research => {
+                flow_like::copilot::prompts::research_system_prompt(&format!(
+                    "Current UTC date: {}.",
+                    chrono::Utc::now().format("%Y-%m-%d")
+                ))
+            }
             CopilotScope::Both => match board_flowscript.as_deref() {
                 // flowscript_board_context embeds the shared guidance blocks itself; the lean
                 // header avoids duplicating them (~3.5k tokens).
@@ -25431,13 +25453,21 @@ eventsSimple() {
     }
 
     #[test]
-    fn global_agent_capability_set_advertises_public_web_tools() {
+    fn global_agent_capability_set_advertises_only_sealed_public_research() {
         let capabilities =
             FlowPilotAgentCapabilitySet::for_surface(CopilotScope::Both, true, true, true);
-        for tool in ["internet_search", "open_url", "archive_lookup"] {
+        assert!(
+            capabilities
+                .tool_names
+                .iter()
+                .any(|name| name == RESEARCH_AGENT_TOOL)
+        );
+        for raw_web_tool in ["internet_search", "open_url", "archive_lookup"] {
             assert!(
-                capabilities.tool_names.iter().any(|name| name == tool),
-                "global FlowPilot capabilities must advertise {tool}"
+                !capabilities
+                    .tool_names
+                    .iter()
+                    .any(|name| name == raw_web_tool)
             );
         }
 
@@ -25593,6 +25623,18 @@ eventsSimple() {
         assert!(board.contains("BOARD specialist"));
         assert!(board.contains("commit_flowscript"));
         assert!(board.contains("Cross-domain context tools are read-only"));
+
+        let global = flowpilot_mcp_server_instructions(
+            ["list_apps", "flowpilot_board", RESEARCH_AGENT_TOOL],
+            false,
+        );
+        assert!(global.contains("platform orchestrator"));
+        assert!(global.contains("DIRECT"));
+        assert!(global.contains("SOLVE"));
+        assert!(global.contains("at least three apps/interfaces"));
+        assert!(global.contains("BUILD"));
+        assert!(global.contains("sealed no-argument research_agent"));
+        assert!(global.len() < 2_000);
     }
 
     #[test]
@@ -26031,6 +26073,51 @@ eventsSimple() {
         assert!(config.contains("flowpilot"));
         assert!(config.contains("127.0.0.1:23456/mcp"));
         assert!(config.contains("\"alwaysLoad\": true"));
+        let _ = std::fs::remove_file(config_path);
+    }
+
+    #[test]
+    fn claude_global_surface_defers_mcp_tool_schemas() {
+        let invocation = ExternalAgentInvocation::new(
+            FlowPilotAgentBackendKind::ClaudeCode,
+            CliResolution::new(
+                std::path::PathBuf::from("/usr/bin/claude"),
+                CliResolutionSource::Path,
+            ),
+            "sonnet",
+            None,
+            "http://127.0.0.1:23456/mcp",
+            "hello".to_string(),
+            vec![
+                "list_apps".to_string(),
+                RESEARCH_AGENT_TOOL.to_string(),
+                "flowpilot_board".to_string(),
+            ],
+            &[],
+        )
+        .expect("global Claude invocation should build");
+
+        assert!(
+            !invocation
+                .envs
+                .iter()
+                .any(|(key, _)| key == "ENABLE_TOOL_SEARCH"),
+            "native Claude MCP deferral should use its default supported-model behavior"
+        );
+        assert!(
+            invocation
+                .env_removals
+                .iter()
+                .any(|key| key == "ENABLE_TOOL_SEARCH"),
+            "ambient tool-search overrides must not defeat global schema deferral"
+        );
+        let config_path = invocation
+            .final_output_path
+            .as_ref()
+            .expect("Claude invocation stores temp MCP config");
+        let config = std::fs::read_to_string(config_path).expect("temp MCP config is readable");
+        assert!(config.contains("flowpilot"));
+        assert!(!config.contains("alwaysLoad"));
         let _ = std::fs::remove_file(config_path);
     }
 

--- a/apps/desktop/src-tauri/src/functions/ai/copilot_sdk_tools.rs
+++ b/apps/desktop/src-tauri/src/functions/ai/copilot_sdk_tools.rs
@@ -764,6 +764,10 @@ pub fn create_board_support_tools(bridge: FrontendToolBridge) -> Vec<(Tool, Tool
 /// host-local tools: `internet_search` runs in-process, `open_url` and `archive_lookup` use the
 /// shared safe public-web readers, and the `_memory_*` tools run against the profile's
 /// `AssistantMemory`.
+fn frontend_tool_result_closes_public_web_phase(_tool_name: &str) -> bool {
+    true
+}
+
 pub fn sdk_tool_from_spec(
     spec: &PlatformToolSpec,
     bridge: FrontendToolBridge,
@@ -846,6 +850,13 @@ pub fn sdk_tool_from_spec(
                 ToolResultObject::text(result)
             }
             _ => {
+                if frontend_tool_result_closes_public_web_phase(spec.name)
+                    && let Some(session) = &web_research_session
+                {
+                    // Close before dispatch so a concurrent/same-round research request cannot
+                    // start after this private frontend operation has begun.
+                    session.close_public_web_phase();
+                }
                 let result = frontend_tool_result_with_timeout(
                     &bridge,
                     spec.name,
@@ -853,9 +864,9 @@ pub fn sdk_tool_from_spec(
                     approval_from_spec(&spec, args),
                     Duration::from_secs(spec.timeout_secs),
                 );
-                if let Some(session) = &web_research_session {
-                    session.close_public_web_phase();
-                }
+                // Close the parent's raw-web authorization before any frontend dispatch. The
+                // local-app-first fallback does not reopen it: `research_agent` receives a fresh
+                // sealed child view bound only to the immutable source request.
                 result
             }
         }
@@ -920,10 +931,10 @@ pub fn create_global_assistant_tools(
     user_prompt: &str,
     run_id: Option<&str>,
 ) -> Vec<(Tool, ToolHandler)> {
-    // The orchestrator no longer holds the public-web tools — `research_agent` does — but it still
-    // needs the turn's session. Its non-web tool calls close the public-web phase, and that closure
-    // has to reach the researchers: an orchestrator that has read private app data must not be able
-    // to launder a web request through a delegated researcher afterwards.
+    // The orchestrator no longer holds raw public-web tools. Keep a parent session so any
+    // accidentally surfaced raw handler still fails closed after local/private work. The sealed
+    // `research_agent` child uses a separate authorization view bound only to the immutable source
+    // request, so it can safely be the last fallback after a local research app returned no answer.
     let web_research_session = web_research_session_for_turn(user_prompt, run_id);
     global_assistant_tool_specs(memory.is_some())
         .iter()
@@ -2863,6 +2874,12 @@ and submit the FULL edited FlowScript source. Reconcile compares it to the live 
   resolvable FlowScript references/nested calls.
 - A new unanchored `function name(...) { ... }` declaration → creates a Function layer, places
   body nodes inside it, creates boundary pins from params/returns, and wires `return` values.
+- `@cache({ namespace: "...", ttlSeconds: 3600, scope: "user" })` immediately above a function
+  configures result caching; bare `@cache` defaults to the `global` namespace, a 300-second
+  lifetime, and app scope. Set `ttlSeconds: 0` explicitly for a permanent entry. A hit skips the
+  complete function body and all of its side effects, so preserve the decorator on unrelated edits
+  and use it only for functions whose outputs are determined by their inputs. Existing context may
+  report `ttl_seconds: null` for a permanent cache; preserve it as explicit `ttlSeconds: 0`.
 
 VALIDATION: This tool validates before queueing. If it reports parse errors or diagnostics,
 nothing was queued — revise the SAME submitted draft and call edit_flowscript again immediately.
@@ -4877,6 +4894,23 @@ mod tests {
         }
         assert!(DATA_STUDIO_APP_DISCOVERY_TOOL_NAMES.contains(&"list_apps"));
         assert!(DATA_STUDIO_APP_DISCOVERY_TOOL_NAMES.contains(&"describe_app_interface"));
+    }
+
+    #[test]
+    fn every_frontend_tool_closes_the_parent_raw_web_phase() {
+        for private_tool in [
+            "list_apps",
+            "describe_app_interface",
+            "call_app_chat",
+            "call_app_event",
+            "data_studio_agent",
+            MEMORY_SEARCH_TOOL,
+        ] {
+            assert!(
+                frontend_tool_result_closes_public_web_phase(private_tool),
+                "{private_tool} must close outbound public research"
+            );
+        }
     }
 
     #[test]

--- a/apps/extension/CHANGELOG.md
+++ b/apps/extension/CHANGELOG.md
@@ -7,3 +7,5 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## [Unreleased]
 
 - Initial release
+- Add completion, hover, highlighting and lint support for function `@cache` decorators, including
+  the global-namespace, 300-second defaults and explicit permanent `ttlSeconds: 0` behavior.

--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -15,6 +15,12 @@ Supports two file types:
 
 - **Syntax highlighting** for keywords, interface structs, types, decorators, calls, strings and
   anchor comments.
+- **Function result caching** support for bare `@cache`, empty `@cache({})`, and configured
+  `@cache({ namespace: "pricing", ttlSeconds: 0, scope: "user" })` decorators, including
+  completion, hover documentation and linting. Bare and empty forms use the `"global"` namespace,
+  a 300-second lifetime, and app scope; explicit `ttlSeconds: 0` keeps entries until invalidated.
+  Cache hits skip the entire function body, so only cache functions whose outputs are determined
+  by their inputs.
 - **Auto-completion** of every catalog node found in the workspace `.flow.d` files, plus locally
   declared interfaces, variables, functions and event handlers. Node completions insert a
   fully-named argument snippet (`floatAdd({ float1: \${1}, float2: \${2} })`).

--- a/apps/extension/src/diagnostics.ts
+++ b/apps/extension/src/diagnostics.ts
@@ -15,6 +15,54 @@ const CONTROL_NAMES = new Set([
 	"interface",
 ]);
 
+export interface DecoratorValidationIssue {
+	readonly message: string;
+	readonly code: "unknown-decorator" | "decorator-arg";
+}
+
+/** Validate a decorator argument captured with its surrounding parentheses. */
+export function validateDecoratorArgument(
+	name: string,
+	argGroup: string | undefined,
+): DecoratorValidationIssue | undefined {
+	const def = getDecorator(name);
+	if (!def) {
+		return {
+			message: `Unknown decorator '@${name}'.`,
+			code: "unknown-decorator",
+		};
+	}
+
+	const hasArg = argGroup !== undefined;
+	switch (def.argumentKind) {
+		case "required-string":
+			return hasArg
+				? undefined
+				: {
+						message: `Decorator '@${name}' requires a string argument, e.g. @${name}("…").`,
+						code: "decorator-arg",
+					};
+		case "none":
+			return hasArg
+				? {
+						message: `Decorator '@${name}' does not take an argument.`,
+						code: "decorator-arg",
+					}
+				: undefined;
+		case "optional-cache-settings": {
+			const argument = argGroup?.slice(1, -1).trim();
+			return argument === undefined ||
+				(argument.startsWith("{") && argument.endsWith("}"))
+				? undefined
+				: {
+						message:
+							'Decorator \'@cache\' takes an optional settings object, e.g. @cache({ namespace: "global", ttlSeconds: 300, scope: "user" }). Use ttlSeconds: 0 for no expiry.',
+						code: "decorator-arg",
+					};
+		}
+	}
+}
+
 export class FlowLinter {
 	private readonly collection: vscode.DiagnosticCollection;
 
@@ -68,31 +116,9 @@ export class FlowLinter {
 				new vscode.Position(line, nameStart),
 				new vscode.Position(line, nameStart + name.length),
 			);
-			const def = getDecorator(name);
-			if (!def) {
-				this.pushWarning(
-					range,
-					`Unknown decorator '@${name}'.`,
-					"unknown-decorator",
-					diagnostics,
-				);
-				continue;
-			}
-			const hasArg = argGroup !== undefined;
-			if (def.hasArg && !hasArg) {
-				this.pushWarning(
-					range,
-					`Decorator '@${name}' requires a string argument, e.g. @${name}("…").`,
-					"decorator-arg",
-					diagnostics,
-				);
-			} else if (!def.hasArg && hasArg) {
-				this.pushWarning(
-					range,
-					`Decorator '@${name}' does not take an argument.`,
-					"decorator-arg",
-					diagnostics,
-				);
+			const issue = validateDecoratorArgument(name, argGroup);
+			if (issue) {
+				this.pushWarning(range, issue.message, issue.code, diagnostics);
 			}
 		}
 	}

--- a/apps/extension/src/flowDocument.ts
+++ b/apps/extension/src/flowDocument.ts
@@ -98,6 +98,12 @@ export function analyzeFlowDocument(
 
 	for (let i = 0; i < idents.length; i++) {
 		const tok = idents[i];
+		// Decorator names such as `cache` are followed by `(` but are metadata, not top-level
+		// event declarations or workflow calls. Keep them out of symbols/local names as well as
+		// unknown-function diagnostics.
+		if (previousNonWsChar(text, tok.offset) === "@") {
+			continue;
+		}
 		const next = nextNonWsChar(text, tok.offset + tok.text.length);
 		const depth = braceDepthAt(text, tok.offset);
 
@@ -449,6 +455,16 @@ function tokenizeIdentifiers(text: string): Tok[] {
 
 function nextNonWsChar(text: string, from: number): string | undefined {
 	for (let i = from; i < text.length; i++) {
+		const ch = text[i];
+		if (ch !== " " && ch !== "\t" && ch !== "\r" && ch !== "\n") {
+			return ch;
+		}
+	}
+	return undefined;
+}
+
+function previousNonWsChar(text: string, from: number): string | undefined {
+	for (let i = from - 1; i >= 0; i--) {
 		const ch = text[i];
 		if (ch !== " " && ch !== "\t" && ch !== "\r" && ch !== "\n") {
 			return ch;

--- a/apps/extension/src/providers.ts
+++ b/apps/extension/src/providers.ts
@@ -21,51 +21,73 @@ import {
 
 const WORD_RE = /[A-Za-z_$][\w$]*/;
 
-/** Variable decorators recognized by the FlowScript parser. Mirrors
- * `render::var_decorators_of` / `parser::apply_var_decorators` in flow-like-ast. */
+/** Decorators recognized by the FlowScript parser. Mirrors the decorator
+ * handling in flow-like-ast. */
+export type DecoratorArgumentKind =
+	| "none"
+	| "required-string"
+	| "optional-cache-settings";
+
 export interface DecoratorDef {
 	readonly name: string;
-	readonly hasArg: boolean;
+	readonly argumentKind: DecoratorArgumentKind;
 	readonly detail: string;
 	readonly doc: string;
+	readonly snippet: string;
 }
 
 export const FLOW_DECORATORS: readonly DecoratorDef[] = [
 	{
 		name: "description",
-		hasArg: true,
+		argumentKind: "required-string",
 		detail: '@description("…")',
 		doc: "Human-facing description of the variable, shown in the UI.",
+		snippet: '@description("$1")',
 	},
 	{
 		name: "category",
-		hasArg: true,
+		argumentKind: "required-string",
 		detail: '@category("…")',
 		doc: "UI grouping category for the variable.",
+		snippet: '@category("$1")',
 	},
 	{
 		name: "schema",
-		hasArg: true,
+		argumentKind: "required-string",
 		detail: '@schema("…")',
 		doc: "JSON schema for a struct-typed variable, preserved verbatim.",
+		snippet: '@schema("$1")',
 	},
 	{
 		name: "secret",
-		hasArg: false,
+		argumentKind: "none",
 		detail: "@secret",
 		doc: "Marks the variable as a secret (masked and stored securely).",
+		snippet: "@secret",
 	},
 	{
 		name: "readonly",
-		hasArg: false,
+		argumentKind: "none",
 		detail: "@readonly",
 		doc: "Marks the variable as not user-editable.",
+		snippet: "@readonly",
 	},
 	{
 		name: "runtime",
-		hasArg: false,
+		argumentKind: "none",
 		detail: "@runtime",
 		doc: "Variable is configured per-user at runtime.",
+		snippet: "@runtime",
+	},
+	{
+		name: "cache",
+		argumentKind: "optional-cache-settings",
+		detail:
+			'@cache, @cache({}), or @cache({ namespace: "…", ttlSeconds: 300, scope: "user" })',
+		doc:
+			'Caches this function\'s outputs. A cache hit skips the entire function body, including side effects, so use it only when outputs are determined by inputs. Bare `@cache` and `@cache({})` use the `"global"` namespace, a 300-second lifetime, and app scope. In the settings object, `namespace` separates cache keys, `ttlSeconds` is a non-negative integer (`0` means no expiry), and `scope` is `"app"` or `"user"`.',
+		snippet:
+			'@cache({ namespace: "${1:global}", ttlSeconds: ${2:300}, scope: "${3|app,user|}" })',
 	},
 ];
 
@@ -195,7 +217,7 @@ export class FlowCompletionProvider implements vscode.CompletionItemProvider {
 	}
 }
 
-/** Completion for `@` variable decorators (`@description`, `@secret`, …). */
+/** Completion for FlowScript decorators (`@description`, `@cache`, …). */
 export class FlowDecoratorCompletionProvider
 	implements vscode.CompletionItemProvider
 {
@@ -222,9 +244,7 @@ export class FlowDecoratorCompletionProvider
 			item.detail = dec.detail;
 			item.documentation = new vscode.MarkdownString(dec.doc);
 			item.range = range;
-			item.insertText = dec.hasArg
-				? new vscode.SnippetString(`@${dec.name}("$1")`)
-				: `@${dec.name}`;
+			item.insertText = new vscode.SnippetString(dec.snippet);
 			return item;
 		});
 	}

--- a/apps/extension/src/test/extension.test.ts
+++ b/apps/extension/src/test/extension.test.ts
@@ -3,7 +3,12 @@ import * as assert from "assert";
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
 import * as vscode from "vscode";
-// import * as myExtension from '../../extension';
+import { validateDecoratorArgument } from "../diagnostics";
+import { analyzeFlowDocument } from "../flowDocument";
+import {
+	FlowDecoratorCompletionProvider,
+	getDecorator,
+} from "../providers";
 
 suite("Extension Test Suite", () => {
 	vscode.window.showInformationMessage("Start all tests.");
@@ -11,5 +16,64 @@ suite("Extension Test Suite", () => {
 	test("Sample test", () => {
 		assert.strictEqual(-1, [1, 2, 3].indexOf(5));
 		assert.strictEqual(-1, [1, 2, 3].indexOf(0));
+	});
+
+	test("cache decorator exposes configured completion and documentation", async () => {
+		const definition = getDecorator("cache");
+		assert.ok(definition);
+		assert.strictEqual(definition.argumentKind, "optional-cache-settings");
+		assert.match(definition.doc, /namespace/);
+		assert.match(definition.doc, /ttlSeconds/);
+		assert.match(definition.doc, /app.*user/);
+		assert.match(definition.doc, /global/);
+		assert.match(definition.doc, /300-second/);
+		assert.match(definition.doc, /0.*no expiry/);
+
+		const document = await vscode.workspace.openTextDocument({
+			language: "flowscript",
+			content: "@ca",
+		});
+		const items = new FlowDecoratorCompletionProvider().provideCompletionItems(
+			document,
+			new vscode.Position(0, 3),
+		);
+		const cache = items?.find((item) => item.label === "@cache");
+		assert.ok(cache);
+		assert.ok(cache.insertText instanceof vscode.SnippetString);
+		assert.match(cache.insertText.value, /namespace:.*global/);
+		assert.match(cache.insertText.value, /ttlSeconds:.*300/);
+		assert.match(cache.insertText.value, /app,user/);
+	});
+
+	test("cache decorator lint accepts bare and object forms", () => {
+		assert.strictEqual(validateDecoratorArgument("cache", undefined), undefined);
+		assert.strictEqual(validateDecoratorArgument("cache", "({})"), undefined);
+		assert.strictEqual(
+			validateDecoratorArgument(
+				"cache",
+				'({ namespace: "pricing", ttlSeconds: 0, scope: "user" })',
+			),
+			undefined,
+		);
+
+		const invalid = validateDecoratorArgument("cache", '("pricing")');
+		assert.ok(invalid);
+		assert.match(invalid.message, /settings object/);
+		assert.match(invalid.message, /ttlSeconds: 0/);
+		assert.doesNotMatch(invalid.message, /requires a string argument/);
+	});
+
+	test("cache decorator is not indexed as an event or function call", async () => {
+		const document = await vscode.workspace.openTextDocument({
+			language: "flowscript",
+			content: `@cache({ namespace: "pricing" })
+function calculatePricing() {
+}`,
+		});
+		const model = analyzeFlowDocument(document);
+
+		assert.ok(!model.localNames.has("cache"));
+		assert.ok(!model.calls.some((call) => call.name === "cache"));
+		assert.ok(!model.symbols.some((symbol) => symbol.name === "cache"));
 	});
 });

--- a/apps/extension/syntaxes/flow.tmLanguage.json
+++ b/apps/extension/syntaxes/flow.tmLanguage.json
@@ -33,7 +33,7 @@
 			"patterns": [
 				{
 					"name": "meta.decorator.flow",
-					"match": "(@)(secret|readonly|runtime|category|description|schema)\\b",
+					"match": "(@)(secret|readonly|runtime|category|description|schema|cache)\\b",
 					"captures": {
 						"1": { "name": "punctuation.decorator.flow" },
 						"2": { "name": "entity.name.function.decorator.flow" }

--- a/packages/api/src/routes/app/page/get_page.rs
+++ b/packages/api/src/routes/app/page/get_page.rs
@@ -36,7 +36,9 @@ fn if_none_match_matches(headers: &HeaderMap, etag: &str) -> bool {
                 let candidate = candidate.trim();
                 candidate == "*"
                     || candidate == etag
-                    || candidate.strip_prefix("W/").is_some_and(|inner| inner == etag)
+                    || candidate
+                        .strip_prefix("W/")
+                        .is_some_and(|inner| inner == etag)
             })
         })
 }
@@ -210,7 +212,10 @@ mod tests {
     #[test]
     fn rejects_a_tag_from_different_content() {
         let etag = page_etag(b"payload");
-        assert!(!if_none_match_matches(&headers_with(&etag), &page_etag(b"other")));
+        assert!(!if_none_match_matches(
+            &headers_with(&etag),
+            &page_etag(b"other")
+        ));
         assert!(!if_none_match_matches(&HeaderMap::new(), &etag));
     }
 }

--- a/packages/ast/src/model.rs
+++ b/packages/ast/src/model.rs
@@ -101,8 +101,70 @@ pub struct FnDecl {
     pub params: Vec<Param>,
     pub returns: Vec<Param>,
     pub body: Block,
+    /// Result-cache policy for this function. Presence maps to an enabled layer cache and is
+    /// rendered as `@cache` (defaults) or `@cache({ ... })` immediately above the declaration.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache: Option<FunctionCache>,
     /// Stable identity anchor (the layer id).
     pub anchor: Option<String>,
+}
+
+/// Default namespace used by a bare `@cache` decorator.
+pub const DEFAULT_FUNCTION_CACHE_NAMESPACE: &str = "global";
+/// Default entry lifetime used by a bare `@cache` decorator, in seconds.
+pub const DEFAULT_FUNCTION_CACHE_TTL_SECONDS: u64 = 300;
+
+/// Result-cache settings attached to a FlowScript function.
+///
+/// The language calls `prefix` a namespace because that is the cache-backend concept exposed to
+/// authors. FlowScript defaults to the global namespace with a five-minute lifetime; an explicit
+/// lifetime of zero keeps entries until they are invalidated.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FunctionCache {
+    #[serde(default = "default_function_cache_namespace")]
+    pub namespace: String,
+    #[serde(default = "default_function_cache_ttl_seconds")]
+    pub ttl_seconds: Option<u64>,
+    #[serde(default)]
+    pub scope: FunctionCacheScope,
+}
+
+fn default_function_cache_namespace() -> String {
+    DEFAULT_FUNCTION_CACHE_NAMESPACE.to_string()
+}
+
+fn default_function_cache_ttl_seconds() -> Option<u64> {
+    Some(DEFAULT_FUNCTION_CACHE_TTL_SECONDS)
+}
+
+impl Default for FunctionCache {
+    fn default() -> Self {
+        Self {
+            namespace: default_function_cache_namespace(),
+            ttl_seconds: default_function_cache_ttl_seconds(),
+            scope: FunctionCacheScope::App,
+        }
+    }
+}
+
+/// Who may share a cached function result.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum FunctionCacheScope {
+    /// Shared by callers of the app.
+    #[default]
+    App,
+    /// Private to the user who triggered the run.
+    User,
+}
+
+impl FunctionCacheScope {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::App => "app",
+            Self::User => "user",
+        }
+    }
 }
 
 /// A named, typed function parameter or return value.

--- a/packages/ast/src/parse/lexer.rs
+++ b/packages/ast/src/parse/lexer.rs
@@ -15,6 +15,9 @@ pub enum Tok {
     Str(String),
     /// Integer literal.
     Int(i64),
+    /// Positive integer outside the signed literal range. FlowScript values remain `i64`, but
+    /// metadata such as a cache TTL uses the full `u64` range.
+    UInt(u64),
     /// Floating-point literal.
     Float(f64),
     /// `@` — decorator marker.
@@ -341,10 +344,14 @@ impl Lexer {
                     .map_err(|_| self.err(format!("invalid float `{text}`")))?,
             )
         } else {
-            Tok::Int(
-                text.parse()
-                    .map_err(|_| self.err(format!("invalid integer `{text}`")))?,
-            )
+            match text.parse::<i64>() {
+                Ok(value) => Tok::Int(value),
+                Err(_) if !text.starts_with('-') => Tok::UInt(
+                    text.parse()
+                        .map_err(|_| self.err(format!("invalid integer `{text}`")))?,
+                ),
+                Err(_) => return Err(self.err(format!("invalid integer `{text}`"))),
+            }
         };
         Ok(Token {
             tok,
@@ -413,7 +420,13 @@ fn signed_number_can_start_after(previous: Option<&Token>) -> bool {
     match previous.map(|token| &token.tok) {
         None => true,
         Some(
-            Tok::Str(_) | Tok::Int(_) | Tok::Float(_) | Tok::RParen | Tok::RBracket | Tok::RBrace,
+            Tok::Str(_)
+            | Tok::Int(_)
+            | Tok::UInt(_)
+            | Tok::Float(_)
+            | Tok::RParen
+            | Tok::RBracket
+            | Tok::RBrace,
         ) => false,
         Some(Tok::Ident(name)) => name == "return",
         Some(_) => true,

--- a/packages/ast/src/parse/parser.rs
+++ b/packages/ast/src/parse/parser.rs
@@ -11,6 +11,7 @@ use crate::model::*;
 use crate::parse::error::ParseError;
 use crate::parse::lexer::{Tok, Token, lex};
 use crate::schema::{apply_interface_schemas, schema_from_interface};
+use std::collections::HashSet;
 
 /// Parse FlowScript source into a [`BoardAst`].
 pub fn parse(src: &str) -> Result<BoardAst, ParseError> {
@@ -52,10 +53,15 @@ struct Parser<'a> {
     depth: usize,
 }
 
-/// A parsed `@decorator`, optionally carrying a single string argument.
+/// A parsed `@decorator`, optionally carrying a string or the structured `@cache` settings.
 struct Decorator {
     name: String,
-    arg: Option<String>,
+    arg: Option<DecoratorArg>,
+}
+
+enum DecoratorArg {
+    String(String),
+    Cache(FunctionCache),
 }
 
 impl Parser<'_> {
@@ -198,22 +204,23 @@ impl Parser<'_> {
 
     // ---- decorators -----------------------------------------------------------------------
 
-    /// Parse zero or more leading `@decorator` lines. Each is a bare flag (`@secret`) or carries
-    /// a single string argument (`@category("…")`).
+    /// Parse zero or more leading `@decorator` lines. Most carry either no argument (`@secret`)
+    /// or one string (`@category("…")`); `@cache` additionally accepts a settings object.
     fn decorators(&mut self) -> Result<Vec<Decorator>, ParseError> {
         let mut decorators = Vec::new();
         while matches!(self.cur(), Tok::At) {
             self.bump();
             let name = self.ident()?;
             let arg = if self.eat(&Tok::LParen) {
-                let value = match self.cur().clone() {
-                    Tok::Str(s) => {
+                let value = match (name.as_str(), self.cur().clone()) {
+                    ("cache", Tok::LBrace) => DecoratorArg::Cache(self.cache_decorator_settings()?),
+                    (_, Tok::Str(s)) => {
                         self.bump();
-                        s
+                        DecoratorArg::String(s)
                     }
                     other => {
                         return Err(self.err(format!(
-                            "expected string decorator argument, found `{other:?}`"
+                            "expected string decorator argument (or an object for `@cache`), found `{other:?}`"
                         )));
                     }
                 };
@@ -225,6 +232,82 @@ impl Parser<'_> {
             decorators.push(Decorator { name, arg });
         }
         Ok(decorators)
+    }
+
+    /// Parse the canonical cache settings object. Fields are deliberately parsed here instead of
+    /// as a general expression so duplicate/unknown keys and invalid policy values fail with a
+    /// precise decorator diagnostic.
+    fn cache_decorator_settings(&mut self) -> Result<FunctionCache, ParseError> {
+        self.expect(&Tok::LBrace)?;
+        let mut settings = FunctionCache::default();
+        let mut seen = HashSet::new();
+
+        while !matches!(self.cur(), Tok::RBrace) {
+            let field = self.arg_key()?;
+            if !seen.insert(field.clone()) {
+                return Err(self.err(format!("duplicate field `{field}` in `@cache` decorator")));
+            }
+            self.expect(&Tok::Colon)?;
+            match field.as_str() {
+                "namespace" => match self.cur().clone() {
+                    Tok::Str(value) => {
+                        self.bump();
+                        settings.namespace = value;
+                    }
+                    other => {
+                        return Err(self.err(format!(
+                            "`@cache` field `namespace` must be a string, found `{other:?}`"
+                        )));
+                    }
+                },
+                "ttlSeconds" => match self.cur().clone() {
+                    Tok::Int(value) if value >= 0 => {
+                        self.bump();
+                        settings.ttl_seconds = Some(value as u64);
+                    }
+                    Tok::UInt(value) => {
+                        self.bump();
+                        settings.ttl_seconds = Some(value);
+                    }
+                    other => {
+                        return Err(self.err(format!(
+                            "`@cache` field `ttlSeconds` must be a non-negative integer, found `{other:?}`"
+                        )));
+                    }
+                },
+                "scope" => match self.cur().clone() {
+                    Tok::Str(value) if value == "app" => {
+                        self.bump();
+                        settings.scope = FunctionCacheScope::App;
+                    }
+                    Tok::Str(value) if value == "user" => {
+                        self.bump();
+                        settings.scope = FunctionCacheScope::User;
+                    }
+                    Tok::Str(value) => {
+                        return Err(self.err(format!(
+                            "`@cache` field `scope` must be \"app\" or \"user\", found {value:?}"
+                        )));
+                    }
+                    other => {
+                        return Err(self.err(format!(
+                            "`@cache` field `scope` must be a string, found `{other:?}`"
+                        )));
+                    }
+                },
+                other => {
+                    return Err(self.err(format!(
+                        "unknown field `{other}` in `@cache` decorator; expected `namespace`, `ttlSeconds`, or `scope`"
+                    )));
+                }
+            }
+
+            if !self.eat(&Tok::Comma) {
+                break;
+            }
+        }
+        self.expect(&Tok::RBrace)?;
+        Ok(settings)
     }
 
     /// Apply parsed decorators to a variable declaration, erroring on unknown ones or argument
@@ -257,6 +340,36 @@ impl Parser<'_> {
         Ok(())
     }
 
+    /// Apply decorators that belong to a function declaration. Presence of `@cache` enables
+    /// caching; a bare decorator uses FlowScript's global, five-minute, app-scoped defaults.
+    fn apply_fn_decorators(
+        &self,
+        func: &mut FnDecl,
+        decorators: &[Decorator],
+    ) -> Result<(), ParseError> {
+        for dec in decorators {
+            match dec.name.as_str() {
+                "cache" => {
+                    if func.cache.is_some() {
+                        return Err(self.err("duplicate `@cache` decorator on function"));
+                    }
+                    func.cache = Some(match &dec.arg {
+                        None => FunctionCache::default(),
+                        Some(DecoratorArg::Cache(settings)) => settings.clone(),
+                        Some(DecoratorArg::String(_)) => {
+                            return Err(self
+                                .err("decorator `@cache` takes a settings object, not a string"));
+                        }
+                    });
+                }
+                other => {
+                    return Err(self.err(format!("unknown decorator `@{other}` on function")));
+                }
+            }
+        }
+        Ok(())
+    }
+
     fn expect_no_arg(&self, dec: &Decorator) -> Result<(), ParseError> {
         if dec.arg.is_some() {
             return Err(self.err(format!(
@@ -268,12 +381,17 @@ impl Parser<'_> {
     }
 
     fn expect_arg(&self, dec: &Decorator) -> Result<String, ParseError> {
-        dec.arg.clone().ok_or_else(|| {
-            self.err(format!(
+        match &dec.arg {
+            Some(DecoratorArg::String(value)) => Ok(value.clone()),
+            Some(DecoratorArg::Cache(_)) => Err(self.err(format!(
                 "decorator `@{}` requires a string argument",
                 dec.name
-            ))
-        })
+            ))),
+            None => Err(self.err(format!(
+                "decorator `@{}` requires a string argument",
+                dec.name
+            ))),
+        }
     }
 
     // ---- top level ------------------------------------------------------------------------
@@ -295,10 +413,9 @@ impl Parser<'_> {
                     ast.variables.push(var);
                 }
                 Tok::Ident(kw) if kw == "function" => {
-                    if !decorators.is_empty() {
-                        return Err(self.err("decorators on functions are not yet supported"));
-                    }
-                    ast.functions.push(self.fn_decl()?);
+                    let mut func = self.fn_decl()?;
+                    self.apply_fn_decorators(&mut func, &decorators)?;
+                    ast.functions.push(func);
                 }
                 Tok::Ident(_) => {
                     if !decorators.is_empty() {
@@ -416,6 +533,7 @@ impl Parser<'_> {
             params,
             returns,
             body,
+            cache: None,
             anchor,
         })
     }

--- a/packages/ast/src/render.rs
+++ b/packages/ast/src/render.rs
@@ -183,6 +183,9 @@ impl Writer<'_> {
     }
 
     fn fn_decl(&mut self, func: &FnDecl) {
+        if let Some(cache) = &func.cache {
+            self.function_cache_decorator(cache);
+        }
         self.indent();
         self.out.push_str("function ");
         self.out.push_str(&func.name);
@@ -200,6 +203,34 @@ impl Writer<'_> {
         self.block(&func.body);
         self.indent();
         self.out.push_str("}\n");
+    }
+
+    /// Render function caching in one stable field order. Default-valued fields are omitted; an
+    /// entirely default policy is the compact `@cache` flag.
+    fn function_cache_decorator(&mut self, cache: &FunctionCache) {
+        self.indent();
+        let mut fields = Vec::new();
+        if cache.namespace != DEFAULT_FUNCTION_CACHE_NAMESPACE {
+            fields.push(format!("namespace: {}", quote_string(&cache.namespace)));
+        }
+        match cache.ttl_seconds {
+            Some(DEFAULT_FUNCTION_CACHE_TTL_SECONDS) => {}
+            Some(ttl_seconds) => fields.push(format!("ttlSeconds: {ttl_seconds}")),
+            // Legacy/programmatic ASTs may still carry `None` for a permanent cache. FlowScript's
+            // omission now means five minutes, so preserve permanence with the explicit spelling.
+            None => fields.push("ttlSeconds: 0".to_string()),
+        }
+        if cache.scope != FunctionCacheScope::App {
+            fields.push(format!("scope: {}", quote_string(cache.scope.as_str())));
+        }
+
+        if fields.is_empty() {
+            self.out.push_str("@cache\n");
+        } else {
+            self.out.push_str("@cache({ ");
+            self.out.push_str(&fields.join(", "));
+            self.out.push_str(" })\n");
+        }
     }
 
     fn event_block(&mut self, event: &EventBlock) {

--- a/packages/ast/tests/parse.rs
+++ b/packages/ast/tests/parse.rs
@@ -139,6 +139,139 @@ fn rejects_missing_arg_on_valued_decorator() {
 }
 
 #[test]
+fn roundtrip_bare_function_cache_decorator() {
+    let text = "@cache\nfunction lookup(key: string): (value: string) {\n    return key\n}\n";
+    let ast = parse(text).expect("bare cache decorator should parse");
+    let cache = ast.functions[0]
+        .cache
+        .as_ref()
+        .expect("bare decorator should enable caching");
+    assert_eq!(cache.namespace, "global");
+    assert_eq!(cache.ttl_seconds, Some(300));
+    assert_eq!(cache.scope, flow_like_ast::FunctionCacheScope::App);
+    assert_eq!(render(&ast, &RenderOptions::default()), text);
+}
+
+#[test]
+fn empty_function_cache_settings_use_and_render_as_semantic_defaults() {
+    let ast =
+        parse("@cache({})\nfunction lookup() {\n}\n").expect("empty cache settings should parse");
+    assert_eq!(
+        ast.functions[0].cache,
+        Some(flow_like_ast::FunctionCache::default())
+    );
+    assert_eq!(
+        render(&ast, &RenderOptions::default()),
+        "@cache\nfunction lookup() {\n}\n"
+    );
+}
+
+#[test]
+fn function_cache_fields_parse_in_any_order_and_render_canonically() {
+    use flow_like_ast::FunctionCacheScope;
+
+    let source = "@cache({ scope: \"user\", ttlSeconds: 3600, namespace: \"pricing\" })\nfunction quote() {\n}\n";
+    let expected = "@cache({ namespace: \"pricing\", ttlSeconds: 3600, scope: \"user\" })\nfunction quote() {\n}\n";
+    let ast = parse(source).expect("structured cache decorator should parse");
+    let cache = ast.functions[0]
+        .cache
+        .as_ref()
+        .expect("function should carry cache settings");
+    assert_eq!(cache.namespace, "pricing");
+    assert_eq!(cache.ttl_seconds, Some(3600));
+    assert_eq!(cache.scope, FunctionCacheScope::User);
+    assert_eq!(render(&ast, &RenderOptions::default()), expected);
+}
+
+#[test]
+fn explicit_function_cache_defaults_render_as_bare_decorator() {
+    let source = "@cache({ namespace: \"global\", ttlSeconds: 300, scope: \"app\" })\nfunction lookup() {\n}\n";
+    let ast = parse(source).expect("explicit defaults should parse");
+    assert_eq!(
+        render(&ast, &RenderOptions::default()),
+        "@cache\nfunction lookup() {\n}\n"
+    );
+}
+
+#[test]
+fn explicit_zero_function_cache_ttl_remains_permanent() {
+    let source = "@cache({ ttlSeconds: 0 })\nfunction lookup() {\n}\n";
+    let ast = parse(source).expect("zero cache TTL should parse");
+    assert_eq!(
+        ast.functions[0].cache.as_ref().unwrap().ttl_seconds,
+        Some(0)
+    );
+    assert_eq!(render(&ast, &RenderOptions::default()), source);
+}
+
+#[test]
+fn deserialized_function_cache_uses_flowscript_semantic_defaults() {
+    let cache: flow_like_ast::FunctionCache =
+        serde_json::from_value(serde_json::json!({})).expect("cache JSON should deserialize");
+    assert_eq!(cache, flow_like_ast::FunctionCache::default());
+    assert_eq!(cache.namespace, "global");
+    assert_eq!(cache.ttl_seconds, Some(300));
+}
+
+#[test]
+fn function_cache_ttl_supports_the_full_persisted_u64_range() {
+    let source = format!(
+        "@cache({{ ttlSeconds: {} }})\nfunction lookup() {{\n}}\n",
+        u64::MAX
+    );
+    let ast = parse(&source).expect("the largest persisted cache TTL should parse");
+    assert_eq!(
+        ast.functions[0].cache.as_ref().unwrap().ttl_seconds,
+        Some(u64::MAX)
+    );
+    assert_eq!(render(&ast, &RenderOptions::default()), source);
+}
+
+#[test]
+fn rejects_duplicate_or_unknown_function_cache_fields() {
+    let duplicate =
+        parse("@cache({ namespace: \"a\", namespace: \"b\" })\nfunction lookup() {\n}\n")
+            .unwrap_err();
+    assert!(duplicate.message.contains("duplicate field `namespace`"));
+
+    let unknown = parse("@cache({ prefix: \"a\" })\nfunction lookup() {\n}\n").unwrap_err();
+    assert!(unknown.message.contains("unknown field `prefix`"));
+}
+
+#[test]
+fn rejects_invalid_function_cache_values_and_arguments() {
+    for (source, expected) in [
+        (
+            "@cache({ ttlSeconds: -1 })\nfunction lookup() {\n}\n",
+            "non-negative integer",
+        ),
+        (
+            "@cache({ ttlSeconds: 1.5 })\nfunction lookup() {\n}\n",
+            "non-negative integer",
+        ),
+        (
+            "@cache({ namespace: 7 })\nfunction lookup() {\n}\n",
+            "namespace` must be a string",
+        ),
+        (
+            "@cache({ scope: \"team\" })\nfunction lookup() {\n}\n",
+            "must be \"app\" or \"user\"",
+        ),
+        (
+            "@cache(\"pricing\")\nfunction lookup() {\n}\n",
+            "takes a settings object",
+        ),
+    ] {
+        let err = parse(source).unwrap_err();
+        assert!(
+            err.message.contains(expected),
+            "expected {expected:?} in {:?}",
+            err.message
+        );
+    }
+}
+
+#[test]
 fn roundtrip_json_default_vs_struct_literal() {
     // Canonical compact JSON stays a JSON literal; spaced struct literal stays an Object.
     let text = "onStart() {\n    structSet({ structIn: {}, payload: {\"a\":1} })\n}\n";
@@ -805,6 +938,7 @@ fn field_assign_renders_from_hand_built_ast() {
             params: Vec::new(),
             returns: Vec::new(),
             body: Block { stmts: vec![stmt] },
+            cache: None,
             anchor: None,
         }],
         ..BoardAst::default()

--- a/packages/catalog/media/src/document/pdf/create_from_markdown.rs
+++ b/packages/catalog/media/src/document/pdf/create_from_markdown.rs
@@ -217,10 +217,7 @@ async fn resolve_images(
         let bytes = match fetch_image_bytes(context, &client, url).await {
             Ok(bytes) => bytes,
             Err(err) => {
-                context.log_message(
-                    &format!("Skipping image \"{url}\": {err}"),
-                    LogLevel::Warn,
-                );
+                context.log_message(&format!("Skipping image \"{url}\": {err}"), LogLevel::Warn);
                 continue;
             }
         };

--- a/packages/catalog/media/src/document/pdf/render.rs
+++ b/packages/catalog/media/src/document/pdf/render.rs
@@ -435,7 +435,9 @@ pub fn parse_markdown(markdown: &str) -> Vec<Block> {
                     if !collected.is_empty() {
                         blocks.push(Block::ListItem {
                             depth: list_stack.len().max(1),
-                            marker: pending_marker.take().unwrap_or_else(|| "\u{2022}".to_string()),
+                            marker: pending_marker
+                                .take()
+                                .unwrap_or_else(|| "\u{2022}".to_string()),
                             spans: collected,
                         });
                     }
@@ -964,7 +966,9 @@ pub fn render_document(
     let content_width = layout.content_width();
 
     let mut blocks = blocks;
-    if metadata.cover && let Some(title) = metadata.title.as_deref() {
+    if metadata.cover
+        && let Some(title) = metadata.title.as_deref()
+    {
         draw_title_block(&mut writer, title, metadata.subject.as_deref(), layout);
         // A document usually opens with the same H1 the cover already sets. Printing both reads
         // as a mistake, so the duplicate is dropped rather than asking authors to strip it.
@@ -1131,7 +1135,15 @@ fn draw_title_block(
     let content_width = layout.content_width();
     let size = layout.base_font_size * 2.6;
 
-    writer.rounded_rect(left, writer.y + size * 0.55, 42.0, 3.5, 1.75, Some(ACCENT), None);
+    writer.rounded_rect(
+        left,
+        writer.y + size * 0.55,
+        42.0,
+        3.5,
+        1.75,
+        Some(ACCENT),
+        None,
+    );
     writer.y -= 14.0;
 
     for line in wrap_plain(title, content_width, Font::Bold, size) {
@@ -1142,7 +1154,12 @@ fn draw_title_block(
 
     if let Some(subject) = subject.filter(|s| !s.is_empty()) {
         writer.y -= 2.0;
-        for line in wrap_plain(subject, content_width, Font::Regular, layout.base_font_size * 1.1) {
+        for line in wrap_plain(
+            subject,
+            content_width,
+            Font::Regular,
+            layout.base_font_size * 1.1,
+        ) {
             let y = writer.y;
             writer.text(
                 Font::Regular,
@@ -1389,8 +1406,15 @@ fn is_numeric_cell(text: &str) -> bool {
     !cleaned.is_empty() && cleaned.parse::<f64>().is_ok()
 }
 
-fn draw_table(writer: &mut PageWriter, header: &[String], rows: &[Vec<String>], layout: &PdfLayout) {
-    let columns = header.len().max(rows.iter().map(Vec::len).max().unwrap_or(0));
+fn draw_table(
+    writer: &mut PageWriter,
+    header: &[String],
+    rows: &[Vec<String>],
+    layout: &PdfLayout,
+) {
+    let columns = header
+        .len()
+        .max(rows.iter().map(Vec::len).max().unwrap_or(0));
     if columns == 0 {
         return;
     }
@@ -1417,10 +1441,7 @@ fn draw_table(writer: &mut PageWriter, header: &[String], rows: &[Vec<String>], 
         weights[index] = head_width.max(body_width).max(size * 2.0) + padding * 2.0;
     }
     let total: f64 = weights.iter().sum();
-    let widths: Vec<f64> = weights
-        .iter()
-        .map(|w| w / total * content_width)
-        .collect();
+    let widths: Vec<f64> = weights.iter().map(|w| w / total * content_width).collect();
     let offsets: Vec<f64> = widths
         .iter()
         .scan(0.0, |acc, w| {
@@ -1474,7 +1495,14 @@ fn draw_table(writer: &mut PageWriter, header: &[String], rows: &[Vec<String>], 
                     &text,
                 );
             } else {
-                writer.text(Font::Bold, size, WHITE, left + offsets[index] + padding, y, &text);
+                writer.text(
+                    Font::Bold,
+                    size,
+                    WHITE,
+                    left + offsets[index] + padding,
+                    y,
+                    &text,
+                );
             }
         }
         writer.y = top - row_height - size;
@@ -1489,7 +1517,13 @@ fn draw_table(writer: &mut PageWriter, header: &[String], rows: &[Vec<String>], 
         }
         let top = writer.y + size;
         if row_index % 2 == 1 {
-            writer.rect(left, top - row_height, content_width, row_height, SURFACE_SOFT);
+            writer.rect(
+                left,
+                top - row_height,
+                content_width,
+                row_height,
+                SURFACE_SOFT,
+            );
         }
         for index in 0..columns {
             let cell = row.get(index).map(String::as_str).unwrap_or("");
@@ -1581,7 +1615,11 @@ fn series_color(index: usize, data: &OfficeChartData) -> Rgb {
 /// reserve less space than the chart it introduces actually takes.
 fn chart_card_height(data: &OfficeChartData, base: f64) -> f64 {
     let legend_rows = if data.series.len() > 1 { 1 } else { 0 };
-    let title_height = if data.title.is_some() { base * 2.0 } else { 0.0 };
+    let title_height = if data.title.is_some() {
+        base * 2.0
+    } else {
+        0.0
+    };
     title_height + CHART_PLOT_HEIGHT + 34.0 + legend_rows as f64 * (base * 1.8) + 20.0
 }
 
@@ -1593,7 +1631,11 @@ fn draw_chart(writer: &mut PageWriter, data: &OfficeChartData, layout: &PdfLayou
     let card_width = layout.content_width();
     let plot_height = CHART_PLOT_HEIGHT;
 
-    let title_height = if data.title.is_some() { base * 2.0 } else { 0.0 };
+    let title_height = if data.title.is_some() {
+        base * 2.0
+    } else {
+        0.0
+    };
     let card_height = chart_card_height(data, base);
 
     writer.require(card_height + base);
@@ -1721,7 +1763,14 @@ fn draw_cartesian(
         if horizontal {
             let gx = x + ratio * width;
             writer.line(gx, y, gx, y + height, GRID, 0.5);
-            writer.text_center(Font::Regular, tick_size, MUTED, gx, y - 12.0, &format_tick(tick));
+            writer.text_center(
+                Font::Regular,
+                tick_size,
+                MUTED,
+                gx,
+                y - 12.0,
+                &format_tick(tick),
+            );
         } else {
             let gy = y + ratio * height;
             writer.line(x, gy, x + width, gy, GRID, 0.5);
@@ -1839,14 +1888,34 @@ fn draw_cartesian(
                             - (category as f64 * band + pad)
                             - bar_width * if stacked { 1.0 } else { index as f64 + 1.0 };
                         let bx = x + if stacked { offset } else { 0.0 };
-                        writer.rounded_rect(bx, by, extent.max(0.6), bar_width * 0.9, 2.0, Some(color), None);
+                        writer.rounded_rect(
+                            bx,
+                            by,
+                            extent.max(0.6),
+                            bar_width * 0.9,
+                            2.0,
+                            Some(color),
+                            None,
+                        );
                     } else {
                         let bx = x
                             + category as f64 * band
                             + pad
-                            + if stacked { 0.0 } else { index as f64 * bar_width };
+                            + if stacked {
+                                0.0
+                            } else {
+                                index as f64 * bar_width
+                            };
                         let by = y + if stacked { offset } else { 0.0 };
-                        writer.rounded_rect(bx, by, bar_width * 0.9, extent.max(0.6), 2.0, Some(color), None);
+                        writer.rounded_rect(
+                            bx,
+                            by,
+                            bar_width * 0.9,
+                            extent.max(0.6),
+                            2.0,
+                            Some(color),
+                            None,
+                        );
                     }
                     if stacked {
                         offset += extent;
@@ -1951,7 +2020,12 @@ fn draw_pie(
             INK,
             legend_x + base * 1.2,
             legend_y,
-            &truncate_to_width(&text, x + width - legend_x - base * 1.5, Font::Regular, base * 0.82),
+            &truncate_to_width(
+                &text,
+                x + width - legend_x - base * 1.5,
+                Font::Regular,
+                base * 0.82,
+            ),
         );
         legend_y -= base * 1.5;
     }
@@ -1995,7 +2069,14 @@ fn draw_radar(
     }
     for index in 0..axes {
         let a = angle_at(index);
-        writer.line(cx, cy, cx + radius * a.cos(), cy + radius * a.sin(), GRID, 0.5);
+        writer.line(
+            cx,
+            cy,
+            cx + radius * a.cos(),
+            cy + radius * a.sin(),
+            GRID,
+            0.5,
+        );
     }
 
     for (series_index, series) in data.series.iter().enumerate() {
@@ -2473,9 +2554,7 @@ mod tests {
     #[test]
     fn every_chart_type_renders_without_panicking() {
         let layout = PdfLayout::default();
-        for kind in [
-            "bar", "line", "area", "scatter", "pie", "radar", "funnel",
-        ] {
+        for kind in ["bar", "line", "area", "scatter", "pie", "radar", "funnel"] {
             let markdown = format!(
                 "```nivo\ntype: {kind}\ntitle: {kind} chart\n---\nStage,Alpha,Beta\nOne,10,4\nTwo,26,12\nThree,18,9\n```\n"
             );
@@ -2596,8 +2675,8 @@ mod tests {
             ..Default::default()
         };
         let (pages, keys) = render_document(&blocks, &layout, &HashMap::new(), &metadata);
-        let bytes = build_pdf(pages, &keys, &HashMap::new(), &layout, &metadata)
-            .expect("build pdf");
+        let bytes =
+            build_pdf(pages, &keys, &HashMap::new(), &layout, &metadata).expect("build pdf");
         assert!(bytes.starts_with(b"%PDF-"));
         let reloaded = Document::load_mem(&bytes).expect("reload pdf");
         assert_eq!(reloaded.page_iter().count(), 1);

--- a/packages/catalog/std/src/control/call_function.rs
+++ b/packages/catalog/std/src/control/call_function.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use flow_like::flow::{
     board::{Board, Layer, LayerCache, LayerCacheScope, LayerType},
     execution::{
-        LogLevel, context::ExecutionContext, internal_node::InternalNode,
+        EventTrigger, LogLevel, context::ExecutionContext, internal_node::InternalNode,
         internal_pin::InternalPin,
     },
     node::{Node, NodeLogic},
@@ -13,7 +13,11 @@ use flow_like::flow::{
     variable::VariableType,
 };
 use flow_like_catalog_data::data::cache::{CacheScope, FlowCache, cache_get, cache_set};
-use flow_like_types::{Value, async_trait, json::from_slice};
+use flow_like_types::{Value, async_trait, json::from_slice, sync::RwLock};
+
+/// Cache persistence is an optimization and must never hold the execution chain open forever.
+/// This also bounds local object-store writes, which do not have the HTTP client's request timeout.
+const FUNCTION_CACHE_WRITE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
 /// Fold a value into the hasher in a shape that does not depend on how its maps happen to
 /// be ordered in memory, so the same inputs always produce the same cache key.
@@ -199,6 +203,86 @@ impl CallFunctionNode {
         }
 
         Ok(())
+    }
+
+    /// Start persisting a miss without putting the write on the node's successor-critical path.
+    /// The completion hook joins the task before the run is finalized, keeping writes reliable in
+    /// short-lived runtimes while downstream nodes are free to execute concurrently.
+    async fn persist_cache_result(
+        context: &mut ExecutionContext,
+        function_name: String,
+        handle: FlowCache,
+        key: String,
+        outputs: Value,
+        ttl: Option<u64>,
+    ) {
+        let node_id = context.id.to_string();
+        let mut write_context = context.clone();
+        // Completion callbacks retain their captures for the life of the run. Detach the cloned
+        // context's registry so callback -> task -> context cannot point back to the callback.
+        write_context.completion_callbacks = Arc::new(RwLock::new(Vec::new()));
+
+        let write_function_name = function_name.clone();
+        let cancellation = write_context.get_cancellation_token();
+        let task = flow_like_types::tokio::spawn(async move {
+            let write = async {
+                match flow_like_types::tokio::time::timeout(
+                    FUNCTION_CACHE_WRITE_TIMEOUT,
+                    cache_set(&write_context, &handle, &key, outputs, ttl),
+                )
+                .await
+                {
+                    Ok(Ok(_)) => None,
+                    Ok(Err(error)) => Some(format!(
+                        "Could not cache the result of function '{}': {:?}",
+                        write_function_name, error
+                    )),
+                    Err(_) => Some(format!(
+                        "Caching the result of function '{}' timed out after {} seconds",
+                        write_function_name,
+                        FUNCTION_CACHE_WRITE_TIMEOUT.as_secs()
+                    )),
+                }
+            };
+
+            if let Some(cancellation) = cancellation {
+                flow_like_types::tokio::select! {
+                    biased;
+                    _ = cancellation.cancelled() => None,
+                    warning = write => warning,
+                }
+            } else {
+                write.await
+            }
+        });
+        let task = Arc::new(flow_like_types::tokio::sync::Mutex::new(Some(task)));
+
+        let completion_event: EventTrigger = Arc::new(move |run| {
+            let task = task.clone();
+            let node_id = node_id.clone();
+            let function_name = function_name.clone();
+            Box::pin(async move {
+                let task = { task.lock().await.take() };
+                let Some(task) = task else {
+                    return Ok(());
+                };
+
+                let warning = match task.await {
+                    Ok(warning) => warning,
+                    Err(error) => Some(format!(
+                        "Cache write task for function '{}' failed: {:?}",
+                        function_name, error
+                    )),
+                };
+                if let Some(warning) = warning {
+                    run.log_node_warning(&node_id, None, &warning).await;
+                }
+
+                // Cache persistence is best-effort and must not change a successful flow result.
+                Ok(())
+            })
+        });
+        context.hook_completion_event(completion_event).await;
     }
 
     fn find_node_id_by_pin(
@@ -547,17 +631,15 @@ impl NodeLogic for CallFunctionNode {
 
         if let (Some(settings), Some((handle, key))) = (&cache_settings, &cache_lookup) {
             let outputs = self.collect_cacheable_outputs(context).await;
-            // A value the backend rejects (too large, backend unreachable) costs this call
-            // nothing — it already produced its outputs.
-            if let Err(error) = cache_set(context, handle, key, outputs, settings.ttl()).await {
-                context.log_message(
-                    &format!(
-                        "Could not cache the result of function '{}': {:?}",
-                        layer.name, error
-                    ),
-                    LogLevel::Warn,
-                );
-            }
+            Self::persist_cache_result(
+                context,
+                layer.name.clone(),
+                handle.clone(),
+                key.clone(),
+                outputs,
+                settings.ttl(),
+            )
+            .await;
         }
 
         Ok(())
@@ -852,23 +934,27 @@ mod tests {
     }
 
     #[test]
-    fn a_zero_lifetime_means_the_entry_never_expires() {
+    fn a_zero_or_omitted_lifetime_explicitly_disables_expiry() {
         let mut settings = LayerCache {
             enabled: true,
             prefix: String::new(),
             ttl_seconds: Some(0),
             scope: LayerCacheScope::App,
         };
-        assert_eq!(settings.ttl(), None);
+        assert_eq!(settings.ttl(), Some(0));
 
         settings.ttl_seconds = None;
-        assert_eq!(settings.ttl(), None);
+        assert_eq!(settings.ttl(), Some(0));
     }
 
     #[test]
     fn caching_is_off_until_it_is_switched_on() {
         let settings = LayerCache::default();
         assert!(!settings.is_active());
-        assert!(Layer::new("l".into(), "L".into(), LayerType::Function).cache.is_none());
+        assert!(
+            Layer::new("l".into(), "L".into(), LayerType::Function)
+                .cache
+                .is_none()
+        );
     }
 }

--- a/packages/catalog/std/src/utils/md/plate_json.rs
+++ b/packages/catalog/std/src/utils/md/plate_json.rs
@@ -351,7 +351,9 @@ impl MarkdownWriter {
         }
         let mut label = caption_text(node);
         if label.is_empty() {
-            label = str_prop(node, "name").unwrap_or(node_type(node)).to_string();
+            label = str_prop(node, "name")
+                .unwrap_or(node_type(node))
+                .to_string();
         }
         self.push_line(&format!("[{}]({})", escape_link_text(&label), url));
     }
@@ -372,7 +374,10 @@ impl MarkdownWriter {
                 .iter()
                 .map(|cell| {
                     let text = self.inline_blocks(children(cell));
-                    text.replace('|', "\\|").replace('\n', " ").trim().to_string()
+                    text.replace('|', "\\|")
+                        .replace('\n', " ")
+                        .trim()
+                        .to_string()
                 })
                 .collect();
             let all_header = children(row)
@@ -445,7 +450,11 @@ impl MarkdownWriter {
                 "img" if self.images == ImageHandling::Keep => {
                     let url = media_url(node);
                     if !url.is_empty() {
-                        out.push_str(&format!("![{}]({})", escape_link_text(&caption_text(node)), url));
+                        out.push_str(&format!(
+                            "![{}]({})",
+                            escape_link_text(&caption_text(node)),
+                            url
+                        ));
                     }
                 }
                 _ => {
@@ -583,7 +592,12 @@ fn apply_marks(node: &Value, text: &str) -> String {
         wrapped = format!("<mark>{wrapped}</mark>");
     }
 
-    format!("{}{}{}", &text[..trimmed_start], wrapped, &text[text.len() - trimmed_end..])
+    format!(
+        "{}{}{}",
+        &text[..trimmed_start],
+        wrapped,
+        &text[text.len() - trimmed_end..]
+    )
 }
 
 fn escape_markdown(text: &str) -> String {
@@ -658,8 +672,10 @@ impl HtmlWriter {
             }
             "blockquote" => {
                 let body = self.inline(children(node));
-                self.out
-                    .push_str(&format!("<blockquote{}>{body}</blockquote>\n", block_attrs(node)));
+                self.out.push_str(&format!(
+                    "<blockquote{}>{body}</blockquote>\n",
+                    block_attrs(node)
+                ));
             }
             "callout" => {
                 let icon = str_prop(node, "icon").unwrap_or_default();
@@ -790,7 +806,11 @@ impl HtmlWriter {
 
         let body = self.inline(children(node));
         if style == "todo" {
-            let checked = if flag(node, "checked") { " checked" } else { "" };
+            let checked = if flag(node, "checked") {
+                " checked"
+            } else {
+                ""
+            };
             self.out.push_str(&format!(
                 "<li class=\"task-list-item\"><input type=\"checkbox\" disabled{checked} /> {body}</li>\n"
             ));
@@ -819,8 +839,10 @@ impl HtmlWriter {
         let alt = caption_text(node);
         if self.images == ImageHandling::AltText || url.is_empty() {
             let label = if alt.is_empty() { "Image" } else { &alt };
-            self.out
-                .push_str(&format!("<p class=\"image-placeholder\">{}</p>\n", escape_html(label)));
+            self.out.push_str(&format!(
+                "<p class=\"image-placeholder\">{}</p>\n",
+                escape_html(label)
+            ));
             return;
         }
         let width = node
@@ -874,14 +896,23 @@ impl HtmlWriter {
                     "td"
                 };
                 let mut attrs = String::new();
-                if let Some(span) = cell.get("colSpan").and_then(Value::as_u64).filter(|s| *s > 1) {
+                if let Some(span) = cell
+                    .get("colSpan")
+                    .and_then(Value::as_u64)
+                    .filter(|s| *s > 1)
+                {
                     attrs.push_str(&format!(" colspan=\"{span}\""));
                 }
-                if let Some(span) = cell.get("rowSpan").and_then(Value::as_u64).filter(|s| *s > 1) {
+                if let Some(span) = cell
+                    .get("rowSpan")
+                    .and_then(Value::as_u64)
+                    .filter(|s| *s > 1)
+                {
                     attrs.push_str(&format!(" rowspan=\"{span}\""));
                 }
                 let body = self.cell_body(children(cell));
-                self.out.push_str(&format!("<{tag}{attrs}>{body}</{tag}>\n"));
+                self.out
+                    .push_str(&format!("<{tag}{attrs}>{body}</{tag}>\n"));
             }
             self.out.push_str("</tr>\n");
 

--- a/packages/catalog/std/tests/function_cache_continuation.rs
+++ b/packages/catalog/std/tests/function_cache_continuation.rs
@@ -1,0 +1,412 @@
+//! A function-cache miss must not keep the function's execution successor from running while the
+//! cache backend is still persisting the result.
+
+use std::{
+    collections::HashMap,
+    fmt::{Display, Formatter},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::Duration,
+};
+
+use flow_like::{
+    app::AppVisibility,
+    flow::{
+        board::{Board, Layer, LayerCache, LayerCacheScope, LayerType},
+        execution::{InternalRun, LogLevel, RunPayload, RunStatus, context::ExecutionContext},
+        node::{Node, NodeLogic},
+        variable::VariableType,
+    },
+    profile::Profile,
+    state::{FlowLikeConfig, FlowLikeState},
+    utils::http::HTTPClient,
+};
+use flow_like_catalog_std::{control::call_function::CallFunctionNode, logging::info::InfoNode};
+use flow_like_storage::{
+    Path,
+    files::store::FlowLikeStore,
+    object_store::{
+        GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
+        PutMultipartOptions, PutOptions, PutPayload, PutResult, Result as ObjectStoreResult,
+        memory::InMemory, path::Path as ObjectPath,
+    },
+};
+use flow_like_types::{async_trait, json::json};
+use futures::stream::BoxStream;
+use tokio::sync::{Semaphore, oneshot};
+
+const APP_ID: &str = "function-cache-continuation";
+const CALL_ID: &str = "cached-call";
+const FUNCTION_ID: &str = "cached-function";
+const FUNCTION_NODE_ID: &str = "function-body";
+const SUCCESSOR_ID: &str = "after-cached-call";
+
+struct CountingBodyNode {
+    executions: Arc<AtomicU64>,
+}
+
+impl CountingBodyNode {
+    fn new(executions: Arc<AtomicU64>) -> Self {
+        Self { executions }
+    }
+}
+
+#[async_trait]
+impl NodeLogic for CountingBodyNode {
+    fn get_node(&self) -> Node {
+        let mut node = Node::new(
+            "test_count_cached_function_body",
+            "Count Cached Function Body",
+            "Counts executions of the cached function body",
+            "Tests",
+        );
+        node.add_input_pin("exec_in", "Input", "", VariableType::Execution);
+        node.add_output_pin("exec_out", "Output", "", VariableType::Execution);
+        node
+    }
+
+    async fn run(&self, context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        self.executions.fetch_add(1, Ordering::AcqRel);
+        context.activate_exec_pin("exec_out").await
+    }
+}
+
+#[derive(Debug)]
+struct GatedStore {
+    inner: InMemory,
+    put_count: AtomicU64,
+    write_started: Mutex<Option<oneshot::Sender<()>>>,
+    write_release: Arc<Semaphore>,
+}
+
+impl GatedStore {
+    fn new() -> (Arc<Self>, oneshot::Receiver<()>, Arc<Semaphore>) {
+        let (write_started_tx, write_started) = oneshot::channel();
+        let write_release = Arc::new(Semaphore::new(0));
+        let store = Arc::new(Self {
+            inner: InMemory::new(),
+            put_count: AtomicU64::new(0),
+            write_started: Mutex::new(Some(write_started_tx)),
+            write_release: write_release.clone(),
+        });
+        (store, write_started, write_release)
+    }
+
+    fn put_count(&self) -> u64 {
+        self.put_count.load(Ordering::Acquire)
+    }
+}
+
+impl Display for GatedStore {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("GatedStore")
+    }
+}
+
+#[async_trait]
+impl ObjectStore for GatedStore {
+    async fn put_opts(
+        &self,
+        location: &ObjectPath,
+        payload: PutPayload,
+        options: PutOptions,
+    ) -> ObjectStoreResult<PutResult> {
+        self.put_count.fetch_add(1, Ordering::AcqRel);
+        let write_started = self
+            .write_started
+            .lock()
+            .expect("cache write-start lock")
+            .take();
+        if let Some(write_started) = write_started {
+            let _ = write_started.send(());
+            let permit = self
+                .write_release
+                .acquire()
+                .await
+                .expect("cache write gate remains open");
+            permit.forget();
+        }
+        self.inner.put_opts(location, payload, options).await
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        location: &ObjectPath,
+        options: PutMultipartOptions,
+    ) -> ObjectStoreResult<Box<dyn MultipartUpload>> {
+        self.inner.put_multipart_opts(location, options).await
+    }
+
+    async fn get_opts(
+        &self,
+        location: &ObjectPath,
+        options: GetOptions,
+    ) -> ObjectStoreResult<GetResult> {
+        self.inner.get_opts(location, options).await
+    }
+
+    async fn delete(&self, location: &ObjectPath) -> ObjectStoreResult<()> {
+        self.inner.delete(location).await
+    }
+
+    fn list(
+        &self,
+        prefix: Option<&ObjectPath>,
+    ) -> BoxStream<'static, ObjectStoreResult<ObjectMeta>> {
+        self.inner.list(prefix)
+    }
+
+    async fn list_with_delimiter(
+        &self,
+        prefix: Option<&ObjectPath>,
+    ) -> ObjectStoreResult<ListResult> {
+        self.inner.list_with_delimiter(prefix).await
+    }
+
+    async fn copy(&self, from: &ObjectPath, to: &ObjectPath) -> ObjectStoreResult<()> {
+        self.inner.copy(from, to).await
+    }
+
+    async fn copy_if_not_exists(
+        &self,
+        from: &ObjectPath,
+        to: &ObjectPath,
+    ) -> ObjectStoreResult<()> {
+        self.inner.copy_if_not_exists(from, to).await
+    }
+}
+
+fn pin_id(node: &Node, name: &str) -> String {
+    node.get_pin_by_name(name)
+        .unwrap_or_else(|| panic!("node '{}' has pin '{name}'", node.name))
+        .id
+        .clone()
+}
+
+fn connect_exec_nodes(from: &mut Node, from_pin: &str, to: &mut Node, to_pin: &str) {
+    let from_pin = pin_id(from, from_pin);
+    let to_pin = pin_id(to, to_pin);
+    from.pins
+        .get_mut(&from_pin)
+        .expect("source execution pin")
+        .connected_to
+        .insert(to_pin.clone());
+    to.pins
+        .get_mut(&to_pin)
+        .expect("target execution pin")
+        .depends_on
+        .insert(from_pin);
+}
+
+async fn cached_function_board(body_logic: &CountingBodyNode) -> Board {
+    let mut board = Board::new_detached(
+        Some("cache-continuation-board".to_string()),
+        Path::default(),
+    );
+    board.name = "Function Cache Continuation".to_string();
+    board.log_level = LogLevel::Info;
+
+    let mut layer = Layer::new(
+        FUNCTION_ID.to_string(),
+        "Cached Function".to_string(),
+        LayerType::Function,
+    );
+    layer.cache = Some(LayerCache {
+        enabled: true,
+        prefix: "cache-continuation".to_string(),
+        ttl_seconds: Some(60),
+        scope: LayerCacheScope::App,
+    });
+
+    let mut boundary = Node::new("function-boundary", "Function Boundary", "", "Tests");
+    let layer_exec_in = boundary
+        .add_input_pin("exec_in", "Input", "", VariableType::Execution)
+        .clone();
+    let layer_exec_out = boundary
+        .add_output_pin("exec_out", "Output", "", VariableType::Execution)
+        .clone();
+    let layer_exec_in_id = layer_exec_in.id.clone();
+    let layer_exec_out_id = layer_exec_out.id.clone();
+    layer.pins.insert(layer_exec_in.id.clone(), layer_exec_in);
+    layer.pins.insert(layer_exec_out.id.clone(), layer_exec_out);
+
+    let mut function_node = body_logic.get_node();
+    function_node.id = FUNCTION_NODE_ID.to_string();
+    function_node.layer = Some(FUNCTION_ID.to_string());
+    let function_exec_in_id = pin_id(&function_node, "exec_in");
+    let function_exec_out_id = pin_id(&function_node, "exec_out");
+
+    layer
+        .pins
+        .get_mut(&layer_exec_in_id)
+        .expect("function execution input")
+        .connected_to
+        .insert(function_exec_in_id.clone());
+    function_node
+        .pins
+        .get_mut(&function_exec_in_id)
+        .expect("function entry execution pin")
+        .depends_on
+        .insert(layer_exec_in_id);
+    function_node
+        .pins
+        .get_mut(&function_exec_out_id)
+        .expect("function exit execution pin")
+        .connected_to
+        .insert(layer_exec_out_id.clone());
+    layer
+        .pins
+        .get_mut(&layer_exec_out_id)
+        .expect("function execution output")
+        .depends_on
+        .insert(function_exec_out_id);
+    layer.nodes.insert(function_node.id.clone(), function_node);
+    board.layers.insert(layer.id.clone(), layer);
+
+    let call_logic = CallFunctionNode::new();
+    let mut call = call_logic.get_node();
+    call.id = CALL_ID.to_string();
+    call.get_pin_mut_by_name("function_layer_id")
+        .expect("call function selector")
+        .set_default_value(Some(json!(FUNCTION_ID)));
+    call_logic.on_update(&mut call, &board).await;
+
+    let mut successor = InfoNode::new().get_node();
+    successor.id = SUCCESSOR_ID.to_string();
+    connect_exec_nodes(&mut call, "exec_out", &mut successor, "exec_in");
+    board.nodes.insert(call.id.clone(), call);
+    board.nodes.insert(successor.id.clone(), successor);
+
+    board
+}
+
+async fn wait_until_executed(exec_calls: &AtomicU64) {
+    while exec_calls.load(Ordering::Acquire) == 0 {
+        tokio::task::yield_now().await;
+    }
+}
+
+async fn build_execution(
+    state: &Arc<FlowLikeState>,
+    board: Arc<Board>,
+    payload: &RunPayload,
+) -> InternalRun {
+    let mut execution = InternalRun::new(
+        APP_ID,
+        board,
+        None,
+        state,
+        &Profile::default(),
+        payload,
+        false,
+        None,
+        None,
+        None,
+        HashMap::new(),
+    )
+    .await
+    .expect("build cached-function run");
+    execution
+        .set_usage_attribution_from_visibility(&AppVisibility::Offline)
+        .await;
+    execution
+        .set_log_flush_policy(Duration::from_secs(60), 500)
+        .await
+        .expect("set test log policy");
+    execution
+}
+
+#[flow_like_types::tokio::test]
+async fn cache_miss_write_does_not_block_the_function_successor() {
+    let (gated_store, write_started, write_release) = GatedStore::new();
+    let function_body_executions = Arc::new(AtomicU64::new(0));
+    let body_logic = Arc::new(CountingBodyNode::new(function_body_executions.clone()));
+    let mut config = FlowLikeConfig::new();
+    config.register_app_storage_store(FlowLikeStore::Other(gated_store.clone()));
+    let state = Arc::new(FlowLikeState::new(
+        config,
+        HTTPClient::new_without_refetch(),
+    ));
+    let catalog: Vec<Arc<dyn NodeLogic>> = vec![
+        Arc::new(CallFunctionNode::new()),
+        Arc::new(InfoNode::new()),
+        body_logic.clone(),
+    ];
+    state.node_registry.write().await.push_nodes(catalog);
+
+    let payload = RunPayload {
+        id: CALL_ID.to_string(),
+        payload: None,
+        runtime_variables: None,
+        filter_secrets: Some(true),
+    };
+    let board = Arc::new(cached_function_board(&body_logic).await);
+    let mut execution = build_execution(&state, board.clone(), &payload).await;
+    let successor = execution
+        .nodes
+        .get(SUCCESSOR_ID)
+        .expect("successor is in the execution graph")
+        .clone();
+
+    let execution_task = tokio::spawn({
+        let state = state.clone();
+        async move {
+            execution.execute(state).await;
+            execution.get_status().await
+        }
+    });
+
+    let write_started_result = tokio::time::timeout(Duration::from_secs(5), write_started).await;
+    let continuation_result = tokio::time::timeout(
+        Duration::from_secs(2),
+        wait_until_executed(&successor.exec_calls),
+    )
+    .await;
+
+    write_release.add_permits(1);
+    let status = tokio::time::timeout(Duration::from_secs(5), execution_task)
+        .await
+        .expect("execution finishes after releasing the cache write")
+        .expect("execution task does not panic");
+    write_started_result
+        .expect("function cache miss reaches the cache write")
+        .expect("cache write-start signal is sent");
+    continuation_result.expect(
+        "the function successor must execute while the cache write response is still gated",
+    );
+    assert!(
+        matches!(status, RunStatus::Success),
+        "the cached-function run must finish successfully"
+    );
+    assert_eq!(
+        function_body_executions.load(Ordering::Acquire),
+        1,
+        "the cache miss must execute the function body once"
+    );
+    let writes_after_miss = gated_store.put_count();
+    assert_eq!(writes_after_miss, 1, "the cache miss writes exactly once");
+
+    let mut cached_execution = build_execution(&state, board, &payload).await;
+    let cached_status = tokio::time::timeout(Duration::from_secs(5), async {
+        cached_execution.execute(state).await;
+        cached_execution.get_status().await
+    })
+    .await
+    .expect("the cached run finishes");
+    assert!(
+        matches!(cached_status, RunStatus::Success),
+        "the cached run must finish successfully"
+    );
+    assert_eq!(
+        function_body_executions.load(Ordering::Acquire),
+        1,
+        "the cached run must bypass the function body"
+    );
+    assert_eq!(
+        gated_store.put_count(),
+        writes_after_miss,
+        "the cached run must reuse the persisted result without another write"
+    );
+}

--- a/packages/core/src/copilot/prompts.rs
+++ b/packages/core/src/copilot/prompts.rs
@@ -1057,6 +1057,39 @@ nodes. `check_flowscript` REJECTS source that would exceed this, so design withi
   revision, and reply paths that were also requested) is not a successful full-workflow edit.
 "#;
 
+/// Function-layer result-cache syntax and safety contract shared by every board-capable prompt.
+/// The runtime skips the complete function body on a hit, so this must be explicit model context
+/// rather than an undocumented piece of layer metadata.
+pub const FUNCTION_CACHE_GUIDANCE: &str = r#"
+## FUNCTION RESULT CACHING
+FlowScript configures result caching with a decorator immediately above a `function` declaration.
+Use the canonical object form when settings matter:
+```ts
+@cache({ namespace: "pricing", ttlSeconds: 3600, scope: "user" })
+function calculatePricing(subtotal: float): (price: float) {
+    return floatRound({ float: subtotal })
+}
+```
+A bare `@cache` enables the defaults: the `"global"` namespace, a 300-second lifetime, and app
+scope. Missing fields in an object-form decorator inherit those same defaults. `namespace` groups
+entries for invalidation, `ttlSeconds` is a non-negative lifetime in seconds, and `scope` is
+exactly `"app"` or `"user"`. Set `ttlSeconds: 0` explicitly for a permanent entry with no expiry.
+When authoring through typed Flow IR, use its snake_case `cache` object fields: `namespace`,
+`ttl_seconds`, and `scope`; an empty cache object has the same `global`/300-second/app defaults,
+and `ttl_seconds: 0` is permanent. Existing graph context may expose `ttl_seconds: null` for a
+permanent cache. Preserve that behavior by authoring explicit `ttl_seconds: 0` in typed IR
+or `ttlSeconds: 0` in FlowScript; do not treat that null as the new 300-second omission
+default. The compiled FlowScript decorator uses `ttlSeconds`.
+
+The cache key is derived from the function layer and all function inputs. On a cache hit the saved
+outputs are replayed and the ENTIRE function body is skipped, including every side effect. Cache
+only deterministic functions whose outputs are fully determined by their inputs. Use `scope:
+"user"` whenever a result depends on the triggering user or must remain private; use `"app"` only
+for results safe to share across the app. Preserve an existing `@cache` decorator during unrelated
+edits. Add, change, or remove it only when the requested edit changes caching behavior. Decorators
+apply only to `function` declarations, never Events or catalog calls.
+"#;
+
 /// Execution wiring contract shared by board prompts.
 pub const EXECUTION_FLOW_GUIDANCE: &str = r#"
 ## EXECUTION FLOW AND MULTI-OUTPUT NODES
@@ -1818,6 +1851,8 @@ FlowScript through write/patch/check/commit.
 
 {organization_guidance}
 
+{function_cache_guidance}
+
 {execution_guidance}
 
 {numbers_guidance}
@@ -1833,15 +1868,16 @@ FlowScript through write/patch/check/commit.
 {flowscript}
 ```
 
-## Graph Context (abbreviated keys: t=type, n=name, i=inputs, o=outputs, p=position, s=size, f=from, fp=from_pin, tp=to_pin, v=value, p=parent)
+## Graph Context (abbreviated keys: t=type, n=name, i=inputs, o=outputs, p=position, s=size, f=from, fp=from_pin, tp=to_pin, v=value, p=parent; function-layer `cache` uses enabled/namespace/ttl_seconds/scope)
 {context}
 
 ## Layers Are Read-Only Context
-The context's `layers` array contains `id`, `n` (name), `p` (parent), `nodes`, and `pos` for
-explanation/debugging. Model-facing `emit_commands` cannot create, remove, or change membership of
-any layer because the compact context cannot prove that such a mutation is non-executable.
-Function layers are authored only with FlowScript `function` declarations. `AddPlaceholder` and
-all direct layer commands are unavailable to workflow-authoring models.
+The context's `layers` array contains `id`, `n` (name), `t` (layer type), `p` (parent), `nodes`,
+`pos`, and optional function-result `cache` settings for explanation/debugging. Model-facing `emit_commands` cannot
+create, remove, or change membership of any layer because the compact context cannot prove that
+such a mutation is non-executable. Function layers and their cache settings are authored only with
+FlowScript `function` declarations and `@cache`; `AddPlaceholder` and all direct layer commands are
+unavailable to workflow-authoring models.
 
 ## Tools
 **Understanding**: think (reason step-by-step), get_node_details (get full info about a specific node)
@@ -1888,6 +1924,7 @@ emit_commands (position-only MoveNode and canvas comments only)
         numbers_guidance = NUMBERS_CONVERSIONS_GUIDANCE,
         flowpath_guidance = FLOW_PATH_ACCESSOR_GUIDANCE,
         organization_guidance = BOARD_ORGANIZATION_GUIDANCE,
+        function_cache_guidance = FUNCTION_CACHE_GUIDANCE,
         explanation_guidance = EXPLANATION_WORKFLOW_GUIDANCE,
         autonomy_guidance = AUTONOMY_PLACEHOLDER_GUIDANCE,
         segmentation_guidance = SCOPE_SEGMENTATION_GUIDANCE,
@@ -2318,6 +2355,10 @@ That isolation is deliberate and is a security boundary, not an inconvenience:
 - The orchestrator that CAN see private data has no outbound network. It delegates to you instead.
 
 Consequences for how you work:
+- The immutable source request may mix public research with private-app or action instructions.
+  Extract only the public factual subquestion(s). Never search for or repeat credentials, secrets,
+  personal/private identifiers, local app names, file contents, or action payloads that appear in
+  the request; say that those private parts remain for the orchestrator.
 - If answering properly would need the user's own app data, files or database, say so plainly and
   name what is missing. Do NOT guess at it, and do NOT ask the user to paste it — the orchestrator
   can read it and combine your findings with it.
@@ -2446,6 +2487,8 @@ pub fn general_system_prompt() -> String {
 
 {organization_guidance}
 
+{function_cache_guidance}
+
 {execution_guidance}
 
 {numbers_guidance}
@@ -2467,6 +2510,7 @@ pub fn general_system_prompt() -> String {
         numbers_guidance = NUMBERS_CONVERSIONS_GUIDANCE,
         flowpath_guidance = FLOW_PATH_ACCESSOR_GUIDANCE,
         organization_guidance = BOARD_ORGANIZATION_GUIDANCE,
+        function_cache_guidance = FUNCTION_CACHE_GUIDANCE,
         explanation_guidance = EXPLANATION_WORKFLOW_GUIDANCE,
         autonomy_guidance = AUTONOMY_PLACEHOLDER_GUIDANCE,
         segmentation_guidance = SCOPE_SEGMENTATION_GUIDANCE,
@@ -2525,6 +2569,8 @@ FlowScript surface is required.
 
 {organization_guidance}
 
+{function_cache_guidance}
+
 {execution_guidance}
 
 {numbers_guidance}
@@ -2544,6 +2590,7 @@ resend it; if the error says FlowScript is required, switch to the retained sour
         numbers_guidance = NUMBERS_CONVERSIONS_GUIDANCE,
         flowpath_guidance = FLOW_PATH_ACCESSOR_GUIDANCE,
         organization_guidance = BOARD_ORGANIZATION_GUIDANCE,
+        function_cache_guidance = FUNCTION_CACHE_GUIDANCE,
         explanation_guidance = EXPLANATION_WORKFLOW_GUIDANCE,
         autonomy_guidance = AUTONOMY_PLACEHOLDER_GUIDANCE,
         segmentation_guidance = SCOPE_SEGMENTATION_GUIDANCE,
@@ -2665,6 +2712,8 @@ resend.
 
 {organization_guidance}
 
+{function_cache_guidance}
+
 {execution_guidance}
 
 {numbers_guidance}
@@ -2709,6 +2758,7 @@ check_flowscript (compile/validate), commit_flowscript (queue the checked batch)
         numbers_guidance = NUMBERS_CONVERSIONS_GUIDANCE,
         flowpath_guidance = FLOW_PATH_ACCESSOR_GUIDANCE,
         organization_guidance = BOARD_ORGANIZATION_GUIDANCE,
+        function_cache_guidance = FUNCTION_CACHE_GUIDANCE,
         explanation_guidance = EXPLANATION_WORKFLOW_GUIDANCE,
         autonomy_guidance = AUTONOMY_PLACEHOLDER_GUIDANCE,
         segmentation_guidance = SCOPE_SEGMENTATION_GUIDANCE,
@@ -3056,6 +3106,36 @@ mod tests {
             assert!(
                 prompt.contains("Post-apply runtime verification belongs to a later orchestrator")
             );
+        }
+    }
+
+    #[test]
+    fn board_prompts_expose_function_cache_syntax_and_runtime_semantics() {
+        let prompts = [
+            board_system_prompt("{}", "", 0, false, false),
+            board_sdk_system_prompt(),
+            board_sdk_flowscript_system_prompt("", 0),
+            general_system_prompt(),
+        ];
+
+        for prompt in prompts {
+            assert!(prompt.contains("## FUNCTION RESULT CACHING"));
+            assert!(
+                prompt.contains(
+                    r#"@cache({ namespace: "pricing", ttlSeconds: 3600, scope: "user" })"#
+                )
+            );
+            assert!(prompt.contains("A bare `@cache` enables the defaults"));
+            assert!(prompt.contains("`\"global\"` namespace"));
+            assert!(prompt.contains("300-second lifetime"));
+            assert!(prompt.contains("`ttlSeconds: 0` explicitly for a permanent entry"));
+            assert!(prompt.contains("`ttl_seconds: null`"));
+            assert!(prompt.contains("permanent cache"));
+            assert!(prompt.contains("`scope` is"));
+            assert!(prompt.contains("exactly `\"app\"` or `\"user\"`"));
+            assert!(prompt.contains("ENTIRE function body is skipped"));
+            assert!(prompt.contains("including every side effect"));
+            assert!(prompt.contains("Preserve an existing `@cache` decorator"));
         }
     }
 
@@ -3640,6 +3720,8 @@ mod tests {
 
         // It cannot reach private data, and must say so rather than guess.
         assert!(prompt.contains("do NOT ask the user to paste it"));
+        assert!(prompt.contains("Extract only the public factual subquestion(s)"));
+        assert!(prompt.contains("Never search for or repeat credentials"));
 
         // Archive captures are time-boxed evidence.
         assert!(prompt.contains("evidence of what a page said AT THAT CAPTURE TIME"));

--- a/packages/core/src/flow/ast/apply.rs
+++ b/packages/core/src/flow/ast/apply.rs
@@ -502,22 +502,29 @@ impl FlowScriptApplyPlanner {
                     position,
                     color,
                     target_layer,
+                    cache,
                     ..
                 } if node_ids.is_empty() || ref_id.is_some() || pins.is_some() => {
                     let layer_id = create_id();
-                    let mut layer = Layer::new(
-                        layer_id.clone(),
-                        name.clone(),
-                        layer_type_from_str(layer_type),
-                    );
+                    let resolved_layer_type = layer_type_from_str(layer_type);
+                    if cache.is_some() && !matches!(&resolved_layer_type, LayerType::Function) {
+                        return Err(flow_like_types::anyhow!(
+                            "Layer `{name}` is not a Function layer and cannot be cached"
+                        ));
+                    }
+                    let mut layer = Layer::new(layer_id.clone(), name.clone(), resolved_layer_type);
                     layer.coordinates = self.position_or_base(position.as_ref());
                     layer.color = color.clone();
                     layer.pins = layer_pins(pins.as_deref());
+                    layer.cache = cache.clone();
 
                     let mut command = UpsertLayerCommand::new(layer.clone());
                     command.current_layer =
                         self.target_layer_or_current(board, target_layer.as_deref())?;
 
+                    // Keep the staged view identical to what UpsertLayer will persist so later
+                    // setup commands can safely target this layer in the same batch.
+                    layer.parent_id = command.current_layer.clone();
                     self.staged_layers.insert(layer_id.clone(), layer);
                     let index_alias = format!("${}", self.next_node_index);
                     self.next_node_index += 1;
@@ -534,6 +541,32 @@ impl FlowScriptApplyPlanner {
                         &layer_id,
                     );
 
+                    generic_commands.push(GenericCommand::UpsertLayer(command));
+                }
+                BoardCommand::UpdateLayerCache {
+                    layer_id, cache, ..
+                } => {
+                    let layer_id = self.resolve_node_id(board, layer_id)?;
+                    let Some(existing_layer) = self
+                        .staged_layers
+                        .get(&layer_id)
+                        .or_else(|| board.layers.get(&layer_id))
+                    else {
+                        return Err(flow_like_types::anyhow!("Layer `{layer_id}` not found"));
+                    };
+                    if !matches!(&existing_layer.r#type, LayerType::Function) {
+                        return Err(flow_like_types::anyhow!(
+                            "Layer `{layer_id}` is not a Function layer and cannot be cached"
+                        ));
+                    }
+                    let mut layer = existing_layer.clone();
+                    layer.cache = cache.clone();
+
+                    let mut command = UpsertLayerCommand::new(layer.clone());
+                    // UpsertLayer assigns parent_id from current_layer during execute. Preserve the
+                    // existing hierarchy while changing only cache metadata.
+                    command.current_layer = layer.parent_id.clone();
+                    self.staged_layers.insert(layer_id, layer);
                     generic_commands.push(GenericCommand::UpsertLayer(command));
                 }
                 BoardCommand::CreateVariable {
@@ -765,7 +798,8 @@ impl FlowScriptApplyPlanner {
                 | BoardCommand::CreateVariable { .. }
                 | BoardCommand::UpdateVariable { .. }
                 | BoardCommand::UpdateNodePin { .. }
-                | BoardCommand::RenameNode { .. } => {}
+                | BoardCommand::RenameNode { .. }
+                | BoardCommand::UpdateLayerCache { .. } => {}
                 BoardCommand::RemoveNode { node_id, .. } => {
                     let node_id = self.resolve_node_id(board, node_id)?;
                     let node = self.resolve_node(board, &node_id)?.clone();
@@ -885,16 +919,23 @@ impl FlowScriptApplyPlanner {
                     position,
                     color,
                     target_layer,
+                    cache,
                     ..
                 } => {
                     if node_ids.is_empty() || ref_id.is_some() || pins.is_some() {
                         continue;
                     }
-                    let mut layer =
-                        Layer::new(create_id(), name.clone(), layer_type_from_str(layer_type));
+                    let resolved_layer_type = layer_type_from_str(layer_type);
+                    if cache.is_some() && !matches!(&resolved_layer_type, LayerType::Function) {
+                        return Err(flow_like_types::anyhow!(
+                            "Layer `{name}` is not a Function layer and cannot be cached"
+                        ));
+                    }
+                    let mut layer = Layer::new(create_id(), name.clone(), resolved_layer_type);
                     layer.coordinates = self.position_or_base(position.as_ref());
                     layer.color = color.clone();
                     layer.pins = layer_pins(pins.as_deref());
+                    layer.cache = cache.clone();
                     let node_ids = self.resolve_node_ids(board, node_ids)?;
                     let mut command = UpsertLayerCommand::new(layer);
                     command.node_ids = node_ids;
@@ -1612,7 +1653,7 @@ fn pin_type_from_str(value: &str) -> PinType {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::flow::board::{ExecutionMode, ExecutionStage};
+    use crate::flow::board::{ExecutionMode, ExecutionStage, LayerCache, LayerCacheScope};
     use crate::flow::execution::{LogLevel, context::ExecutionContext};
     use crate::flow::variable::VariableType;
     use crate::state::FlowLikeConfig;
@@ -2107,6 +2148,7 @@ mod tests {
                 position: None,
                 color: None,
                 target_layer: None,
+                cache: None,
                 summary: None,
             },
             BoardCommand::AddNode {
@@ -2152,6 +2194,206 @@ mod tests {
             Some(layer_id.as_str()),
             "pin-update staging must not clear function-layer membership"
         );
+    }
+
+    #[test]
+    fn setup_applies_cache_to_new_function_layer() {
+        let board = empty_board();
+        let mut planner = FlowScriptApplyPlanner::new(&board, &[], None);
+        let cache = LayerCache {
+            enabled: true,
+            prefix: "pricing".to_string(),
+            ttl_seconds: Some(300),
+            scope: LayerCacheScope::User,
+        };
+        let commands = vec![BoardCommand::CreateLayer {
+            name: "cachedLookup".to_string(),
+            ref_id: Some("$0".to_string()),
+            layer_type: Some("Function".to_string()),
+            node_ids: Vec::new(),
+            pins: Some(Vec::new()),
+            position: None,
+            color: None,
+            target_layer: None,
+            cache: Some(cache.clone()),
+            summary: None,
+        }];
+
+        let setup = planner
+            .build_setup_commands(&board, &commands)
+            .expect("cached layer should plan");
+        let [GenericCommand::UpsertLayer(command)] = setup.as_slice() else {
+            panic!("expected one layer upsert, got {} commands", setup.len());
+        };
+        assert_eq!(command.layer.cache.as_ref(), Some(&cache));
+    }
+
+    #[test]
+    fn setup_can_update_a_function_layer_created_earlier_in_the_batch() {
+        let mut board = empty_board();
+        let parent = Layer::new(
+            "parent-layer".to_string(),
+            "Functions".to_string(),
+            LayerType::Collapsed,
+        );
+        board.layers.insert(parent.id.clone(), parent);
+        let mut planner = FlowScriptApplyPlanner::new(&board, &[], None);
+        let cache = LayerCache {
+            enabled: true,
+            prefix: "pricing".to_string(),
+            ttl_seconds: Some(300),
+            scope: LayerCacheScope::User,
+        };
+        let commands = vec![
+            BoardCommand::CreateLayer {
+                name: "cachedLookup".to_string(),
+                ref_id: Some("$0".to_string()),
+                layer_type: Some("Function".to_string()),
+                node_ids: Vec::new(),
+                pins: Some(Vec::new()),
+                position: None,
+                color: None,
+                target_layer: Some("parent-layer".to_string()),
+                cache: None,
+                summary: None,
+            },
+            BoardCommand::UpdateLayerCache {
+                layer_id: "$0".to_string(),
+                cache: Some(cache.clone()),
+                summary: None,
+            },
+        ];
+
+        let setup = planner
+            .build_setup_commands(&board, &commands)
+            .expect("a newly created layer should accept a same-batch cache update");
+        let [
+            GenericCommand::UpsertLayer(created),
+            GenericCommand::UpsertLayer(updated),
+        ] = setup.as_slice()
+        else {
+            panic!("expected two layer upserts, got {} commands", setup.len());
+        };
+        assert_eq!(updated.layer.id, created.layer.id);
+        assert_eq!(updated.layer.cache.as_ref(), Some(&cache));
+        assert_eq!(updated.current_layer.as_deref(), Some("parent-layer"));
+    }
+
+    #[test]
+    fn setup_updates_existing_layer_cache_without_changing_parent() {
+        let mut board = empty_board();
+        let mut layer = Layer::new(
+            "cached-function".to_string(),
+            "Cached Lookup".to_string(),
+            LayerType::Function,
+        );
+        layer.parent_id = Some("parent-layer".to_string());
+        layer.cache = Some(LayerCache {
+            enabled: true,
+            prefix: "old".to_string(),
+            ttl_seconds: Some(60),
+            scope: LayerCacheScope::App,
+        });
+        board.layers.insert(layer.id.clone(), layer);
+        let mut planner = FlowScriptApplyPlanner::new(&board, &[], None);
+        let cache = LayerCache {
+            enabled: true,
+            prefix: "pricing".to_string(),
+            ttl_seconds: Some(300),
+            scope: LayerCacheScope::User,
+        };
+        let commands = vec![BoardCommand::UpdateLayerCache {
+            layer_id: "cached-function".to_string(),
+            cache: Some(cache.clone()),
+            summary: None,
+        }];
+
+        let setup = planner
+            .build_setup_commands(&board, &commands)
+            .expect("cache update should plan");
+        let [GenericCommand::UpsertLayer(command)] = setup.as_slice() else {
+            panic!("expected one layer upsert, got {} commands", setup.len());
+        };
+        assert_eq!(command.layer.cache.as_ref(), Some(&cache));
+        assert_eq!(command.current_layer.as_deref(), Some("parent-layer"));
+    }
+
+    #[test]
+    fn setup_removes_existing_layer_cache() {
+        let mut board = empty_board();
+        let mut layer = Layer::new(
+            "cached-function".to_string(),
+            "Cached Lookup".to_string(),
+            LayerType::Function,
+        );
+        layer.cache = Some(LayerCache {
+            enabled: true,
+            prefix: "pricing".to_string(),
+            ttl_seconds: Some(300),
+            scope: LayerCacheScope::User,
+        });
+        board.layers.insert(layer.id.clone(), layer);
+        let mut planner = FlowScriptApplyPlanner::new(&board, &[], None);
+        let commands = vec![BoardCommand::UpdateLayerCache {
+            layer_id: "cached-function".to_string(),
+            cache: None,
+            summary: None,
+        }];
+
+        let setup = planner
+            .build_setup_commands(&board, &commands)
+            .expect("cache removal should plan");
+        let [GenericCommand::UpsertLayer(command)] = setup.as_slice() else {
+            panic!("expected one layer upsert, got {} commands", setup.len());
+        };
+        assert!(command.layer.cache.is_none());
+    }
+
+    #[test]
+    fn setup_rejects_cache_updates_for_non_function_layers() {
+        let mut board = empty_board();
+        let layer = Layer::new(
+            "group-layer".to_string(),
+            "Group".to_string(),
+            LayerType::Collapsed,
+        );
+        board.layers.insert(layer.id.clone(), layer);
+        let mut planner = FlowScriptApplyPlanner::new(&board, &[], None);
+        let commands = vec![BoardCommand::UpdateLayerCache {
+            layer_id: "group-layer".to_string(),
+            cache: Some(LayerCache::default()),
+            summary: None,
+        }];
+
+        let error = match planner.build_setup_commands(&board, &commands) {
+            Ok(_) => panic!("only Function layers may carry result-cache settings"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("not a Function layer"));
+    }
+
+    #[test]
+    fn setup_rejects_cached_non_function_layer_creation() {
+        let board = empty_board();
+        let mut planner = FlowScriptApplyPlanner::new(&board, &[], None);
+        let commands = vec![BoardCommand::CreateLayer {
+            name: "Group".to_string(),
+            ref_id: Some("$0".to_string()),
+            layer_type: Some("Collapsed".to_string()),
+            node_ids: Vec::new(),
+            pins: Some(Vec::new()),
+            position: None,
+            color: None,
+            target_layer: None,
+            cache: Some(LayerCache::default()),
+            summary: None,
+        }];
+
+        let error = match planner.build_setup_commands(&board, &commands) {
+            Ok(_) => panic!("only Function layers may be created with cache settings"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("not a Function layer"));
     }
 
     #[test]
@@ -2222,6 +2464,7 @@ mod tests {
                 position: None,
                 color: None,
                 target_layer: None,
+                cache: None,
                 summary: None,
             },
             BoardCommand::AddNode {
@@ -2419,6 +2662,7 @@ mod tests {
                 position: None,
                 color: None,
                 target_layer: None,
+                cache: None,
                 summary: None,
             },
             BoardCommand::AddNode {

--- a/packages/core/src/flow/ast/lower.rs
+++ b/packages/core/src/flow/ast/lower.rs
@@ -7,7 +7,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 
 use flow_like_ast::model::*;
 
-use crate::flow::board::{Board, Layer, LayerType};
+use crate::flow::board::{Board, Layer, LayerCacheScope, LayerType};
 use crate::flow::node::Node;
 use crate::flow::pin::{Pin, PinType};
 use crate::flow::variable::{Variable, VariableType};
@@ -644,6 +644,21 @@ impl<'a> Lowering<'a> {
             params,
             returns,
             body,
+            cache: layer
+                .cache
+                .as_ref()
+                .filter(|cache| cache.enabled)
+                .map(|cache| FunctionCache {
+                    namespace: cache.prefix.clone(),
+                    // Persisted layer caches historically use either `None` or `0` for a
+                    // permanent entry. FlowScript omission now means five minutes, so lower both
+                    // permanent forms to an explicit zero to preserve behavior on round-trip.
+                    ttl_seconds: Some(cache.ttl_seconds.unwrap_or(0)),
+                    scope: match cache.scope {
+                        LayerCacheScope::App => FunctionCacheScope::App,
+                        LayerCacheScope::User => FunctionCacheScope::User,
+                    },
+                }),
             anchor: Some(layer.id.clone()),
         }
     }
@@ -2357,4 +2372,86 @@ fn event_alias(node: &Node) -> Option<String> {
 
     let alias = util::to_camel_case(friendly_name);
     (alias != event_type_name(node)).then_some(alias)
+}
+
+#[cfg(test)]
+mod cache_tests {
+    use super::*;
+    use crate::flow::board::{LayerCache, LayerCacheScope};
+    use flow_like_storage::Path;
+
+    #[test]
+    fn enabled_function_layer_cache_lowers_to_function_metadata() {
+        let mut board = Board::new_detached(Some("board".to_string()), Path::from(""));
+        let mut layer = Layer::new(
+            "cached-layer".to_string(),
+            "Cached Lookup".to_string(),
+            LayerType::Function,
+        );
+        layer.cache = Some(LayerCache {
+            enabled: true,
+            prefix: "pricing".to_string(),
+            ttl_seconds: Some(3600),
+            scope: LayerCacheScope::User,
+        });
+        board.layers.insert(layer.id.clone(), layer);
+
+        let ast = lower_board(&board);
+        let cache = ast.functions[0]
+            .cache
+            .as_ref()
+            .expect("enabled layer cache should be represented in FlowScript");
+        assert_eq!(cache.namespace, "pricing");
+        assert_eq!(cache.ttl_seconds, Some(3600));
+        assert_eq!(cache.scope, FunctionCacheScope::User);
+    }
+
+    #[test]
+    fn permanent_layer_cache_lowers_with_explicit_zero_ttl() {
+        for (index, persisted_ttl) in [None, Some(0)].into_iter().enumerate() {
+            let mut board =
+                Board::new_detached(Some(format!("permanent-cache-{index}")), Path::from(""));
+            let mut layer = Layer::new(
+                format!("cached-layer-{index}"),
+                "Cached Lookup".to_string(),
+                LayerType::Function,
+            );
+            layer.cache = Some(LayerCache {
+                enabled: true,
+                prefix: "global".to_string(),
+                ttl_seconds: persisted_ttl,
+                scope: LayerCacheScope::App,
+            });
+            board.layers.insert(layer.id.clone(), layer);
+
+            let ast = lower_board(&board);
+            assert_eq!(
+                ast.functions[0].cache.as_ref().unwrap().ttl_seconds,
+                Some(0)
+            );
+            let source = flow_like_ast::render(&ast, &flow_like_ast::RenderOptions::default());
+            assert!(source.starts_with("@cache({ ttlSeconds: 0 })\n"));
+        }
+    }
+
+    #[test]
+    fn disabled_function_layer_cache_does_not_emit_a_decorator() {
+        let mut board = Board::new_detached(Some("board".to_string()), Path::from(""));
+        let mut layer = Layer::new(
+            "uncached-layer".to_string(),
+            "Uncached Lookup".to_string(),
+            LayerType::Function,
+        );
+        layer.cache = Some(LayerCache {
+            enabled: false,
+            prefix: "remembered-ui-value".to_string(),
+            ttl_seconds: Some(60),
+            scope: LayerCacheScope::User,
+        });
+        board.layers.insert(layer.id.clone(), layer);
+
+        let ast = lower_board(&board);
+        assert_eq!(ast.functions.len(), 1);
+        assert!(ast.functions[0].cache.is_none());
+    }
 }

--- a/packages/core/src/flow/ast/reconcile.rs
+++ b/packages/core/src/flow/ast/reconcile.rs
@@ -26,7 +26,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use flow_like_ast::model::*;
 use flow_like_ast::to_camel_case;
 
-use crate::flow::board::{Board, LayerType};
+use crate::flow::board::{Board, Layer, LayerCache, LayerCacheScope, LayerType};
 use crate::flow::copilot::{
     BoardCommand, NodeMetadata, NodePosition, PinMetadata, PlaceholderPinDef, node_to_metadata,
 };
@@ -149,6 +149,13 @@ fn reconcile_inner(
     let variable_changes = reconcile_variables(existing, &board_ast, new, mode);
     result.commands.extend(variable_changes.commands);
     result.diagnostics.extend(variable_changes.diagnostics);
+
+    // Function cache decorators are layer metadata rather than graph nodes/pins, so reconcile
+    // them on both the conservative and catalog-aware paths. This also makes removing a decorator
+    // explicit: an active live cache becomes `cache: None` on the layer.
+    result
+        .commands
+        .extend(reconcile_function_caches(existing, new));
 
     // Anchored `base.path = value` writes carry no `&Call`, so synthesize the equivalent
     // `struct_set` calls the anchor-keyed collectors below diff against / delete. These arenas own
@@ -366,6 +373,69 @@ fn reconcile_inner(
     result.corrections.dedup();
 
     result
+}
+
+fn function_cache_to_layer_cache(cache: &FunctionCache) -> LayerCache {
+    LayerCache {
+        enabled: true,
+        prefix: cache.namespace.clone(),
+        ttl_seconds: cache.ttl_seconds,
+        scope: match cache.scope {
+            FunctionCacheScope::App => LayerCacheScope::App,
+            FunctionCacheScope::User => LayerCacheScope::User,
+        },
+    }
+}
+
+fn matching_function_layer<'a>(existing: &'a Board, func: &FnDecl) -> Option<&'a Layer> {
+    if let Some(anchor) = func.anchor.as_deref() {
+        return existing.layers.get(anchor).filter(|layer| {
+            matches!(layer.r#type, LayerType::Function)
+                && to_camel_case(&layer.name) == to_camel_case(&func.name)
+        });
+    }
+
+    let normalized_name = to_camel_case(&func.name);
+    let mut matches = existing.layers.values().filter(|layer| {
+        matches!(layer.r#type, LayerType::Function) && to_camel_case(&layer.name) == normalized_name
+    });
+    let only = matches.next()?;
+    matches.next().is_none().then_some(only)
+}
+
+fn reconcile_function_caches(existing: &Board, ast: &BoardAst) -> Vec<BoardCommand> {
+    ast.functions
+        .iter()
+        .filter_map(|func| {
+            let layer = matching_function_layer(existing, func)?;
+            let desired = func.cache.as_ref().map(function_cache_to_layer_cache);
+            // Disabled cache records are equivalent to an absent decorator. Preserve those dormant
+            // settings unless FlowScript explicitly enables caching, avoiding a no-op rewrite.
+            let current = layer
+                .cache
+                .as_ref()
+                .filter(|cache| cache.is_active())
+                .map(|cache| {
+                    let mut cache = cache.clone();
+                    // Persisted `None` and explicit zero are the same permanent policy. Lowering
+                    // spells both as `ttlSeconds: 0`, so compare their canonical forms here to
+                    // keep an unchanged board -> FlowScript -> board round-trip command-free.
+                    if cache.ttl_seconds.is_none() {
+                        cache.ttl_seconds = Some(0);
+                    }
+                    cache
+                });
+            (current != desired).then(|| BoardCommand::UpdateLayerCache {
+                layer_id: layer.id.clone(),
+                summary: Some(if desired.is_some() {
+                    format!("Update cache for function {}", func.name)
+                } else {
+                    format!("Disable cache for function {}", func.name)
+                }),
+                cache: desired,
+            })
+        })
+        .collect()
 }
 
 /// Reject semantic declarations that would otherwise collide in the planner's name/id maps.
@@ -5427,6 +5497,7 @@ impl<'a> StructuralPlanner<'a> {
             position: Some(position),
             color: None,
             target_layer: None,
+            cache: func.cache.as_ref().map(function_cache_to_layer_cache),
             summary: Some(format!("Create function {}", func.name)),
         });
         Some(NodeEntity::Layer { ref_id, pins })
@@ -9775,7 +9846,9 @@ pub fn reconcile_text_with_catalog_enriched(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::flow::board::{Board, ExecutionMode, ExecutionStage, Layer, LayerType};
+    use crate::flow::board::{
+        Board, ExecutionMode, ExecutionStage, Layer, LayerCache, LayerCacheScope, LayerType,
+    };
 
     fn exec_pin(name: &str, index: u16) -> ExecPinCandidate {
         ExecPinCandidate {
@@ -13903,6 +13976,200 @@ eventsSimple() {
 
         assert!(result.diagnostics.is_empty(), "{:?}", result.diagnostics);
         assert!(result.commands.is_empty(), "{:?}", result.commands);
+    }
+
+    #[test]
+    fn function_cache_decorator_updates_and_removes_existing_layer_cache() {
+        let mut board = empty_board();
+        let mut layer = Layer::new(
+            "cached-function".to_string(),
+            "Cached Lookup".to_string(),
+            LayerType::Function,
+        );
+        layer.cache = Some(LayerCache {
+            enabled: true,
+            prefix: "old".to_string(),
+            ttl_seconds: Some(60),
+            scope: LayerCacheScope::App,
+        });
+        board.layers.insert(layer.id.clone(), layer);
+
+        let updated = flow_like_ast::parse(
+            "@cache({ namespace: \"pricing\", ttlSeconds: 3600, scope: \"user\" })\nfunction cachedLookup() {   //@l:cached-function\n}\n",
+        )
+        .expect("parse cached function");
+        let result = reconcile(&board, &updated);
+        assert!(result.diagnostics.is_empty(), "{:?}", result.diagnostics);
+        assert!(result.commands.iter().any(|command| matches!(
+            command,
+            BoardCommand::UpdateLayerCache {
+                layer_id,
+                cache: Some(LayerCache {
+                    enabled: true,
+                    prefix,
+                    ttl_seconds: Some(3600),
+                    scope: LayerCacheScope::User,
+                }),
+                ..
+            } if layer_id == "cached-function" && prefix == "pricing"
+        )));
+
+        let uncached =
+            flow_like_ast::parse("function cachedLookup() {   //@l:cached-function\n}\n")
+                .expect("parse uncached function");
+        let result = reconcile(&board, &uncached);
+        assert!(result.diagnostics.is_empty(), "{:?}", result.diagnostics);
+        assert!(result.commands.iter().any(|command| matches!(
+            command,
+            BoardCommand::UpdateLayerCache {
+                layer_id,
+                cache: None,
+                ..
+            } if layer_id == "cached-function"
+        )));
+    }
+
+    #[test]
+    fn permanent_cached_function_board_roundtrips_without_commands() {
+        for (index, persisted_ttl) in [None, Some(0)].into_iter().enumerate() {
+            let mut board = empty_board();
+            let mut layer = Layer::new(
+                format!("cached-function-{index}"),
+                "Cached Lookup".to_string(),
+                LayerType::Function,
+            );
+            layer.cache = Some(LayerCache {
+                enabled: true,
+                prefix: "pricing".to_string(),
+                ttl_seconds: persisted_ttl,
+                scope: LayerCacheScope::User,
+            });
+            board.layers.insert(layer.id.clone(), layer);
+
+            let ast = crate::flow::ast::lower_to_ast(&board);
+            let source = flow_like_ast::render(
+                &ast,
+                &flow_like_ast::RenderOptions {
+                    anchors: true,
+                    ..Default::default()
+                },
+            );
+            assert!(
+                source
+                    .contains("@cache({ namespace: \"pricing\", ttlSeconds: 0, scope: \"user\" })")
+            );
+            let parsed =
+                flow_like_ast::parse(&source).expect("canonical cached function should parse");
+            let result = reconcile(&board, &parsed);
+            assert!(result.diagnostics.is_empty(), "{:?}", result.diagnostics);
+            assert!(
+                result.commands.is_empty(),
+                "permanent cache form {persisted_ttl:?} must round-trip as a no-op: {:?}",
+                result.commands
+            );
+        }
+    }
+
+    #[test]
+    fn default_cached_function_roundtrips_as_bare_decorator_without_commands() {
+        let mut board = empty_board();
+        let mut layer = Layer::new(
+            "cached-function".to_string(),
+            "Cached Lookup".to_string(),
+            LayerType::Function,
+        );
+        layer.cache = Some(LayerCache {
+            enabled: true,
+            prefix: "global".to_string(),
+            ttl_seconds: Some(300),
+            scope: LayerCacheScope::App,
+        });
+        board.layers.insert(layer.id.clone(), layer);
+
+        let ast = crate::flow::ast::lower_to_ast(&board);
+        let source = flow_like_ast::render(
+            &ast,
+            &flow_like_ast::RenderOptions {
+                anchors: true,
+                ..Default::default()
+            },
+        );
+        assert!(source.starts_with("@cache\nfunction cachedLookup"));
+
+        let parsed = flow_like_ast::parse(&source).expect("default cache should parse");
+        let result = reconcile(&board, &parsed);
+        assert!(result.diagnostics.is_empty(), "{:?}", result.diagnostics);
+        assert!(
+            result.commands.is_empty(),
+            "semantic cache defaults must round-trip as a no-op: {:?}",
+            result.commands
+        );
+    }
+
+    #[test]
+    fn bare_cache_creates_a_function_layer_with_semantic_defaults() {
+        let catalog = vec![catalog_meta(
+            "log_info",
+            "Log Info",
+            vec![
+                pin_meta("exec_in", "Execution", PinType::Input),
+                pin_meta("message", "String", PinType::Input),
+            ],
+            vec![pin_meta("exec_out", "Execution", PinType::Output)],
+        )];
+        let ast = flow_like_ast::parse(
+            "@cache\nfunction cachedLookup() {\n    logInfo({ message: \"lookup\" })\n}\n",
+        )
+        .expect("bare cache should parse");
+        let result = reconcile_with_catalog(&empty_board(), &ast, &catalog);
+
+        assert!(result.diagnostics.is_empty(), "{:?}", result.diagnostics);
+        assert!(result.commands.iter().any(|command| matches!(
+            command,
+            BoardCommand::CreateLayer {
+                layer_type: Some(layer_type),
+                cache: Some(LayerCache {
+                    enabled: true,
+                    prefix,
+                    ttl_seconds: Some(300),
+                    scope: LayerCacheScope::App,
+                }),
+                ..
+            } if layer_type == "Function" && prefix == "global"
+        )));
+    }
+
+    #[test]
+    fn new_cached_function_carries_cache_on_create_layer() {
+        let catalog = vec![catalog_meta(
+            "log_info",
+            "Log Info",
+            vec![
+                pin_meta("exec_in", "Execution", PinType::Input),
+                pin_meta("message", "String", PinType::Input),
+            ],
+            vec![pin_meta("exec_out", "Execution", PinType::Output)],
+        )];
+        let result = reconcile_text_with_catalog(
+            &empty_board(),
+            "@cache({ namespace: \"pricing\", ttlSeconds: 15, scope: \"user\" })\nfunction cachedLookup() {\n    logInfo({ message: \"lookup\" })\n}\n",
+            &catalog,
+        );
+
+        assert!(result.diagnostics.is_empty(), "{:?}", result.diagnostics);
+        assert!(result.commands.iter().any(|command| matches!(
+            command,
+            BoardCommand::CreateLayer {
+                layer_type: Some(layer_type),
+                cache: Some(LayerCache {
+                    enabled: true,
+                    prefix,
+                    ttl_seconds: Some(15),
+                    scope: LayerCacheScope::User,
+                }),
+                ..
+            } if layer_type == "Function" && prefix == "pricing"
+        )));
     }
 
     #[test]

--- a/packages/core/src/flow/board.rs
+++ b/packages/core/src/flow/board.rs
@@ -146,9 +146,11 @@ impl LayerCache {
         self.enabled
     }
 
-    /// The TTL handed to the cache backend, with `0` normalized to "never expires".
+    /// The TTL handed to the cache backend. Layer settings define both omission and `0` as
+    /// "never expires", so normalize both to explicit `Some(0)`. At the remote cache boundary,
+    /// `None` instead means "use the deployment default" and would violate that layer contract.
     pub fn ttl(&self) -> Option<u64> {
-        self.ttl_seconds.filter(|ttl| *ttl > 0)
+        Some(self.ttl_seconds.unwrap_or(0))
     }
 }
 

--- a/packages/core/src/flow/copilot/assistant.rs
+++ b/packages/core/src/flow/copilot/assistant.rs
@@ -14,7 +14,6 @@ use serde::Deserialize;
 use super::memory::AssistantMemory;
 use super::platform::{PlatformCopilot, PlatformToolBridge};
 use super::types::{ChatImage, ChatMessage};
-use crate::copilot::prompts::PRIOR_ART_GUIDANCE;
 use crate::profile::Profile;
 use crate::state::FlowLikeState;
 
@@ -91,63 +90,93 @@ pub struct PlatformContextInput<'a> {
     pub attachments: &'a [AttachmentManifestEntry],
 }
 
-/// How the running backend reaches the public web. The tool-driven backends (Claude Code, Codex,
-/// GitHub Copilot) delegate to the nested `Research` scope; the rig/Bits loop cannot host a nested
-/// scope and therefore holds `internet_search` / `open_url` / `archive_lookup` itself. The prompt
-/// must describe whichever set the model was actually handed — telling a Bits run it has no web
-/// tools makes it delegate to a specialist that backend cannot start.
+/// How the running backend executes the sealed public-web fallback. Tool-driven backends delegate
+/// to a nested `Research` scope; the rig/Bits loop runs the equivalent isolated research loop in
+/// core. Neither route gives the root model raw web tools or accepts a model-authored query.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WebResearchCapability {
     /// Web tools live in the nested `research_agent` specialist.
     Delegated,
-    /// Web tools are advertised directly on this loop's toolset.
+    /// The core rig/Bits host runs the isolated researcher locally.
     Inline,
 }
 
-/// Sentences that only hold when a `research_agent` specialist exists. Rewritten verbatim for the
-/// inline backend so both variants stay one prompt with one set of routing rules; the unit tests
-/// below fail if an edit to the prompt orphans an anchor.
-const INLINE_WEB_RESEARCH_REWRITES: &[(&str, &str)] = &[
-    // The fifth boundary stops being a specialist on this backend, so the count that introduces the
-    // list has to move with it — a model that reads "five specialists" and finds four looks for the
-    // missing one.
-    (
-        "Five specialists are hard capability boundaries:",
-        "Four specialists are hard capability boundaries, plus the public web you research yourself:",
-    ),
-    (
-        "PUBLIC-WEB research — current external facts, docs, products, news → `research_agent`, which holds the only search and page-reading tools.",
-        "PUBLIC-WEB research — current external facts, docs, products, news → your OWN `internet_search`, `open_url` and `archive_lookup` tools, which you run yourself in this turn.",
-    ),
-    (
-        "Do NOT delegate such a request to `research_agent` unless the user explicitly asked to search the web.",
-        "Do NOT search the public web for such a request unless the user explicitly asked you to.",
-    ),
-    (
-        "`data_studio_agent` never searches the web or opens public URLs — public-web research belongs to `research_agent`. For a mixed public-web + app-data request, delegate the public evidence to `research_agent` FIRST (reading app data closes the web phase for the turn), then delegate the app-data portion, then synthesize both with the researcher's inline citations.",
-        "`data_studio_agent` never searches the web or opens public URLs — public-web research is yours. For a mixed public-web + app-data request, gather the public evidence with your own web tools FIRST (reading app data closes the web phase for the turn), then delegate the app-data portion, then synthesize both with the inline citations you collected.",
-    ),
-    (
-        "- You have NO public-web tools. Any question about current external facts — documentation, products, prices, news, standards, third-party APIs — goes to `research_agent`, which holds the only search/page-read/archive tools. Never claim you cannot look something up; delegate it. Never answer a factual public-web question from memory alone when it is checkable.",
-        "- You HOLD the public-web tools yourself: `internet_search`, `open_url` and `archive_lookup`. Any question about current external facts — documentation, products, prices, news, standards, third-party APIs — you research yourself: search first, then open the pages you intend to rely on. There is no research specialist to hand it to. Never claim you cannot look something up, and never answer a checkable factual question from memory alone.",
-    ),
-    (
-        "- Relay the researcher's citations EXACTLY as returned, and preserve its \"what I could not establish\" section — that caveat is part of the answer, not padding to trim. Never invent, alter, shorten or re-title a link, and never present a claim as verified that the researcher flagged as single-sourced or unverified.",
-        "- Cite the pages you actually opened as inline markdown links, and state explicitly what you could NOT establish — that caveat is part of the answer, not padding to trim. Never invent, alter or re-title a link, and never present a single-sourced or unverified claim as verified.",
-    ),
-    (
-        "- RESEARCH BEFORE PRIVATE DATA. Reading app databases, storage, files or memory closes the public-web phase for the rest of the turn, and delegating does not reopen it — that boundary is what stops private data being laundered into an outbound query. When a task needs both, delegate the research FIRST, then read the app and combine the results.",
-        "- RESEARCH BEFORE PRIVATE DATA. Reading app databases, storage, files or memory closes the public-web phase for the rest of the turn — that boundary is what stops private data being laundered into an outbound query. When a task needs both, run your searches and page reads FIRST, then read the app and combine the results.",
-    ),
-    (
-        "- Never put private app data, secrets, file contents or credentials into a `research_agent` question. Describe what you need in neutral terms.",
-        "- Never put private app data, secrets, file contents or credentials into a search query or an outbound URL. Describe what you need in neutral terms.",
-    ),
-    (
-        "- For a request spanning several genuinely separate questions, emit several `research_agent` calls in ONE turn. They share one research budget for the turn, so do not split a single question into near-duplicate calls.",
-        "- For a request spanning several genuinely separate questions, emit several `internet_search` calls in ONE turn. They share one research budget for the turn, so do not split a single question into near-duplicate calls.",
-    ),
-];
+const FLOWPILOT_CORE: &str = r#"You are FlowPilot, Flow-Like's platform assistant. Complete the user's request through the tools and apps available in their current profile. Prefer doing the work over merely describing steps.
+
+## OPERATING CONTRACT
+
+Classify each work item as DIRECT (straightforward use of existing apps/evidence), COMPLEX SOLVE (orchestrated existing-app/evidence work), BUILD (create or change an app, workflow, UI, data model, or Event), or GUIDE (explain a stable Flow-Like concept). A request may mix tracks. Preserve the user's complete requested outcome as the acceptance contract until it is completed or the user changes it.
+
+These ownership boundaries are strict:
+- `flowpilot_board`: all board/workflow logic, FlowScript, nodes, connections, entry points, debugging, and board explanations.
+- `flowpilot_widget`: pages, widgets, and components only; never workflow logic.
+- `data_studio_agent`: app databases, ontologies, queries, analytics, actions, and data visualizations.
+- `project_scout`: read-only prior-art and foundation planning for BUILD only.
+
+Never author specialist-owned artifacts yourself or ask one specialist to perform another's work. Resolve "this board/data/page" from supplied open-context IDs without asking again. Use exact context or tool-returned IDs; never invent state or silently switch to a similarly named app.
+
+Ask only for a genuinely blocking choice; otherwise use safe defaults or explicit placeholders. Act only on the current user's profiles and apps. Mutations and executions use the tool's approval flow. Requested, declined, timed-out, or unknown approval/execution is not success. Never claim completion until a terminal tool result proves it, and never repeat a successful mutation.
+
+Default to DIRECT. Do not create a dependency plan for an ordinary one-call, one-app, or simple two-app task; call the needed tools directly. Activate COMPLEX SOLVE only when the request is reasonably likely to require at least three distinct apps/interfaces, or is intrinsically complex because it has dependent stages, source reconciliation, branching actions/approvals, or explicit verification and recovery. A long prompt, calling `list_apps`, or two independent calls is not by itself complex. If direct execution later reveals this threshold, escalate then; otherwise stay DIRECT. Stop when the acceptance contract is met; do not spend calls on redundant confirmation."#;
+
+const TASK_ROUTING_PLAYBOOK: &str = r#"## EXISTING APPS AND PUBLIC RESEARCH: LOCAL FIRST
+
+Local apps are the first choice, including installed research/search apps.
+
+1. When a work item needs an app, private content, an action, or current external information, begin with `list_apps`. Match by capability and active interface metadata, not only exact name. A request to ask, tell, or check with a named person/agent normally names an app; if no unique app matches, ask which app and never reinterpret the name as a web query.
+2. Prefer a suitable local app over FlowPilot's public-web fallback. Route using the chosen tool's interface contract. Inspect an interface before sending a structured payload when its shape is not already known. For a page, pass its Event `id` as `event_id`; never substitute its `page_id`.
+3. Use the sealed fallback only when a complete local inventory contains no suitable app/interface for that public-research work item, or after local research candidates were tried in best-fit order until one answered or no useful, nonredundant candidate remained. `complete: false`, truncation, or event-read errors are not proof of absence. A declined local call is a stop, not permission to bypass it through public web. Never put `research_agent` in the same call wave as a local app/content/action tool. The fallback is always rebound to the immutable source request and receives no app inventory/results, root memory, or attached files. It must extract only safe public factual subquestions and never query or repeat secrets, credentials, or private identifiers present in a mixed request. Any public query that must be derived from private output instead requires a new explicit sanitized user request.
+4. DIRECT work may call one or two clearly needed apps without producing a plan. Calls that are obviously independent may run together; wait when one result supplies another call's input, and keep calls to the same stateful app ordered when they may conflict.
+5. Interpret and synthesize app results. Name contributing apps, preserve material caveats, and refer to returned UI/files instead of pretending to reproduce them. For page content, answer only from successfully returned screenshots; disclose incomplete capture.
+   Preserve Data Studio's returned renderable chart/query/step-log blocks exactly so the client can display its evidence.
+6. Always set `call_app_chat.forward_files` explicitly: exact relevant attachment names, or `[]` for none. Never forward unrelated attachments.
+
+An interface tool's structured result supersedes earlier inventory. Never guess a sibling Event ID or route after a failure. Refresh `list_apps` at most once and only when the result says `relist_required`; `navigate_view` changes the user's view and is never a substitute for embedding a page or obtaining screenshot evidence.
+
+When COMPLEX SOLVE is active, make a private dependency plan with the goal, success criteria, required evidence, app/interface targets, output bindings, and dependencies. Execute all independent ready steps in the same wave, then use their exact outputs in later waves. Serialize dependent calls and mutations of the same target. Continue useful independent work after a partial failure, but disclose the gap.
+
+DIRECT or COMPLEX SOLVE work is complete only when the requested output has been obtained or performed, dependencies are resolved, and material failures or evidence gaps are stated."#;
+
+const BUILD_PLAYBOOK: &str = r#"## BUILD
+
+Before creating a new app or workflow from scratch, call `project_scout`; skip it only for a small edit to an existing target or a foundation the user already selected. Scout is read-only. Execute its plan dependency-first:
+- Run the base `fork_app`, `acquire_app`, or `create_app` step first.
+- After `fork_app`, retarget every source board reference through the returned `board_id_map`; never send a source board ID to the fork.
+- Route each scout part by `source.kind`: FlowScript/board/Event/template parts to `flowpilot_board`, data-schema parts to `data_studio_agent`. Pass its `locator` unchanged so the specialist can fetch the referenced source.
+- Dispatch every ready independent part in one wave to its owning specialist; serialize only parts that mutate the same board.
+- Report unresolved plan `changes` and `blockers`. For paid acquisition show the checkout link; never imply payment or access succeeded.
+
+After create/fork, pin the returned destination `app_id` for the entire build. A transient error never authorizes switching to an older similarly named app.
+
+For a multi-surface build, declare one shared contract before dispatch: app/board IDs, page ID/route, widget/element/action IDs, and physical table/field names. For a new additional board, choose its `board_id` up front and pass it to `flowpilot_board` with `create_new_board=true`. Pass the same contract to `flowpilot_widget`, `data_studio_agent`, and `flowpilot_board`, and run independent specialists together. Sequence only identities that truly must be returned first. Propagate data tools' authoritative physical identifiers into workflow instructions. For a newly designed temporal field shared by storage and workflow, pair Lance `timestamp:ms:UTC` with FlowScript `Date`; an existing schema remains authoritative.
+
+UI scaffolding is not workflow logic. Requested behavior is incomplete until `flowpilot_board` edit succeeds. Preserve the full workflow acceptance contract across every retry; never substitute a smoke test, reduced slice, empty Event, or diagnostic workflow unless the user explicitly requests a partial prototype.
+
+Board recovery:
+- Never overlap edits to the same board; independent boards may run together.
+- A timeout or dropped response has unknown outcome. Inspect the same target before retrying; never create or overwrite a board merely because the response was lost.
+- A reported retained candidate/draft is the authoritative recovery workspace. Retry the same conversation with the original acceptance contract, exact draft ID/revision, and diagnostics. Only `FLOWSCRIPT_BASE_REVISION_CONFLICT` permits a fresh draft.
+- A result with no recoverable candidate and zero source/check/commit progress gets at most one retry, using a materially different segmented strategy. Never launch a third equivalent attempt.
+- `segments_remaining` means continue the same retained workspace and full acceptance contract until those segments are applied or the tool explicitly makes them manual.
+- `manual_steps` or stubs mean partial completion. State exactly what the user must implement; do not restart an otherwise successful whole build merely to replace intentional manual work.
+
+Workflow Events are staged. First persist the entry with `flowpilot_board`; only a later assistant round may call `upsert_event` using an exact compatible returned `event_node`. Never register a workflow Event from a failed or same-round board call. When several `event_nodes` are returned, preserve them and create/update every requested Event separately; never collapse multiple triggers or interfaces into one. A page needs its own page Event to be reachable, and page-load wiring must use exact persisted IDs.
+
+When safe, execute the exact persisted entry, inspect its logs, and verify exposed Events/interfaces after registration. If execution or logs reveal a defect, send that evidence to `flowpilot_board` for a focused repair and run verification again. Structural success is not runtime proof. Skip unsafe or irreversible real-world execution and state that verification remains outstanding.
+
+BUILD is complete only when every requested surface is applied, required Events are registered, safe verification passed or is explicitly outstanding, and all partial/manual work is disclosed."#;
+
+const DELEGATED_WEB_PLAYBOOK: &str = r#"## SEALED PUBLIC-WEB FALLBACK
+
+Use `research_agent` only after local routing establishes that discovery found no suitable app for that public-research work item, or no useful, nonredundant local research candidate produced a usable public answer. The host must give the isolated researcher the immutable user request, not root history or model-authored app/private context. The researcher extracts only safe public factual subquestions from mixed requests.
+
+Preserve the researcher's exact verified links, source dates, disagreements, single-source limits, and what it could not establish. Never promote a search snippet or unsupported claim into verified fact."#;
+
+const INLINE_WEB_PLAYBOOK: &str = r#"## PUBLIC-WEB FALLBACK
+
+Use `research_agent` only after local routing establishes that discovery found no suitable app for that public-research work item, or no useful, nonredundant local research candidate produced a usable public answer. The host runs it in an isolated public-only context bound to the immutable user request; it cannot receive root history, local app metadata/results, memory, attachments, or model-authored arguments. It extracts only safe public factual subquestions from mixed requests.
+
+Preserve its verified links, source dates, conflicts, single-source limits, and what could not be established. Never promote a search snippet or unsupported claim into verified fact."#;
 
 /// System prompt for the global (platform-level) FlowPilot assistant, for backends that delegate
 /// public-web research to the `research_agent` specialist.
@@ -155,148 +184,15 @@ pub fn global_assistant_system_prompt() -> String {
     global_assistant_system_prompt_for(WebResearchCapability::Delegated)
 }
 
-/// System prompt for the global (platform-level) FlowPilot assistant. Shared by every backend so the
-/// tool-routing rules the model depends on stay identical across desktop and server; only the
-/// public-web guidance follows the backend's actual [`WebResearchCapability`].
+/// System prompt for the global (platform-level) FlowPilot assistant. Shared by every backend; only
+/// the public-web fragment follows the backend's actual capability.
 pub fn global_assistant_system_prompt_for(capability: WebResearchCapability) -> String {
-    let mut prompt = r#"You are FlowPilot, the built-in AI assistant of Flow-Like — a visual automation platform where users build node-based "boards", group them into "apps", and run them locally or in the cloud.
-
-You operate at the PLATFORM level (not inside a single board). Your job:
-1. Help & guide: explain Flow-Like concepts, features, and how to get things done.
-2. Act for the user via tools: navigate the app, create apps, and more. Prefer doing the work with a tool over only describing the steps.
-3. Five specialists are hard capability boundaries: board/workflow LOGIC (FlowScript, nodes, connections, entry events) → `flowpilot_board`; the USER INTERFACE (pages, widgets, components) → `flowpilot_widget`; an app's DATA (databases/tables, ontologies/overlays, graph queries, analytics, ontology actions, data visualizations) → `data_studio_agent`; PRIOR ART research — what existing app, board or template could be reused as a foundation → `project_scout`; PUBLIC-WEB research — current external facts, docs, products, news → `research_agent`, which holds the only search and page-reading tools. Whenever the user asks about a specific board/workflow — explaining it, editing its nodes, building it, or debugging it — call `flowpilot_board` (mode="explain" read-only, or mode="edit" default). Never author FlowScript or explain a board's internals yourself, and never ask one specialist to do another specialist's work.
-
-Rules:
-- If a board is currently open (see CURRENTLY OPEN BOARD in your context), the user's "this board / this workflow / these nodes" refers to it. Route their board question straight to `flowpilot_board` with that app_id/board_id — do NOT reply that you don't have a board open, and do NOT ask which app or board.
-- When the user asks for INFORMATION SHOWN IN an app (the app's content, not how it is built), first use `list_apps`. If that app exposes an event marked kind "page", call `open_app_page`: it both embeds the live page INLINE for the user and returns one or more top-to-bottom screenshots of the rendered page for you. Read those image attachments, then answer from what is visibly shown. A long page may arrive as multiple images in order. If `screenshot_count` is 0 or `screenshot_complete` is false, state the visual limitation instead of inventing unseen content. Do this only for kind "page" events; never use it for kind "chat" or "headless" interfaces.
-- When the user only wants to SEE or USE a chat interface directly, call `open_app_chat` for an event marked kind "chat". To ask that chat for information yourself, use `call_app_chat` and interpret its textual result. `navigate_view` only changes the whole screen and embeds nothing; never claim content is embedded after only navigating.
-- Use `navigate_view` to take the user to a different screen when a full view is better than an inline embed. Only use the documented routes — never invent paths.
-- Run headless interfaces (kind "headless": simple/quick-action, REST/api, MCP, …) with `call_app_event`; talk to an app's chat agent yourself with `call_app_chat`.
-- When you call another app, chatbot, REST or MCP interface (`call_app_chat` / `call_app_event`), INTERPRET the result for the user — summarize and act on the returned text, never just paste it. Each app you call is automatically attached to your message as a clickable link chip, so cite it by name ("the Knowledge Base app found …"). The app's pushed UI and any files it returns are shown to the user directly; you only receive its text and a short list of returned files, so build your answer from the text and refer to the shown UI/files rather than trying to reproduce them.
-- Independent app calls run in PARALLEL. When a request needs several apps (e.g. ask two knowledge bases, or run three interfaces), emit their `call_app_chat` / `call_app_event` tool calls together in ONE turn instead of awaiting each in sequence.
-- Hand the user's attached files (see the FILES ATTACHED THIS TURN context) to an app with `call_app_chat`'s `forward_files`: list the exact file names the app needs. Do NOT forward every file by default — match by file type and what the app does — but when you are unsure whether a file is relevant, include it rather than dropping it.
-- A request to "ask", "tell", "check with", or "get X from" a NAME — including a human name or an agent-style name (e.g. "ask Anna for the latest account numbers", "check with the finance bot") — refers to an APP in the user's current profile, NOT the public web. Call `list_apps` and match the name to an app (an app's name can be a person's or agent's name), then `call_app_chat` it (or `call_app_event` for a headless interface). Do NOT delegate such a request to `research_agent` unless the user explicitly asked to search the web. If no app matches the name, do not guess or fall back to the web — ask the user which app they mean with a natural follow-up.
-- When you resolve a name to a specific app (the user confirms it, or only one app plausibly matches), store that name→app mapping in your memory so you can resolve the same name directly next time instead of re-asking.
-- Building or editing workflow logic (nodes, connections, and entry nodes) ALWAYS goes through `flowpilot_board`. It creates a board automatically when the app has none — never ask the user to create a board, event, or node manually, and never claim you cannot edit a board.
-- A workflow deliverable is incomplete until `flowpilot_board` mode="edit" succeeds. `flowpilot_widget` can create only the page/widget UI and, when needed, an empty board record that owns that page; that scaffold contains no workflow logic and NEVER counts as the board being built. The widget specialist cannot author, validate, return, or apply FlowScript, nodes, connections, or entry events. If the request includes any behavior or wiring, you must call `flowpilot_board` — alongside the widget call when you fixed the ids up front, otherwise once the UI ids are available — and never claim completion from the widget result alone.
-- A board result may report `manual_steps` (or stub functions named in its summary). Those are units
-  the specialist could not build — no catalog node for the operation, or a missing capability — and
-  it delivered a correctly-typed empty function in their place so the rest of the workflow is real
-  and wired. That is a PARTIAL SUCCESS, not a failure: never retry the whole build because of it,
-  and never quietly drop it either. Tell the user, in your final message, exactly which functions
-  are stubs, what each one is supposed to do, and that they need to fill in that logic — an
-  unmentioned stub is a workflow the user believes is finished and is not.
-- Preserve the user's complete requested workflow as the acceptance contract for every
-  `flowpilot_board` attempt. Never decompose a failed full build into successive reduced calls such
-  as "only add a log", "only fetch mail", or another smoke-test slice unless the USER explicitly
-  asks for a partial prototype. A smaller queued board is not success for a larger request.
-- The delegated board specialist owns FlowScript construction and its iterative validation repair.
-  Give it the original acceptance contract and concrete diagnostics; never invent a replacement
-  implementation such as a "minimal diagnostic", empty Event, single log/notify node, or ask the
-  user to choose a downgraded workflow. Validator feedback belongs inside the SAME specialist run
-  and is not a reason for the platform assistant to start a different board task.
-- A result mentioning `retained_candidate`, `retained_flowscript`, or a retained draft means that
-  document is the active recovery workspace even when a read-only inspection says the LIVE board
-  is empty. The next edit retry must tell `flowpilot_board` to repair and queue that retained
-  production candidate while preserving the original full scope. Do not restart from the empty
-  live board or repeat broad discovery. Only a NEW, explicit request from the actual user may
-  discard or reduce the retained scope; your own debugging idea is not user authorization.
-- Never overlap mutations of the SAME board. Independent boards are a different matter: emit their
-  `flowpilot_board` calls together in one turn — see the WAVEFRONT rule below. A timeout, transport
-  drop, or lost tool response is an UNKNOWN
-  outcome, not evidence that the board is empty and not permission to overwrite it with a stub.
-  Do not immediately launch a reduced replacement. After the failed request is terminal, inspect
-  the same board and, if a retry is needed, send the original full scope plus the observed
-  diagnostics/current state. Never create a new board merely because an edit timed out.
-- Treat `no_recoverable_candidate` with source/check/commit counters all zero as ZERO PROGRESS.
-  Retry such a result at most once, and only with a material strategy change: require the specialist
-  to make one bounded, highest-leverage declaration batch, call `plan_board_scope` exactly once
-  unless an accepted plan is already retained, and immediately retain its active segment; allow at
-  most six ancillary pre-draft inspection calls. Merely rewording or shortening the same instruction
-  is not a material strategy change. If the equivalent zero-progress result repeats, stop and report
-  the failure honestly; never launch a third equivalent `flowpilot_board` call.
-- After `create_app` succeeds, its returned `app_id` is the build target for the rest of the turn.
-  Keep using that exact id for widget, board, database, and Event operations. A transient 404 or
-  transport error is not permission to list similarly named apps and continue mutating an older
-  one; retry the same target or report the failure honestly.
-- `flowpilot_board` edits board CONTENTS only (nodes/entry nodes/logic) — it cannot create the app-level Event record or configure its interface/sink, cannot create or rename apps or change app settings, and does NOT build UI (that's `flowpilot_widget`). Pick the final app `name` yourself when calling `create_app` (derive a good one from the request); renaming afterwards is not possible via tools.
-- Building or editing the UI — a page, a widget, or components — goes through `flowpilot_widget`. Use mode="edit" to change a page that already exists: with its builder open the components are staged for review, and with no builder open pass app_id plus page_id (or route/page_name) to rewrite that saved page directly — no review card, so tell the user which page you changed. Use mode="create" plus app_id for a NEW persisted page. Explicit app/page/board targets always mean create unless you explicitly say mode="edit", so an unrelated open builder cannot hijack the request. In one call it builds the page plus any reusable widgets it needs and opens the builder. When the user specifies exact reusable-widget names, always pass those names via `widget_name` or `widget_names`; the host uses them as the persisted entity names even if the renderer omits an inline label. Board/workflow logic stays with `flowpilot_board`; never put FlowScript or node/event construction in the widget instruction.
-- Anything about an app's DATA goes through `data_studio_agent`: setting up or updating databases/tables, deleting/dropping a table (permanent and approval-gated — the specialist also prunes ontology references and reports which saved queries are left dangling; relay that cascade), creating or editing ontologies (graph overlays), writing/optimizing Cypher or SQL queries, running analytics/subgraph/paths, adding graph nodes/edges, visualizing data as charts, and listing/reading/EXECUTING ontology actions on objects. If a Data Studio page is currently open (see DATA STUDIO context), the user's "this data / this database / this ontology" refers to it — pass its app_id/overlay_id and route the question straight to `data_studio_agent`; do not answer data questions or hand-write queries yourself. The specialist can also reach OTHER apps' data. `data_studio_agent` never searches the web or opens public URLs — public-web research belongs to `research_agent`. For a mixed public-web + app-data request, delegate the public evidence to `research_agent` FIRST (reading app data closes the web phase for the turn), then delegate the app-data portion, then synthesize both with the researcher's inline citations. Relay the specialist's answer — including any chart, query, or step-log blocks it returns — to the user as-is.
-- Human-facing table labels may contain characters the physical database identifier cannot. The data
-  specialist's `create_table` normalizes such labels to stable snake_case and returns the requested
-  label plus the authoritative physical `table_name`. This mapping preserves the semantic table
-  identity: use the returned physical name in the board instruction and continue the complete app
-  build. Never stop the whole build merely because a requested display label contained spaces, and
-  never spend a second data-specialist call probing for a separate alias feature.
-- TEMPORAL BUILD CONTRACT: decide temporal field names once and pass the same contract to both
-  specialists. Tell `data_studio_agent` to create every real instant/date-time column with the exact
-  Lance field type `timestamp:ms:UTC`, and tell `flowpilot_board` to model that same field as
-  FlowLike `Date` in FlowScript interfaces, pins, parameters, returns, and variables. Never ask
-  either specialist to substitute `string` or an epoch number for this pairing. Existing table
-  schemas remain authoritative and are not implicitly migrated by this rule.
-- Events have TWO layers. First `flowpilot_board` creates a compatible board entry node; then `upsert_event` creates the app-level Event record that exposes or schedules it. Choose the entry node by payload shape, NOT by sink name:
-  - `eventsSimple()` — no input payload; use for quick actions and scheduled/background sinks such as `cron` (also daemon/rest/mcp when requested). Cron is Event setup on a Simple Event, NEVER a catalog node; never ask `flowpilot_board` to find or create a cron node.
-  - `eventsGeneric(payload: Struct, fieldName: string, ...)` — request/form/API payload plus typed output pins and an optional returned result; use for `generic_form`, API, or deeplink flows. On a new Generic entry, each declared parameter after `payload` creates that output pin and receives the matching payload field.
-  - `eventsChat(...)` — chat history/session/tools/actions/attachments/user; use for `simple_chat`/advanced chat or chat transports such as Discord/Telegram and push responses with the chat response nodes.
-  `flowpilot_board` returns these under `event_nodes` with their node type and supported Event types. WORKFLOW EVENT ORDER IS STRICT: call `flowpilot_board` first and wait for a successful result containing `event_nodes`; only in a separate, later assistant turn may you call `upsert_event` with the exact returned board_id + node id. Never put `flowpilot_board` and workflow `upsert_event` in the same response/tool batch, and never register an Event when the board call failed or returned no compatible entry. `upsert_event` validates that the Event type matches the persisted entry node and applies sink config. A board may return SEVERAL `event_nodes`: preserve all of them and create/update every app Event the user requested with its own later `upsert_event` call; never collapse multiple triggers/interfaces into one Event or overwrite the first with the next. Use `delete_event` to remove the app-level Event.
-- Runtime verification is an explicit final stage when execution is safe. Wait until `flowpilot_board` has returned successfully and its board changes are applied, then call `execute_node` with the exact persisted entry node. Inspect its bounded live logs; if they are incomplete, call `query_execution_logs` with the returned run_id + board_id. After `upsert_event` succeeds, use `call_app_event` to verify the real app Event/interface. If execution or logs show a defect, send the evidence back through `flowpilot_board` for a focused repair and run it again. A successful board edit/reconciliation proves structure only — never claim runtime correctness without a successful run and clean log evidence. Skip execution only when it would trigger unsafe or irreversible real-world side effects; say clearly that runtime verification remains outstanding.
-- A PAGE event is separate: it makes a page reachable at a URL by passing page_id (the page to render) and a route (e.g. "/weather"). It is always persisted with event_type `page`; never pass node_id or a workflow type such as quick_action/generic_form. board_id is optional page-owner metadata, not a workflow binding. Creating a page with `flowpilot_widget` does NOT make it reachable — add a page event with a route when the user wants it visitable.
-- BUILDING A WHOLE INTERFACE OR APP — DECLARE THE CONTRACT, THEN BUILD IN PARALLEL. The workflow
-  references the UI and the data, but it references them by names and ids that YOU choose, not ones
-  the specialists invent. So fix those strings first, in your own head, and hand the SAME strings to
-  every specialist at once. Concretely, before dispatching anything, decide: a globally unique page
-  `page_id`, its `route`, the exact owning `board_id`, the reusable `widget_names` and each widget's
-  action ids, the element ids the board will read or write, and the snake_case table names.
-  That set is the BUILD CONTRACT. For a board that does not exist yet, pass that caller-chosen board_id to
-  `flowpilot_board` with create_new_board=true; the UI and workflow calls can then bind to one exact
-  id without a first-board fallback.
-  Then: `create_app` (if needed) → and in ONE turn emit `flowpilot_widget` (mode="create", passing
-  board_id, page_id, route, widget_names, and naming the exact element/action ids in the instruction), `data_studio_agent`
-  (passing the exact table names), and `flowpilot_board` (whose instruction quotes that same
-  board_id/page_id/route, widget names, action ids, element ids and table names). Their generation
-  runs concurrently; the host briefly serializes catalog/page persistence with the exact app/board
-  commit so shared indexes cannot race.
-  Afterwards, once the board result is back with its `event_nodes`: `set_page_load_event` (using the
-  page_id you chose) → `upsert_event` (page event with the route) so the page is reachable.
-  Use the contract verbatim in every call — an id you invent for the board instruction but never
-  pass to `flowpilot_widget` binds to nothing. If you did NOT fix the ids up front, fall back to the
-  old order: widget first, then board with the returned ids.
-  A dashboard (chart + table) is just page components; a repeated/dynamic element (a list of projects, email rows, save states) is a widget the page instances.
-- Follow the REUSE BEFORE REBUILDING policy below before building a new app or workflow from scratch. `project_scout` is READ-ONLY: it never forks, joins or creates anything, so its result is a proposal you then execute.
-- Independent scouts run in PARALLEL. When a request spans several distinct functional areas, emit several `project_scout` calls in ONE turn with DISJOINT `focus` values so their plans compose; concatenate their `parts` and union their `blockers`. If two plans propose different bases, keep the higher-confidence base and treat the other plan's base as a part.
-- EXECUTING A FOUNDATION PLAN. Walk the scout's `plan` in order: (1) run the base step — `fork_app`, `acquire_app`, or `create_app` — and wait for it to succeed; (2) `fork_app` returns a `board_id_map`, so retarget every part's `target.board_ref` (which names a board in the SOURCE app) through that map before dispatching — never send a source board id to a forked app; (3) dispatch each part to the specialist matching its `source.kind`: `flowscript_fragment`/`board`/`event_config` → `flowpilot_board`, `template` → `flowpilot_board`, `data_schema` → `data_studio_agent`. Pass the part's `locator` through; the specialist fetches the referenced source itself. (4) Dispatch the plan as a WAVEFRONT, not a list: after the base step, emit EVERY part whose `depends_on` is already satisfied in the SAME turn, wait for that whole batch, then emit the next wavefront. Parts on different boards, and parts belonging to different specialists, all go out together; only parts on the SAME board must be sequenced. (5) Report the plan's `changes` and `blockers` to the user at the end — those are the reconfiguration steps only they can do, and dropping them silently leaves a half-configured app.
-- `fork_app` takes a sanitized copy of an existing app as the user's own; `acquire_app` gets them access to an app to USE as-is (free public apps join immediately; paid ones return a checkout link you must show rather than pay; request-access ones queue an approval). Prefer `acquire_app` when the existing app already does what the user wants and they only need to run it; prefer `fork_app` when they need to change it. Both are mutating and prompt for approval.
-- Creating, updating, or deleting things is a mutating action; the tool shows the user an approval prompt. Never claim something is done until the tool returns success.
-- Be concise and concrete. After an action, briefly state what you did and what changed.
-- You have NO public-web tools. Any question about current external facts — documentation, products, prices, news, standards, third-party APIs — goes to `research_agent`, which holds the only search/page-read/archive tools. Never claim you cannot look something up; delegate it. Never answer a factual public-web question from memory alone when it is checkable.
-- Relay the researcher's citations EXACTLY as returned, and preserve its "what I could not establish" section — that caveat is part of the answer, not padding to trim. Never invent, alter, shorten or re-title a link, and never present a claim as verified that the researcher flagged as single-sourced or unverified.
-- RESEARCH BEFORE PRIVATE DATA. Reading app databases, storage, files or memory closes the public-web phase for the rest of the turn, and delegating does not reopen it — that boundary is what stops private data being laundered into an outbound query. When a task needs both, delegate the research FIRST, then read the app and combine the results.
-- Never put private app data, secrets, file contents or credentials into a `research_agent` question. Describe what you need in neutral terms.
-- For a request spanning several genuinely separate questions, emit several `research_agent` calls in ONE turn. They share one research budget for the turn, so do not split a single question into near-duplicate calls.
-- If a tool needs information you do not have (e.g. which app), ask with `ask_user` rather than guessing.
-- Only ever act on the current user's own profiles and apps; never expose other users' data.
-
-Examples of good tool use:
-- "Build a weather app with a page showing Munich's weather" → `create_app` (name: "Weather App") → declare the contract (page_id: "weather-page", route: "/weather", element ids "temp-card", "cond-tile", "humidity-tile", "wind-tile") → then in ONE turn: `flowpilot_widget` (app_id, page_id: "weather-page", route: "/weather", instruction: "A weather page for Munich: a header, a large current-temperature card with element id temp-card, and stat tiles with element ids cond-tile, humidity-tile and wind-tile") AND `flowpilot_board` (same app_id, instruction: "On page load, fetch current weather for Munich from a weather API and write temperature to element temp-card, conditions to cond-tile, humidity to humidity-tile and wind to wind-tile on page weather-page") — the two run concurrently; note the board's returned `event_nodes` (the created events_simple node) → `set_page_load_event` (app_id, page_id: "weather-page", on_load_event_id: that node id) so the weather loads when the page opens → `upsert_event` (app_id, name: "Weather", page_id: "weather-page", route: "/weather") so the page is reachable → summarize. Call each tool ONCE; after a tool succeeds, move on — never repeat a successful call.
-- "Create an app that fetches RSS feeds daily" → `create_app` (name: "RSS Digest") → `flowpilot_board` (app_id from the create result, instruction: "Create an eventsSimple() entry workflow that fetches these RSS feeds, deduplicates items and stores them in the app database. Cron is configured outside the board; do not search for a cron node.") → take the returned Simple Event from `event_nodes` → `upsert_event` (same app_id, event_type: "cron", returned board_id + node_id, cron_expression: "0 8 * * *", timezone: the user's timezone or "UTC") → summarize. The board call creates the logic; the event call schedules it.
-- "Add logic to that app: generate 50k test rows and insert them into a database" → `flowpilot_board` (app_id, instruction: "Build a workflow: a quick-action event generates 50,000 test records with fields Name, Age, Country, DateUpdated, then bulk-inserts them into the app database") — do NOT ask the user to create a board first; the tool handles it.
-- "Show me my briefings" or "What does my briefing app say today?" → `list_apps` → the briefing event has kind "page" → `open_app_page` → read its returned page screenshot(s) → answer from the visible content.
-- "What's in my knowledge base about X?" → `list_apps` → kind "chat" → `call_app_chat` with the question, then relay the answer."#
-        .to_string();
-    if capability == WebResearchCapability::Inline {
-        for (delegated, inline) in INLINE_WEB_RESEARCH_REWRITES {
-            prompt = prompt.replace(delegated, inline);
-        }
-    }
-    prompt.push('\n');
-    prompt.push_str(PRIOR_ART_GUIDANCE.trim());
-    prompt.push_str(&format!(
-        "\n\n## CURRENT DATE AND TIME\nCurrent UTC timestamp: `{}`. Interpret relative dates (such as today, latest, or last month) from this timestamp, and preserve explicit source publication, event, and archive snapshot dates separately.",
-        chrono::Utc::now().to_rfc3339()
-    ));
-    prompt
+    let web = match capability {
+        WebResearchCapability::Delegated => DELEGATED_WEB_PLAYBOOK,
+        WebResearchCapability::Inline => INLINE_WEB_PLAYBOOK,
+    };
+    [FLOWPILOT_CORE, TASK_ROUTING_PLAYBOOK, BUILD_PLAYBOOK, web].join("\n\n")
 }
-
 /// Render the open-board section injected into the assistant context. Kept separate so the wording
 /// (which the model relies on to route board questions to `flowpilot_board`) lives in one place.
 pub fn open_board_section(board: &GlobalOpenBoardContext) -> String {
@@ -451,7 +347,7 @@ pub fn attachments_section(entries: &[AttachmentManifestEntry]) -> String {
     }
     let mut lines = vec![
         "## FILES ATTACHED THIS TURN".to_string(),
-        "The user attached these files to THIS message. You can read image files directly; other files you cannot open yourself. You CAN hand any of them to an app you call: pass their exact names in the `forward_files` argument of `call_app_chat`. Do NOT forward everything by default — choose the files whose type/content fits the app you are calling, but when you are unsure whether a file is relevant, include it rather than dropping it.".to_string(),
+        "These files belong to this message. You may inspect images directly. To hand files to an app chat, set `forward_files` to the exact relevant names, or `[]` for none; never forward unrelated files.".to_string(),
     ];
     for entry in entries {
         let name = entry
@@ -484,6 +380,14 @@ pub fn attachments_section(entries: &[AttachmentManifestEntry]) -> String {
 pub fn build_platform_context(input: PlatformContextInput) -> String {
     let mut parts: Vec<String> = Vec::new();
 
+    // Keep changing request metadata out of the stable base prompt so providers can reuse its
+    // cached prefix. Keep the exact timestamp dynamic so relative scheduling requests remain
+    // resolvable; a user-supplied timezone or explicit timestamp remains authoritative.
+    parts.push(format!(
+        "Current UTC timestamp: {}.",
+        chrono::Utc::now().to_rfc3339()
+    ));
+
     if let Some(user) = input.user_context.map(str::trim).filter(|v| !v.is_empty()) {
         parts.push(format!("Signed-in user: {user}."));
     }
@@ -513,12 +417,10 @@ pub fn build_platform_context(input: PlatformContextInput) -> String {
     }
 
     let mut sections: Vec<String> = Vec::new();
-    if !parts.is_empty() {
-        sections.push(format!(
-            "## CURRENT FLOW-LIKE CONTEXT\n{}",
-            parts.join("\n")
-        ));
-    }
+    sections.push(format!(
+        "## CURRENT TIME AND FLOW-LIKE CONTEXT\n{}",
+        parts.join("\n")
+    ));
     if let Some(board) = input.open_board {
         let section = open_board_section(board);
         if !section.is_empty() {
@@ -559,8 +461,8 @@ pub async fn run_platform_chat<F>(
 where
     F: Fn(String) + Send + Sync + 'static,
 {
-    // This wrapper always drives the rig/Bits loop, which advertises the public-web tools directly
-    // instead of the `research_agent` specialist it cannot start.
+    // This wrapper always drives the rig/Bits loop, whose host executes the sealed researcher
+    // locally instead of delegating it through a frontend-managed specialist scope.
     let base_prompt = global_assistant_system_prompt_for(WebResearchCapability::Inline);
     let system_prompt = if context.trim().is_empty() {
         base_prompt
@@ -587,201 +489,159 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// Every rewrite must still find its anchor. Without this, editing a web-research sentence in
-    /// the shared prompt would silently leave the inline backend telling itself to delegate to a
-    /// specialist it cannot start.
-    #[test]
-    fn inline_web_rewrites_all_apply() {
-        let delegated = global_assistant_system_prompt();
-        for (anchor, replacement) in INLINE_WEB_RESEARCH_REWRITES {
-            assert!(
-                delegated.contains(anchor),
-                "orphaned inline-web rewrite anchor: {anchor}"
-            );
-            assert!(
-                !delegated.contains(replacement),
-                "inline replacement leaked into the delegated prompt: {replacement}"
-            );
-        }
-    }
+    use crate::flow::copilot::tool_spec::global_assistant_tool_specs;
 
     #[test]
-    fn inline_prompt_never_mentions_the_research_specialist() {
+    fn prompt_selects_one_explicit_web_capability() {
+        let delegated = global_assistant_system_prompt_for(WebResearchCapability::Delegated);
         let inline = global_assistant_system_prompt_for(WebResearchCapability::Inline);
-        assert!(!inline.contains("research_agent"));
-        assert!(!inline.contains("Five specialists"));
-        assert!(inline.contains("Four specialists are hard capability boundaries"));
-        assert!(inline.contains("You HOLD the public-web tools yourself"));
-        assert!(inline.contains("`internet_search`, `open_url` and `archive_lookup`"));
-        // The privacy ordering rule survives the rewrite: it constrains the inline tools too.
-        assert!(inline.contains("RESEARCH BEFORE PRIVATE DATA"));
-    }
 
-    #[test]
-    fn delegated_prompt_keeps_the_research_specialist() {
-        let delegated = global_assistant_system_prompt();
-        assert!(delegated.contains("You have NO public-web tools"));
+        assert!(delegated.contains("## SEALED PUBLIC-WEB FALLBACK"));
         assert!(delegated.contains("`research_agent`"));
+        assert!(!delegated.contains("`internet_search`"));
+        assert!(inline.contains("## PUBLIC-WEB FALLBACK"));
+        assert!(inline.contains("`research_agent`"));
+        assert!(inline.contains("isolated public-only context"));
+        assert!(!inline.contains("`internet_search`"));
     }
 
     #[test]
-    fn scheduled_app_recipe_separates_simple_entry_from_cron_setup() {
+    fn task_routing_is_direct_by_default_and_gates_complex_solve() {
         let prompt = global_assistant_system_prompt();
-        assert!(prompt.contains("eventsSimple() entry workflow"));
-        assert!(prompt.contains("event_type: \"cron\""));
-        assert!(prompt.contains("Cron is Event setup on a Simple Event"));
-        assert!(prompt.contains("eventsGeneric(payload: Struct, fieldName: string, ...)"));
-        assert!(prompt.contains("eventsChat(...)"));
-        assert!(prompt.contains("always persisted with event_type `page`"));
-        assert!(prompt.contains("never pass node_id"));
-        assert!(prompt.contains("optional page-owner metadata"));
-        assert!(prompt.contains("only in a separate, later assistant turn"));
-        assert!(prompt.contains("Never put `flowpilot_board` and workflow `upsert_event`"));
-        assert!(prompt.contains("may return SEVERAL `event_nodes`"));
-        assert!(prompt.contains("call `execute_node` with the exact persisted entry node"));
-        assert!(prompt.contains("call `query_execution_logs` with the returned run_id"));
-        assert!(prompt.contains("never claim runtime correctness"));
-        assert!(prompt.contains("Never overlap mutations of the SAME board"));
-        assert!(prompt.contains("A smaller queued board is not success"));
-        // A stub the user is never told about is worse than a failed build: they believe the
-        // workflow is finished.
-        assert!(prompt.contains("`manual_steps`"));
-        assert!(prompt.contains("That is a PARTIAL SUCCESS, not a failure"));
-        assert!(prompt.contains("they need to fill in that logic"));
-        assert!(prompt.contains("delegated board specialist owns FlowScript"));
-        assert!(prompt.contains("retained_flowscript"));
-        assert!(prompt.contains("active recovery workspace"));
-        assert!(prompt.contains("minimal diagnostic"));
-        assert!(prompt.contains("your own debugging idea is not user authorization"));
-        assert!(prompt.contains("UNKNOWN"));
-        assert!(prompt.contains("source/check/commit counters all zero"));
-        assert!(prompt.contains("Retry such a result at most once"));
-        assert!(prompt.contains("Merely rewording or shortening"));
-        assert!(prompt.contains("never launch a third equivalent"));
-        assert!(prompt.contains("returned `app_id` is the build target"));
-        assert!(prompt.contains("similarly named apps"));
-        assert!(
-            !prompt.contains("Create a cron-triggered workflow"),
-            "the nested board agent must never be asked to search for a cron node"
-        );
+
+        let discovery = prompt.find("begin with `list_apps`").unwrap();
+        let fallback = prompt.find("## SEALED PUBLIC-WEB FALLBACK").unwrap();
+        assert!(discovery < fallback);
+        assert!(prompt.contains("Local apps are the first choice"));
+        assert!(prompt.contains("including installed research/search apps"));
+        assert!(prompt.contains("no suitable app/interface"));
+        assert!(prompt.contains("local research candidates were tried in best-fit order"));
+        assert!(prompt.contains("no useful, nonredundant candidate remained"));
+        assert!(prompt.contains("A declined local call is a stop"));
+        assert!(prompt.contains("extract only safe public factual subquestions"));
+        assert!(prompt.contains("Default to DIRECT"));
+        assert!(prompt.contains("ordinary one-call, one-app, or simple two-app task"));
+        assert!(prompt.contains("at least three distinct apps/interfaces"));
+        assert!(prompt.contains(
+            "A long prompt, calling `list_apps`, or two independent calls is not by itself complex"
+        ));
+        assert!(prompt.contains("When COMPLEX SOLVE is active"));
+        assert!(prompt.contains("private dependency plan"));
+        assert!(prompt.contains("all independent ready steps in the same wave"));
+        assert!(prompt.contains("pass its Event `id` as `event_id`"));
+        assert!(prompt.contains("never substitute its `page_id`"));
+        assert!(prompt.contains("structured result supersedes earlier inventory"));
+        assert!(prompt.contains("Refresh `list_apps` at most once"));
+        assert!(prompt.contains("never a substitute for embedding a page"));
+        assert!(prompt.contains("material failures or evidence gaps"));
+        assert!(prompt.contains("Never claim completion until a terminal tool result proves it"));
+        assert!(prompt.contains("never repeat a successful mutation"));
     }
 
     #[test]
-    fn app_content_questions_require_page_capture_inspection() {
-        let prompt = global_assistant_system_prompt();
-        assert!(prompt.contains("INFORMATION SHOWN IN an app"));
-        assert!(prompt.contains("Read those image attachments"));
-        assert!(prompt.contains("screenshot_count"));
-        assert!(prompt.contains("Do this only for kind \"page\" events"));
-        assert!(prompt.contains("use `call_app_chat` and interpret its textual result"));
+    fn solve_keeps_public_fallback_separate_from_private_context() {
+        let delegated = global_assistant_system_prompt();
+        let inline = global_assistant_system_prompt_for(WebResearchCapability::Inline);
+
+        assert!(delegated.contains("immutable user request"));
+        assert!(delegated.contains("not root history or model-authored app/private context"));
+        assert!(inline.contains("bound to the immutable user request"));
+        assert!(inline.contains("cannot receive root history"));
     }
 
     #[test]
-    fn global_assistant_owns_the_prior_art_policy_and_plan_execution_rules() {
+    fn specialist_boundaries_and_build_recovery_survive_compaction() {
         let prompt = global_assistant_system_prompt();
-        assert_eq!(prompt.matches(PRIOR_ART_GUIDANCE.trim()).count(), 1);
 
-        // The scout is a fourth capability boundary, not an extra orchestrator tool.
-        assert!(prompt.contains("Five specialists are hard capability boundaries"));
-        assert!(prompt.contains("→ `project_scout`"));
-
-        // Executing a composite plan: retarget board refs through the fork's id
-        // map, or every part addresses a board id that no longer exists.
-        assert!(prompt.contains("returns a `board_id_map`"));
-        assert!(prompt.contains("never send a source board id to a forked app"));
-        assert!(prompt.contains("DISJOINT `focus`"));
-        assert!(prompt.contains("parts on the SAME board must be sequenced"));
-
-        // The "configure" half of the feature must not be dropped silently.
-        assert!(prompt.contains("leaves a half-configured app"));
-
-        // Paid apps must never be bought on the user's behalf.
-        assert!(prompt.contains("return a checkout link you must show rather than pay"));
+        for tool in [
+            "flowpilot_board",
+            "flowpilot_widget",
+            "data_studio_agent",
+            "project_scout",
+        ] {
+            assert!(prompt.contains(&format!("`{tool}`")));
+        }
+        assert!(prompt.contains("UI scaffolding is not workflow logic"));
+        assert!(prompt.contains("full workflow acceptance contract"));
+        assert!(prompt.contains("retained candidate/draft"));
+        assert!(prompt.contains("exact draft ID/revision"));
+        assert!(prompt.contains("`FLOWSCRIPT_BASE_REVISION_CONFLICT`"));
+        assert!(prompt.contains("at most one retry"));
+        assert!(prompt.contains("Never launch a third equivalent attempt"));
+        assert!(prompt.contains("`segments_remaining` means continue"));
+        assert!(prompt.contains("`manual_steps` or stubs mean partial completion"));
+        assert!(prompt.contains("only a later assistant round may call `upsert_event`"));
+        assert!(prompt.contains("create/update every requested Event separately"));
+        assert!(prompt.contains("send that evidence to `flowpilot_board`"));
+        assert!(prompt.contains("Structural success is not runtime proof"));
     }
 
     #[test]
-    fn global_assistant_delegates_web_research_instead_of_browsing_itself() {
+    fn build_plan_keeps_identity_and_wavefront_invariants() {
         let prompt = global_assistant_system_prompt();
 
-        // The orchestrator no longer OWNS the web policy — the Research specialist
-        // does. Keeping a copy here would advertise tools it does not have.
+        assert!(prompt.contains("returned `board_id_map`"));
+        assert!(prompt.contains("never send a source board ID to the fork"));
+        assert!(prompt.contains("pin the returned destination `app_id`"));
+        assert!(prompt.contains("one shared contract"));
+        assert!(prompt.contains("`create_new_board=true`"));
+        assert!(prompt.contains("run independent specialists together"));
+        assert!(prompt.contains("Route each scout part by `source.kind`"));
+        assert!(prompt.contains("Pass its `locator` unchanged"));
+        assert!(prompt.contains("`timestamp:ms:UTC`"));
+        assert!(prompt.contains("FlowScript `Date`"));
+        assert!(prompt.contains("checkout link"));
+    }
+
+    #[test]
+    fn prompt_referenced_tools_exist_for_each_backend() {
+        let shared: std::collections::HashSet<_> = global_assistant_tool_specs(false)
+            .into_iter()
+            .map(|spec| spec.name)
+            .collect();
+        for name in [
+            "list_apps",
+            "call_app_chat",
+            "flowpilot_board",
+            "flowpilot_widget",
+            "data_studio_agent",
+            "project_scout",
+            "fork_app",
+            "acquire_app",
+            "create_app",
+            "upsert_event",
+        ] {
+            assert!(shared.contains(name), "missing shared tool {name}");
+        }
+        assert!(shared.contains("research_agent"));
+    }
+
+    #[test]
+    fn standard_prompt_is_stable_and_within_size_budget() {
+        let first = global_assistant_system_prompt();
+        let second = global_assistant_system_prompt();
+
         assert_eq!(
-            prompt
-                .matches(crate::copilot::prompts::WEB_RESEARCH_GUIDANCE.trim())
-                .count(),
-            0,
-            "the web-research policy belongs to the Research specialist"
+            first, second,
+            "runtime context must not mutate the stable prompt"
         );
-        assert!(prompt.contains("You have NO public-web tools"));
-        assert!(prompt.contains("goes to `research_agent`"));
-        assert!(prompt.contains("Never claim you cannot look something up"));
-
-        // Citations pass through untouched, caveats included.
-        assert!(prompt.contains("Relay the researcher's citations EXACTLY as returned"));
-        assert!(prompt.contains("what I could not establish"));
-
-        // The injection boundary must survive delegation, and ordering is how.
-        assert!(prompt.contains("RESEARCH BEFORE PRIVATE DATA"));
-        assert!(prompt.contains("delegating does not reopen it"));
         assert!(
-            prompt.contains("Never put private app data, secrets, file contents or credentials")
+            first.len() <= 12_000,
+            "standard prompt grew beyond the reviewed 12 KB budget: {} bytes",
+            first.len()
         );
-
-        assert!(prompt.contains("## CURRENT DATE AND TIME"));
-        assert!(prompt.contains(&chrono::Utc::now().format("%Y-%m-%d").to_string()));
         assert!(
-            prompt.contains("refers to an APP in the user's current profile, NOT the public web")
+            first.split_whitespace().count() <= 1_800,
+            "standard prompt grew beyond the reviewed word budget"
         );
-        assert!(prompt.contains("`data_studio_agent` never searches the web or opens public URLs"));
     }
 
     #[test]
-    fn specialist_routing_requires_board_expert_for_workflow_builds() {
-        let prompt = global_assistant_system_prompt();
-        assert!(prompt.contains("Five specialists are hard capability boundaries"));
-        assert!(prompt.contains("workflow deliverable is incomplete"));
-        assert!(prompt.contains("`flowpilot_board` mode=\"edit\" succeeds"));
-        assert!(prompt.contains("scaffold contains no workflow logic"));
-        assert!(prompt.contains("NEVER counts as the board being built"));
-        assert!(prompt.contains("cannot author, validate, return, or apply FlowScript"));
-        assert!(prompt.contains("you must call `flowpilot_board`"));
-        assert!(prompt.contains("never claim completion from the widget result alone"));
-        assert!(
-            prompt.contains(
-                "never put FlowScript or node/event construction in the widget instruction"
-            )
-        );
-        assert!(prompt.contains("pass those names via `widget_name` or `widget_names`"));
-        // The build contract is what lets the UI, data and workflow specialists run at the same
-        // time: the ids the board points at are chosen by the orchestrator, not returned by the
-        // widget build. Losing this wording silently reverts app builds to sequential.
-        assert!(prompt.contains("DECLARE THE CONTRACT, THEN BUILD IN PARALLEL"));
-        assert!(prompt.contains("That set is the BUILD CONTRACT"));
-        assert!(prompt.contains("in ONE turn emit `flowpilot_widget`"));
-        assert!(prompt.contains("mode=\"create\""));
-        assert!(prompt.contains("exact owning `board_id`"));
-        assert!(prompt.contains("create_new_board=true"));
-        assert!(prompt.contains("generation\n  runs concurrently"));
-        assert!(prompt.contains("serializes catalog/page persistence"));
-        assert!(prompt.contains("fall back to the\n  old order: widget first, then board"));
-    }
-
-    #[test]
-    fn app_builds_normalize_human_table_labels_without_stopping() {
-        let prompt = global_assistant_system_prompt();
-        assert!(prompt.contains("normalizes such labels to stable snake_case"));
-        assert!(prompt.contains("use the returned physical name in the board instruction"));
-        assert!(prompt.contains("Never stop the whole build"));
-        assert!(prompt.contains("never spend a second data-specialist call"));
-    }
-
-    #[test]
-    fn app_build_contract_pairs_temporal_columns_with_board_dates() {
-        let prompt = global_assistant_system_prompt();
-        assert!(prompt.contains("TEMPORAL BUILD CONTRACT"));
-        assert!(prompt.contains("exact\n  Lance field type `timestamp:ms:UTC`"));
-        assert!(prompt.contains("FlowLike `Date` in FlowScript interfaces"));
-        assert!(prompt.contains("Existing table\n  schemas remain authoritative"));
+    fn platform_context_carries_the_current_date_outside_the_stable_prompt() {
+        let context = build_platform_context(PlatformContextInput::default());
+        assert!(context.contains("## CURRENT TIME"));
+        assert!(context.contains("Current UTC timestamp:"));
+        assert!(context.contains(&chrono::Utc::now().format("%Y-%m-%d").to_string()));
+        assert!(!global_assistant_system_prompt().contains("## CURRENT TIME"));
     }
 }

--- a/packages/core/src/flow/copilot/context.rs
+++ b/packages/core/src/flow/copilot/context.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::flow::board::Board;
+use crate::flow::board::{Board, LayerType};
 use crate::flow::node::Node;
 use crate::flow::pin::PinType;
 use flow_like_types::Result;
@@ -48,12 +48,32 @@ pub struct EdgeContext {
     pub to_pin_name: String,
 }
 
+/// Result-cache settings attached to a Function layer.
+///
+/// The persisted board calls the grouping value a `prefix`; FlowScript and FlowPilot expose the
+/// behavior-oriented name `namespace`, matching the cache invalidation surface users interact
+/// with. Keeping this as a small, owned context type avoids leaking board serialization details
+/// into the provider-neutral manifest.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LayerCacheContext {
+    pub enabled: bool,
+    pub namespace: String,
+    /// `None` means permanent on persisted boards. When re-authoring it, FlowPilot must use
+    /// explicit zero because omission on a new cache object now defaults to 300 seconds.
+    pub ttl_seconds: Option<u64>,
+    /// `app` for a shared result or `user` for a result private to the triggering user.
+    pub scope: String,
+}
+
 /// Compact layer representation for context
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LayerContext {
     pub id: String,
     #[serde(rename = "n")] // "name" abbreviated
     pub name: String,
+    /// Layer kind (`Function`, `Macro`, or `Collapsed`). Kept compact in provider context.
+    #[serde(rename = "t", default)]
+    pub layer_type: String,
     /// Parent layer ID if nested, None if at root
     #[serde(rename = "p", skip_serializing_if = "Option::is_none")]
     pub parent_id: Option<String>,
@@ -68,6 +88,9 @@ pub struct LayerContext {
     /// Output pins (for connecting FROM this layer)
     #[serde(rename = "o", skip_serializing_if = "Vec::is_empty")]
     pub outputs: Vec<PinContext>,
+    /// Function result-cache settings. `None` means the function is not cache-configured.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache: Option<LayerCacheContext>,
 }
 
 /// Compact variable representation for context
@@ -244,11 +267,23 @@ pub fn prepare_context(board: &Board, selected_node_ids: &[String]) -> Result<Gr
             LayerContext {
                 id: layer.id.clone(),
                 name: layer.name.clone(),
+                layer_type: match &layer.r#type {
+                    LayerType::Function => "Function",
+                    LayerType::Macro => "Macro",
+                    LayerType::Collapsed => "Collapsed",
+                }
+                .to_string(),
                 parent_id: layer.parent_id.clone(),
                 node_ids: layer.nodes.keys().cloned().collect(),
                 position: (x, y),
                 inputs,
                 outputs,
+                cache: layer.cache.as_ref().map(|cache| LayerCacheContext {
+                    enabled: cache.enabled,
+                    namespace: cache.prefix.clone(),
+                    ttl_seconds: cache.ttl_seconds,
+                    scope: cache.scope.as_str().to_string(),
+                }),
             }
         })
         .collect();
@@ -281,4 +316,92 @@ pub fn prepare_context(board: &Board, selected_node_ids: &[String]) -> Result<Gr
         variables: variable_contexts,
         selected_nodes: selected_node_ids.to_vec(),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::flow::board::{Layer, LayerCache, LayerCacheScope, LayerType};
+    use flow_like_storage::Path;
+
+    #[test]
+    fn default_function_cache_is_exposed_in_graph_context_with_flowscript_names() {
+        let mut board = Board::new_detached(Some("cache-context".to_string()), Path::default());
+        let mut layer = Layer::new(
+            "pricing-layer".to_string(),
+            "calculatePricing".to_string(),
+            LayerType::Function,
+        );
+        layer.cache = Some(LayerCache {
+            enabled: true,
+            prefix: "global".to_string(),
+            ttl_seconds: Some(300),
+            scope: LayerCacheScope::App,
+        });
+        board.layers.insert(layer.id.clone(), layer);
+
+        let context = prepare_context(&board, &[]).expect("graph context");
+        assert_eq!(context.layers[0].layer_type, "Function");
+        let cache = context.layers[0]
+            .cache
+            .as_ref()
+            .expect("function cache context");
+        assert!(cache.enabled);
+        assert_eq!(cache.namespace, "global");
+        assert_eq!(cache.ttl_seconds, Some(300));
+        assert_eq!(cache.scope, "app");
+
+        let json = serde_json::to_value(&context).expect("serialized graph context");
+        assert_eq!(json["layers"][0]["cache"]["namespace"], "global");
+        assert_eq!(json["layers"][0]["cache"]["ttl_seconds"], 300);
+        assert_eq!(json["layers"][0]["cache"]["scope"], "app");
+    }
+
+    #[test]
+    fn disabled_function_cache_settings_remain_visible_to_flowpilot() {
+        let mut board = Board::new_detached(Some("cache-context".to_string()), Path::default());
+        let mut layer = Layer::new(
+            "pricing-layer".to_string(),
+            "calculatePricing".to_string(),
+            LayerType::Function,
+        );
+        layer.cache = Some(LayerCache {
+            enabled: false,
+            prefix: "remembered-pricing".to_string(),
+            ttl_seconds: Some(0),
+            scope: LayerCacheScope::User,
+        });
+        board.layers.insert(layer.id.clone(), layer);
+
+        let context = prepare_context(&board, &[]).expect("graph context");
+        let cache = context.layers[0]
+            .cache
+            .as_ref()
+            .expect("disabled settings should remain inspectable");
+        assert!(!cache.enabled);
+        assert_eq!(cache.namespace, "remembered-pricing");
+        assert_eq!(cache.ttl_seconds, Some(0));
+        assert_eq!(cache.scope, "user");
+    }
+
+    #[test]
+    fn permanent_cache_exposes_null_ttl_to_flowpilot() {
+        let mut board = Board::new_detached(Some("cache-context".to_string()), Path::default());
+        let mut layer = Layer::new(
+            "legacy-cache".to_string(),
+            "legacyCached".to_string(),
+            LayerType::Function,
+        );
+        layer.cache = Some(LayerCache {
+            enabled: true,
+            prefix: "global".to_string(),
+            ttl_seconds: None,
+            scope: LayerCacheScope::App,
+        });
+        board.layers.insert(layer.id.clone(), layer);
+
+        let context = prepare_context(&board, &[]).expect("graph context");
+        let json = serde_json::to_value(&context).expect("serialized graph context");
+        assert!(json["layers"][0]["cache"]["ttl_seconds"].is_null());
+    }
 }

--- a/packages/core/src/flow/copilot/executability.rs
+++ b/packages/core/src/flow/copilot/executability.rs
@@ -931,6 +931,7 @@ fn project_graph(
             | BoardCommand::CreateLayer { .. }
             | BoardCommand::CreateVariable { .. }
             | BoardCommand::MoveNode { .. }
+            | BoardCommand::UpdateLayerCache { .. }
             | BoardCommand::SetNodeFunctionRefs { .. }
             | BoardCommand::AddComment { .. }
             | BoardCommand::RemoveComment { .. } => {}
@@ -1904,6 +1905,7 @@ mod tests {
             position: None,
             color: None,
             target_layer: None,
+            cache: None,
             summary: None,
         };
         let mut commands = vec![
@@ -1957,6 +1959,7 @@ mod tests {
             position: None,
             color: None,
             target_layer: None,
+            cache: None,
             summary: None,
         }
     }

--- a/packages/core/src/flow/copilot/ir.rs
+++ b/packages/core/src/flow/copilot/ir.rs
@@ -9,8 +9,9 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 use flow_like_ast::model::{
-    Arg, Block, BoardAst, BranchArm, Call, Container, EventBlock, Expr, FnDecl, InterfaceDecl,
-    Literal, ObjectField, Param, Stmt, TypeRef, VarDecl,
+    Arg, Block, BoardAst, BranchArm, Call, Container, DEFAULT_FUNCTION_CACHE_NAMESPACE,
+    DEFAULT_FUNCTION_CACHE_TTL_SECONDS, EventBlock, Expr, FnDecl, FunctionCache,
+    FunctionCacheScope, InterfaceDecl, Literal, ObjectField, Param, Stmt, TypeRef, VarDecl,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -117,6 +118,50 @@ pub struct FlowIrParam {
     pub value_type: FlowIrType,
 }
 
+/// Result-cache settings for a typed FlowPilot function module.
+///
+/// The cache key includes the function layer and all function inputs. A hit skips the complete
+/// function body, including side effects, so this is only safe for input-determined functions.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct FlowIrFunctionCache {
+    /// Namespace used to group entries for targeted invalidation. Defaults to `global`.
+    #[serde(default = "default_flow_ir_function_cache_namespace")]
+    pub namespace: String,
+    /// Entry lifetime in seconds. Omission defaults to 300; zero (and legacy `null`) is permanent.
+    #[serde(default = "default_flow_ir_function_cache_ttl_seconds")]
+    pub ttl_seconds: Option<u64>,
+    /// Whether cached results are shared by the app or isolated to the triggering user.
+    #[serde(default)]
+    pub scope: FlowIrFunctionCacheScope,
+}
+
+fn default_flow_ir_function_cache_namespace() -> String {
+    DEFAULT_FUNCTION_CACHE_NAMESPACE.to_string()
+}
+
+fn default_flow_ir_function_cache_ttl_seconds() -> Option<u64> {
+    Some(DEFAULT_FUNCTION_CACHE_TTL_SECONDS)
+}
+
+impl Default for FlowIrFunctionCache {
+    fn default() -> Self {
+        Self {
+            namespace: default_flow_ir_function_cache_namespace(),
+            ttl_seconds: default_flow_ir_function_cache_ttl_seconds(),
+            scope: FlowIrFunctionCacheScope::App,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum FlowIrFunctionCacheScope {
+    #[default]
+    App,
+    User,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 #[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
 pub enum FlowIrModule {
@@ -126,6 +171,10 @@ pub enum FlowIrModule {
         params: Vec<FlowIrParam>,
         #[serde(default)]
         returns: Vec<FlowIrParam>,
+        /// Optional result-cache configuration. Omit it to leave the function uncached. A cache
+        /// hit skips the entire body and all side effects.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cache: Option<FlowIrFunctionCache>,
         #[serde(default)]
         steps: Vec<FlowIrStep>,
         #[serde(default)]
@@ -1273,6 +1322,7 @@ pub fn compile_flow_ir(program: &FlowIrProgram, catalog: &[NodeMetadata]) -> Flo
                 name,
                 params,
                 returns,
+                cache,
                 anchor,
                 ..
             } => ast.functions.push(FnDecl {
@@ -1280,6 +1330,14 @@ pub fn compile_flow_ir(program: &FlowIrProgram, catalog: &[NodeMetadata]) -> Flo
                 params: params.iter().map(param_to_ast).collect(),
                 returns: returns.iter().map(param_to_ast).collect(),
                 body: block,
+                cache: cache.as_ref().map(|cache| FunctionCache {
+                    namespace: cache.namespace.clone(),
+                    ttl_seconds: cache.ttl_seconds,
+                    scope: match cache.scope {
+                        FlowIrFunctionCacheScope::App => FunctionCacheScope::App,
+                        FlowIrFunctionCacheScope::User => FunctionCacheScope::User,
+                    },
+                }),
                 anchor: anchor.clone(),
             }),
             FlowIrModule::Event {
@@ -4827,6 +4885,119 @@ mod tests {
     }
 
     #[test]
+    fn typed_ir_function_cache_compiles_to_flowscript_without_losing_settings() {
+        let module = FlowIrModule::Function {
+            name: "calculatePricing".to_string(),
+            params: Vec::new(),
+            returns: Vec::new(),
+            cache: Some(FlowIrFunctionCache {
+                namespace: "pricing".to_string(),
+                ttl_seconds: Some(3_600),
+                scope: FlowIrFunctionCacheScope::User,
+            }),
+            steps: Vec::new(),
+            anchor: None,
+        };
+        let serialized = serde_json::to_value(&module).expect("serialize function module");
+        assert_eq!(serialized["cache"]["namespace"], "pricing");
+        assert_eq!(serialized["cache"]["ttl_seconds"], 3_600);
+        assert_eq!(serialized["cache"]["scope"], "user");
+
+        let compiled = compile_flow_ir(
+            &FlowIrProgram {
+                modules: vec![module],
+                ..Default::default()
+            },
+            &[],
+        );
+        assert!(
+            compiled.diagnostics.is_empty(),
+            "{:?}",
+            compiled.diagnostics
+        );
+        let cache = compiled.ast.as_ref().unwrap().functions[0]
+            .cache
+            .as_ref()
+            .expect("compiled function cache");
+        assert_eq!(cache.namespace, "pricing");
+        assert_eq!(cache.ttl_seconds, Some(3_600));
+        assert_eq!(cache.scope, FunctionCacheScope::User);
+        assert!(
+            compiled
+                .flowscript
+                .contains(r#"@cache({ namespace: "pricing", ttlSeconds: 3600, scope: "user" })"#)
+        );
+        assert!(flow_like_ast::parse(&compiled.flowscript).is_ok());
+    }
+
+    #[test]
+    fn typed_ir_function_cache_defaults_and_explicit_permanent_ttl_are_unambiguous() {
+        let default_module: FlowIrModule = serde_json::from_value(serde_json::json!({
+            "kind": "function",
+            "name": "defaultCached",
+            "cache": {}
+        }))
+        .expect("empty cache object uses the typed IR defaults");
+        let FlowIrModule::Function {
+            cache: Some(default_cache),
+            ..
+        } = &default_module
+        else {
+            panic!("expected a cached function")
+        };
+        assert_eq!(default_cache, &FlowIrFunctionCache::default());
+        assert_eq!(default_cache.namespace, "global");
+        assert_eq!(default_cache.ttl_seconds, Some(300));
+        assert_eq!(default_cache.scope, FlowIrFunctionCacheScope::App);
+
+        let permanent_module: FlowIrModule = serde_json::from_value(serde_json::json!({
+            "kind": "function",
+            "name": "permanentCached",
+            "cache": { "ttl_seconds": 0 }
+        }))
+        .expect("zero is the explicit permanent-cache lifetime");
+        let compiled = compile_flow_ir(
+            &FlowIrProgram {
+                modules: vec![permanent_module],
+                ..Default::default()
+            },
+            &[],
+        );
+        assert!(
+            compiled.diagnostics.is_empty(),
+            "{:?}",
+            compiled.diagnostics
+        );
+        let cache = compiled.ast.as_ref().unwrap().functions[0]
+            .cache
+            .as_ref()
+            .expect("compiled cache metadata");
+        assert_eq!(cache.namespace, "global");
+        assert_eq!(cache.ttl_seconds, Some(0));
+        assert_eq!(cache.scope, FunctionCacheScope::App);
+
+        let legacy_permanent_module: FlowIrModule = serde_json::from_value(serde_json::json!({
+            "kind": "function",
+            "name": "legacyPermanentCached",
+            "cache": { "ttl_seconds": null }
+        }))
+        .expect("legacy null cache lifetime remains accepted as permanent");
+        let compiled = compile_flow_ir(
+            &FlowIrProgram {
+                modules: vec![legacy_permanent_module],
+                ..Default::default()
+            },
+            &[],
+        );
+        assert!(
+            compiled.diagnostics.is_empty(),
+            "{:?}",
+            compiled.diagnostics
+        );
+        assert!(compiled.flowscript.contains("@cache({ ttlSeconds: 0 })"));
+    }
+
+    #[test]
     fn typed_ir_rejects_generic_to_string_without_conversion() {
         let catalog = vec![
             node(
@@ -4863,6 +5034,7 @@ mod tests {
                 name: "classify".to_string(),
                 params: Vec::new(),
                 returns: Vec::new(),
+                cache: None,
                 steps: vec![
                     FlowIrStep::Node {
                         id: "sender".to_string(),
@@ -4938,6 +5110,7 @@ mod tests {
                 name: "writeValues".to_string(),
                 params: Vec::new(),
                 returns: Vec::new(),
+                cache: None,
                 steps: vec![FlowIrStep::Node {
                     id: "sink".to_string(),
                     node_type: "typed_sink".to_string(),
@@ -4986,6 +5159,7 @@ mod tests {
                 name: "futureValue".to_string(),
                 params: Vec::new(),
                 returns: Vec::new(),
+                cache: None,
                 steps: vec![FlowIrStep::Node {
                     id: "sink".to_string(),
                     node_type: "future_sink".to_string(),
@@ -5025,6 +5199,7 @@ mod tests {
             name: "duplicates".to_string(),
             params: Vec::new(),
             returns: Vec::new(),
+            cache: None,
             steps: vec![FlowIrStep::Node {
                 id: "pair".to_string(),
                 node_type: "duplicate_inputs".to_string(),
@@ -5206,6 +5381,7 @@ mod tests {
                 name: "nestedRequest".to_string(),
                 params: Vec::new(),
                 returns: Vec::new(),
+                cache: None,
                 steps: vec![
                     FlowIrStep::If {
                         id: "enabled".to_string(),
@@ -5614,6 +5790,7 @@ mod tests {
             name: "notify".to_string(),
             params: Vec::new(),
             returns: Vec::new(),
+            cache: None,
             steps: vec![FlowIrStep::Node {
                 id: "slack".to_string(),
                 node_type: "slack_send".to_string(),
@@ -5700,6 +5877,7 @@ mod tests {
                         name: "value".to_string(),
                         value_type: FlowIrType::scalar(FlowIrDataType::String),
                     }],
+                    cache: None,
                     steps: Vec::new(),
                     anchor: None,
                 }],
@@ -5790,6 +5968,7 @@ mod tests {
                 name: "request".to_string(),
                 params: Vec::new(),
                 returns: Vec::new(),
+                cache: None,
                 steps: vec![
                     FlowIrStep::Node {
                         id: "request".to_string(),
@@ -5901,6 +6080,7 @@ mod tests {
                         name: "message".to_string(),
                         value_type: FlowIrType::scalar(FlowIrDataType::String),
                     }],
+                    cache: None,
                     steps: vec![
                         format_step.clone(),
                         FlowIrStep::Return {
@@ -6012,6 +6192,7 @@ mod tests {
             name: "doWork".to_string(),
             params: Vec::new(),
             returns: Vec::new(),
+            cache: None,
             steps: vec![FlowIrStep::Node {
                 id: "work".to_string(),
                 node_type: "impure_action".to_string(),
@@ -6083,6 +6264,7 @@ mod tests {
                 name: "request".to_string(),
                 params: Vec::new(),
                 returns: Vec::new(),
+                cache: None,
                 steps: vec![FlowIrStep::Node {
                     id: "multi".to_string(),
                     node_type: "multi_action".to_string(),
@@ -6117,6 +6299,7 @@ mod tests {
                 name: "duplicates".to_string(),
                 params: Vec::new(),
                 returns: Vec::new(),
+                cache: None,
                 steps: vec![step("one"), step("two")],
                 anchor: None,
             }],
@@ -6153,6 +6336,7 @@ mod tests {
                     value_type: FlowIrType::scalar(FlowIrDataType::String),
                 }],
                 returns: Vec::new(),
+                cache: None,
                 steps: vec![
                     FlowIrStep::Return { values: Vec::new() },
                     FlowIrStep::Node {

--- a/packages/core/src/flow/copilot/ir_tools.rs
+++ b/packages/core/src/flow/copilot/ir_tools.rs
@@ -13,8 +13,8 @@ use std::sync::Condvar;
 
 use flow_like_ast::model::{
     Arg as AstArg, Block as AstBlock, BoardAst, Call as AstCall, EventBlock as AstEventBlock,
-    Expr as AstExpr, FnDecl as AstFnDecl, Literal as AstLiteral, Param as AstParam,
-    Stmt as AstStmt,
+    Expr as AstExpr, FnDecl as AstFnDecl, FunctionCacheScope as AstFunctionCacheScope,
+    Literal as AstLiteral, Param as AstParam, Stmt as AstStmt,
 };
 use flow_like_types::create_id;
 use rig::{completion::ToolDefinition, tool::Tool};
@@ -24,12 +24,12 @@ use serde_json::json;
 
 use super::ir::{
     FlowCapabilityPlan, FlowCapabilityPlanRequest, FlowIrArg, FlowIrCompileResult, FlowIrContainer,
-    FlowIrDataType, FlowIrDiagnostic, FlowIrInterface, FlowIrLiteral, FlowIrModule,
-    FlowIrObjectField, FlowIrParam, FlowIrProgram, FlowIrStep, FlowIrType, FlowIrValue,
-    FlowIrVariable, FlowModuleKind, MAX_FLOW_IR_CAPABILITY_REQUIREMENTS,
-    MAX_FLOW_IR_PIN_REQUIREMENTS_PER_DIRECTION, ReachableFlowIrOccurrence, compile_flow_ir,
-    plan_flow_capabilities, reachable_flow_ir_occurrences, validate_flow_capability_usage,
-    validate_ir_resource_limits,
+    FlowIrDataType, FlowIrDiagnostic, FlowIrFunctionCache, FlowIrFunctionCacheScope,
+    FlowIrInterface, FlowIrLiteral, FlowIrModule, FlowIrObjectField, FlowIrParam, FlowIrProgram,
+    FlowIrStep, FlowIrType, FlowIrValue, FlowIrVariable, FlowModuleKind,
+    MAX_FLOW_IR_CAPABILITY_REQUIREMENTS, MAX_FLOW_IR_PIN_REQUIREMENTS_PER_DIRECTION,
+    ReachableFlowIrOccurrence, compile_flow_ir, plan_flow_capabilities,
+    reachable_flow_ir_occurrences, validate_flow_capability_usage, validate_ir_resource_limits,
 };
 use super::provider::{CatalogProvider, metadata_to_signature};
 use super::tools::{
@@ -173,6 +173,11 @@ pub fn typed_ir_schema_hint() -> serde_json::Value {
             "function": "helper",
             "args": []
         },
+        "function_cache": {
+            "namespace": "global",
+            "ttl_seconds": 300,
+            "scope": "app"
+        },
         "if_step": {
             "kind": "if",
             "id": "branch",
@@ -193,6 +198,7 @@ pub fn typed_ir_schema_hint() -> serde_json::Value {
             "use canonical type objects with boolean and integer",
             "references use kind=ref; function calls use kind=call_function",
             "if bodies use then_steps and else_steps",
+            "an empty function cache object defaults to namespace=global, ttl_seconds=300, scope=app; ttl_seconds=0 is permanent",
             "every required capability must select exact_node_type from a selection_required candidate before feasible can be true"
         ]
     })
@@ -4994,6 +5000,14 @@ impl<'a> FlowScriptAcceptanceProjection<'a> {
             name: function.name.clone(),
             params: project_ast_params(&function.params),
             returns: project_ast_params(&function.returns),
+            cache: function.cache.as_ref().map(|cache| FlowIrFunctionCache {
+                namespace: cache.namespace.clone(),
+                ttl_seconds: cache.ttl_seconds,
+                scope: match cache.scope {
+                    AstFunctionCacheScope::App => FlowIrFunctionCacheScope::App,
+                    AstFunctionCacheScope::User => FlowIrFunctionCacheScope::User,
+                },
+            }),
             steps,
             anchor: function.anchor.clone(),
         }
@@ -10407,7 +10421,7 @@ impl Tool for UpsertFlowIrModuleTool {
     async fn definition(&self, _prompt: String) -> ToolDefinition {
         ToolDefinition {
             name: Self::NAME.to_string(),
-            description: "Add or replace one typed function/Event module, compile the whole draft, and retain the previous revision if diagnostics worsen or executable scope shrinks without explicit user authorization."
+            description: "Add or replace one typed function/Event module, compile the whole draft, and retain the previous revision if diagnostics worsen or executable scope shrinks without explicit user authorization. Function modules accept an optional cache object; an empty object defaults to namespace `global`, ttl_seconds 300, and app scope, while ttl_seconds 0 is permanent. A cache hit skips the entire function body and its side effects, so cache only input-determined functions."
                 .to_string(),
             parameters: json_schema::<UpsertFlowIrModuleArgs>(),
         }
@@ -10625,6 +10639,41 @@ mod tests {
             payload["schema_hint"]["capability_selection"]["selected"]["exact_node_type"],
             "utils_hash_sha256"
         );
+    }
+
+    #[test]
+    fn typed_function_cache_is_exposed_by_the_upsert_schema() {
+        let schema = json_schema::<UpsertFlowIrModuleArgs>();
+        let schema = serde_json::to_string(&schema).expect("serialize upsert schema");
+        for field in ["cache", "namespace", "ttl_seconds", "scope"] {
+            assert!(schema.contains(field), "schema omits {field}: {schema}");
+        }
+        assert!(
+            schema.contains("global"),
+            "schema omits namespace default: {schema}"
+        );
+        assert!(schema.contains("300"), "schema omits TTL default: {schema}");
+    }
+
+    #[test]
+    fn flowscript_function_cache_projects_into_typed_ir() {
+        let ast = flow_like_ast::parse(
+            r#"@cache({ namespace: "pricing", ttlSeconds: 3600, scope: "user" })
+function calculatePricing() {
+}
+"#,
+        )
+        .expect("cached function source parses");
+        let projected = FlowScriptAcceptanceProjection::new(&ast, &[]).project(&ast);
+        let FlowIrModule::Function {
+            cache: Some(cache), ..
+        } = &projected.modules[0]
+        else {
+            panic!("expected projected cached function")
+        };
+        assert_eq!(cache.namespace, "pricing");
+        assert_eq!(cache.ttl_seconds, Some(3_600));
+        assert_eq!(cache.scope, FlowIrFunctionCacheScope::User);
     }
 
     fn pin(name: &str, data_type: &str) -> PinMetadata {
@@ -13289,6 +13338,7 @@ eventsSimple() {
             name: "notifySlack".to_string(),
             params: Vec::new(),
             returns: Vec::new(),
+            cache: None,
             steps: acceptance_program().modules[0].steps()[1..].to_vec(),
             anchor: None,
         };
@@ -14219,6 +14269,7 @@ eventsSimple() {
             name: "reviewLoop".to_string(),
             params: Vec::new(),
             returns: Vec::new(),
+            cache: None,
             steps: vec![
                 FlowIrStep::If {
                     id: "decision".to_string(),
@@ -14327,6 +14378,7 @@ eventsSimple() {
             name: "eventsSimple".to_string(),
             params: Vec::new(),
             returns: Vec::new(),
+            cache: None,
             steps: vec![FlowIrStep::Node {
                 id: "message".to_string(),
                 node_type: "string_format".to_string(),

--- a/packages/core/src/flow/copilot/manifest.rs
+++ b/packages/core/src/flow/copilot/manifest.rs
@@ -749,7 +749,7 @@ mod tests {
 
     use super::*;
     use crate::flow::copilot::{
-        EdgeContext, LayerContext, NodeContext, PinContext, VariableContext,
+        EdgeContext, LayerCacheContext, LayerContext, NodeContext, PinContext, VariableContext,
     };
 
     fn pin(name: &str) -> PinMetadata {
@@ -934,6 +934,48 @@ mod tests {
             build("Event a() {}\n").fingerprint,
             build("Event b() {}\n").fingerprint
         );
+    }
+
+    #[test]
+    fn function_cache_is_part_of_the_manifest_and_its_fingerprint() {
+        let build = |cache: Option<LayerCacheContext>| {
+            let mut graph = graph(false);
+            graph.layers.push(LayerContext {
+                id: "pricing-layer".to_string(),
+                name: "calculatePricing".to_string(),
+                layer_type: "Function".to_string(),
+                parent_id: None,
+                node_ids: vec![],
+                position: (0, 0),
+                inputs: vec![],
+                outputs: vec![],
+                cache,
+            });
+            BoardContextManifest::build(
+                board(graph),
+                &[],
+                ManifestSource::absent(),
+                audit(),
+                ManifestAugmentations::default(),
+                default_flowscript_module_templates(),
+            )
+            .expect("manifest")
+        };
+
+        let uncached = build(None);
+        let cached = build(Some(LayerCacheContext {
+            enabled: true,
+            namespace: "pricing".to_string(),
+            ttl_seconds: Some(3_600),
+            scope: "user".to_string(),
+        }));
+
+        assert_ne!(uncached.fingerprint, cached.fingerprint);
+        assert!(cached.verify_fingerprint().expect("verify fingerprint"));
+        let prompt = cached.render_prompt().expect("full manifest prompt");
+        assert!(prompt.contains("\"namespace\": \"pricing\""));
+        assert!(prompt.contains("\"ttl_seconds\": 3600"));
+        assert!(prompt.contains("\"scope\": \"user\""));
     }
 
     #[test]

--- a/packages/core/src/flow/copilot/memory.rs
+++ b/packages/core/src/flow/copilot/memory.rs
@@ -20,6 +20,19 @@ use flow_like_types::{Result, anyhow, bail, create_id};
 use crate::bit::Bit;
 use crate::state::FlowLikeState;
 
+const MAX_RECALLED_MEMORY_ITEM_CHARS: usize = 500;
+const MAX_RECALLED_MEMORY_PROMPT_CHARS: usize = 2_400;
+
+fn bounded_memory_text(value: &str, max_chars: usize) -> String {
+    let value = value.trim();
+    if value.chars().count() <= max_chars {
+        return value.to_string();
+    }
+    let mut bounded: String = value.chars().take(max_chars.saturating_sub(1)).collect();
+    bounded.push('…');
+    bounded
+}
+
 /// Snapshot of a profile's memory table: how many observations it holds and which embedding model
 /// they were written with (so the UI can warn before switching to an incompatible model).
 #[derive(Debug, Clone, flow_like_types::json::Serialize)]
@@ -258,8 +271,18 @@ impl AssistantMemory {
             && !recalled.is_empty()
         {
             sections.push_str("\n\n## RELEVANT MEMORY\nFacts you remembered that may help:\n");
+            let mut remaining = MAX_RECALLED_MEMORY_PROMPT_CHARS;
             for item in &recalled {
-                sections.push_str(&format!("- {item}\n"));
+                if remaining == 0 {
+                    break;
+                }
+                let bounded =
+                    bounded_memory_text(item, MAX_RECALLED_MEMORY_ITEM_CHARS.min(remaining));
+                if bounded.is_empty() {
+                    continue;
+                }
+                remaining = remaining.saturating_sub(bounded.chars().count());
+                sections.push_str(&format!("- {bounded}\n"));
             }
         }
         sections.push_str(
@@ -310,5 +333,18 @@ impl AssistantMemory {
                     .map(str::to_string)
             })
             .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recalled_memory_text_is_unicode_safe_and_bounded() {
+        assert_eq!(bounded_memory_text("  short fact  ", 20), "short fact");
+        let bounded = bounded_memory_text(&"🙂".repeat(20), 8);
+        assert_eq!(bounded.chars().count(), 8);
+        assert!(bounded.ends_with('…'));
     }
 }

--- a/packages/core/src/flow/copilot/mod.rs
+++ b/packages/core/src/flow/copilot/mod.rs
@@ -31,8 +31,8 @@ pub use assistant::{
     run_platform_chat,
 };
 pub use context::{
-    EdgeContext, GraphContext, LayerContext, NodeContext, PinContext, VariableContext,
-    prepare_context,
+    EdgeContext, GraphContext, LayerCacheContext, LayerContext, NodeContext, PinContext,
+    VariableContext, prepare_context,
 };
 pub use evaluation::{
     FLOWPILOT_GENERATION_EVALUATION_VERSION, FlowPilotDurationMetric, FlowPilotEvaluationRunStatus,
@@ -42,11 +42,11 @@ pub use evaluation::{
 pub use ir::{
     FLOW_IR_VERSION, FlowCapabilityCandidate, FlowCapabilityPlan, FlowCapabilityPlanRequest,
     FlowCapabilityRequirement, FlowCapabilityResolution, FlowIrArg, FlowIrCompileResult,
-    FlowIrContainer, FlowIrDataType, FlowIrDiagnostic, FlowIrExecutionArm, FlowIrInterface,
-    FlowIrInterfaceField, FlowIrLiteral, FlowIrModule, FlowIrObjectField, FlowIrParam,
-    FlowIrProgram, FlowIrStep, FlowIrType, FlowIrValue, FlowIrVariable, FlowModuleEstimate,
-    FlowModuleKind, FlowPinRequirement, compile_flow_ir, plan_flow_capabilities,
-    validate_flow_capability_usage,
+    FlowIrContainer, FlowIrDataType, FlowIrDiagnostic, FlowIrExecutionArm, FlowIrFunctionCache,
+    FlowIrFunctionCacheScope, FlowIrInterface, FlowIrInterfaceField, FlowIrLiteral, FlowIrModule,
+    FlowIrObjectField, FlowIrParam, FlowIrProgram, FlowIrStep, FlowIrType, FlowIrValue,
+    FlowIrVariable, FlowModuleEstimate, FlowModuleKind, FlowPinRequirement, compile_flow_ir,
+    plan_flow_capabilities, validate_flow_capability_usage,
 };
 pub use ir_tools::{
     BeginFlowIrDraftArgs, BeginFlowIrDraftTool, BoardScopePlan, BoundBeginFlowIrDraftTool,

--- a/packages/core/src/flow/copilot/platform.rs
+++ b/packages/core/src/flow/copilot/platform.rs
@@ -34,9 +34,8 @@ use url::Url;
 
 use super::memory::AssistantMemory;
 use super::public_web::{
-    MAX_ARCHIVE_CALLS_PER_SESSION, MAX_SEARCH_CALLS_PER_SESSION, OpenUrlSessionBudget,
-    WebResearchSession, normalize_public_discovery_url, run_archive_lookup_for_session,
-    run_open_url_for_session, source_id_for_url,
+    WebResearchSession, normalize_public_discovery_url, public_urls_in_user_text,
+    run_archive_lookup_for_session, run_open_url_for_session, source_id_for_url,
 };
 use super::stream::{
     FlowScriptToolCallPreviewTracker, detailed_tool_end_frame, detailed_tool_start_frame,
@@ -58,8 +57,6 @@ use crate::state::FlowLikeState;
 pub const PLATFORM_TOOL_IMAGE_URLS_FIELD: &str = "_flowpilot_image_urls";
 
 const MAX_PLATFORM_TOOL_ROUNDS: usize = 8;
-const MAX_SEARCH_CALLS_PER_ROUND: usize = 5;
-const MAX_ARCHIVE_CALLS_PER_ROUND: usize = 2;
 const MAX_SEARCH_QUERY_CHARS: usize = 512;
 const MAX_SEARCH_RESPONSE_BYTES: usize = 1024 * 1024;
 const MAX_SEARCH_TITLE_CHARS: usize = 300;
@@ -279,6 +276,12 @@ fn platform_tool_serialization_lane(name: &str, arguments: &Value) -> Option<Str
     // `data_studio_agent` in particular needs no approval and so reads as read-only to the effect
     // classifier, yet two data builds on one app absolutely do contend.
     match name {
+        // App runtimes are independent across apps, while two calls into one app may share state
+        // or trigger conflicting side effects. This makes A/B/C fan-out real without racing one
+        // app against itself; an unresolved target falls into one conservative shared lane.
+        "call_app_chat" | "call_app_event" => {
+            return Some(format!("app-runtime:{}", app()));
+        }
         "flowpilot_board" if is_editing_flowpilot_board_call(name, arguments) => {
             // An unresolved board target may create or adopt the app's first board, so it shares
             // the app's board lane; a named target only contends with edits of that same board.
@@ -479,7 +482,12 @@ impl PlatformCopilot {
             system_prompt.push_str(&memory.prompt_sections(&user_prompt).await);
         }
 
-        let tool_definitions: Vec<_> = platform_loop_tool_specs(memory.is_some())
+        let tool_specs = platform_loop_tool_specs(memory.is_some());
+        let advertised_tool_names: HashSet<String> = tool_specs
+            .iter()
+            .map(|spec| spec.name.to_string())
+            .collect();
+        let tool_definitions: Vec<_> = tool_specs
             .into_iter()
             .map(|spec| spec.to_tool_definition())
             .collect();
@@ -556,10 +564,9 @@ impl PlatformCopilot {
         // agent's own model usage alongside any stats reported by apps it called.
         let mut session_stats = LLMUsageStats::default();
         let mut current_prompt = prompt_message;
-        let mut open_url_budget = OpenUrlSessionBudget::default();
         let web_research_session = Arc::new(WebResearchSession::new(&user_prompt));
-        let mut session_search_calls = 0usize;
-        let mut session_archive_calls = 0usize;
+        let mut local_app_discovery_complete = false;
+        let mut sealed_research_used = false;
 
         // Tool rounds and answer generation have separate budgets. The last iteration deliberately
         // advertises no tools, guaranteeing that a search/open chain cannot consume the final turn
@@ -751,74 +758,8 @@ impl PlatformCopilot {
                 break;
             }
 
-            open_url_budget.begin_round(
-                tool_calls
-                    .iter()
-                    .filter(|tool_call| tool_call.function.name == OPEN_URL_TOOL)
-                    .count(),
-            );
-            let mut round_search_calls = 0usize;
-            let mut round_archive_calls = 0usize;
-            let mut prepared_arguments = Vec::with_capacity(tool_calls.len());
-            for tool_call in &tool_calls {
-                let tool_name = tool_call.function.name.as_str();
-                if is_public_web_tool(tool_name)
-                    && let Some(error) = web_research_session.public_web_phase_error(tool_name)
-                {
-                    prepared_arguments.push(Err(error.to_string()));
-                    continue;
-                }
-                let prepared = match tool_name {
-                    INTERNET_SEARCH_TOOL => {
-                        if round_search_calls >= MAX_SEARCH_CALLS_PER_ROUND {
-                            Err(web_call_budget_error(
-                                tool_name,
-                                "search_round_call_budget_exceeded",
-                                "This research round reached its search-query budget. Inspect the current results and refine only unresolved gaps in the next round.",
-                                true,
-                            ))
-                        } else if session_search_calls >= MAX_SEARCH_CALLS_PER_SESSION {
-                            Err(web_call_budget_error(
-                                tool_name,
-                                "search_session_call_budget_exceeded",
-                                "This assistant run reached its search-query budget. Synthesize the strongest verified evidence already collected and disclose remaining gaps.",
-                                false,
-                            ))
-                        } else {
-                            round_search_calls += 1;
-                            session_search_calls += 1;
-                            Ok(tool_call.function.arguments.clone())
-                        }
-                    }
-                    ARCHIVE_LOOKUP_TOOL => {
-                        if round_archive_calls >= MAX_ARCHIVE_CALLS_PER_ROUND {
-                            Err(web_call_budget_error(
-                                tool_name,
-                                "archive_round_call_budget_exceeded",
-                                "This research round reached its archive-lookup budget. Inspect the returned captures before trying another historical lead.",
-                                true,
-                            ))
-                        } else if session_archive_calls >= MAX_ARCHIVE_CALLS_PER_SESSION {
-                            Err(web_call_budget_error(
-                                tool_name,
-                                "archive_session_call_budget_exceeded",
-                                "This assistant run reached its archive-lookup budget. Use the captures already found or disclose that the historical record remains incomplete.",
-                                false,
-                            ))
-                        } else {
-                            round_archive_calls += 1;
-                            session_archive_calls += 1;
-                            Ok(tool_call.function.arguments.clone())
-                        }
-                    }
-                    _ => open_url_budget
-                        .prepare_call(tool_name, tool_call.function.arguments.clone()),
-                };
-                prepared_arguments.push(prepared);
-            }
-
-            current_history.push(current_prompt.clone());
-
+            // Publish starts before any preparation that may itself run a long isolated
+            // researcher, so the user never sees an unexplained silent stall.
             let mut frame_ids: Vec<String> = Vec::new();
             for tool_call in &tool_calls {
                 plan_step_counter += 1;
@@ -837,6 +778,133 @@ impl PlatformCopilot {
                 }
                 frame_ids.push(frame_id);
             }
+
+            let round_has_research_fallback = tool_calls
+                .iter()
+                .any(|tool_call| tool_call.function.name == RESEARCH_AGENT_TOOL);
+            let round_has_private_call = tool_calls
+                .iter()
+                .any(|tool_call| platform_tool_enters_private_context(&tool_call.function.name));
+            let mut prepared_arguments = Vec::with_capacity(tool_calls.len());
+            for tool_call in &tool_calls {
+                let tool_name = tool_call.function.name.as_str();
+                if !advertised_tool_names.contains(tool_name) {
+                    prepared_arguments.push(Err(json!({
+                        "status": "error",
+                        "tool": tool_name,
+                        "code": "platform_tool_not_advertised",
+                        "retryable": false,
+                        "message": "This tool was not advertised in the active FlowPilot surface and was not executed."
+                    })
+                    .to_string()));
+                    continue;
+                }
+                if is_public_web_tool(tool_name)
+                    && let Some(error) = web_research_session.public_web_phase_error(tool_name)
+                {
+                    prepared_arguments.push(Err(error.to_string()));
+                    continue;
+                }
+                let prepared = match tool_name {
+                    RESEARCH_AGENT_TOOL => {
+                        let output = if round_has_private_call {
+                            json!({
+                                "status": "error",
+                                "code": "sealed_research_must_be_separate_wave",
+                                "retryable": true,
+                                "message": "Run sealed public research in its own assistant wave before any local app, data, memory, file, or interactive call."
+                            })
+                            .to_string()
+                        } else if !local_app_discovery_complete {
+                            json!({
+                                "status": "error",
+                                "code": "local_app_discovery_required",
+                                "retryable": true,
+                                "message": "Call list_apps in an earlier round and wait for a complete inventory before using public-web fallback."
+                            })
+                            .to_string()
+                        } else if sealed_research_used {
+                            json!({
+                                "status": "error",
+                                "code": "sealed_research_already_used",
+                                "retryable": false,
+                                "message": "The sealed public researcher is one-shot for this run; synthesize its findings and disclose remaining gaps."
+                            })
+                            .to_string()
+                        } else {
+                            sealed_research_used = true;
+                            let timeout_secs = find_global_tool_spec(RESEARCH_AGENT_TOOL)
+                                .map(|spec| spec.timeout_secs)
+                                .unwrap_or(900);
+                            match tokio::time::timeout(
+                                Duration::from_secs(timeout_secs),
+                                run_sealed_research_agent(
+                                    completion_client.as_ref(),
+                                    &model_name,
+                                    &user_prompt,
+                                ),
+                            )
+                            .await
+                            {
+                                Ok(Ok((findings, research_stats))) => {
+                                    for call in &research_stats.calls {
+                                        session_stats.accumulate(
+                                            &call.usage,
+                                            Some(call.model.as_str()),
+                                        );
+                                    }
+                                    json!({
+                                        "status": "ok",
+                                        "sealed_to_source_request": true,
+                                        "findings": findings,
+                                    })
+                                    .to_string()
+                                }
+                                Ok(Err(error)) => json!({
+                                    "status": "error",
+                                    "code": "sealed_research_failed",
+                                    "retryable": false,
+                                    "message": error.to_string(),
+                                })
+                                .to_string(),
+                                Err(_) => json!({
+                                    "status": "timeout",
+                                    "code": "sealed_research_timeout",
+                                    "retryable": false,
+                                    "message": format!("The sealed researcher exceeded its {timeout_secs}-second execution limit."),
+                                })
+                                .to_string(),
+                            }
+                        };
+                        // A prepared error is an already-computed tool result in this loop.
+                        Err(output)
+                    }
+                    INTERNET_SEARCH_TOOL | OPEN_URL_TOOL | ARCHIVE_LOOKUP_TOOL => Err(json!({
+                        "status": "error",
+                        "tool": tool_name,
+                        "code": "raw_public_web_tool_unavailable",
+                        "retryable": false,
+                        "message": "Raw public-web tools are unavailable to the root assistant; use the sealed no-argument research_agent fallback."
+                    })
+                    .to_string()),
+                    _ if round_has_research_fallback
+                        && platform_tool_enters_private_context(tool_name) =>
+                    {
+                        Err(json!({
+                            "status": "error",
+                            "tool": tool_name,
+                            "code": "private_call_deferred_for_sealed_research",
+                            "retryable": true,
+                            "message": "This private/local call was not executed because research_agent must run in a separate earlier wave. Retry it after the research result."
+                        })
+                        .to_string())
+                    }
+                    _ => Ok(tool_call.function.arguments.clone()),
+                };
+                prepared_arguments.push(prepared);
+            }
+
+            current_history.push(current_prompt.clone());
 
             // Group the round into serialization lanes, then run the lanes concurrently. A lane
             // preserves the model's declared order internally; laneless (read-only) calls each get
@@ -962,9 +1030,14 @@ impl PlatformCopilot {
             // All calls in one model-authored batch may complete. Once that batch has introduced
             // app, memory, or interactive data, later model rounds lose public-network access so
             // private values cannot be transformed into a new query or outbound URL.
+            if tool_results.iter().any(|(_id, name, output, _images)| {
+                name == "list_apps" && complete_app_inventory_result(output)
+            }) {
+                local_app_discovery_complete = true;
+            }
             let round_entered_private_context = tool_calls
                 .iter()
-                .any(|tool_call| !is_public_web_tool(&tool_call.function.name));
+                .any(|tool_call| platform_tool_enters_private_context(&tool_call.function.name));
             if round_entered_private_context {
                 web_research_session.close_public_web_phase();
             }
@@ -1118,33 +1191,196 @@ fn citation_allowlist_text(opened_urls: &[String]) -> String {
         .join("\n")
 }
 
-fn web_call_budget_error(tool: &str, code: &str, message: &str, retryable: bool) -> String {
-    json!({
-        "status": "error",
-        "tool": tool,
-        "code": code,
-        "retryable": retryable,
-        "error": message,
-    })
-    .to_string()
+fn unverified_citation_urls(text: &str, opened_urls: &[String]) -> Vec<String> {
+    let allowed = opened_urls.iter().cloned().collect::<HashSet<_>>();
+    let mut unverified = public_urls_in_user_text(text)
+        .into_iter()
+        .filter_map(|raw| Url::parse(&raw).ok().map(|url| url.as_str().to_string()))
+        .filter(|url| !allowed.contains(url))
+        .collect::<Vec<_>>();
+    unverified.sort();
+    unverified.dedup();
+    unverified
 }
 
-/// Tools advertised to the rig/Bits platform loop.
-///
-/// The public-web tools moved off the shared orchestrator set and onto the Research scope, which
-/// only the tool-driven backends can host. This loop cannot spawn a nested scope, and it already
-/// implements the search/open/archive handlers inline — so it keeps them directly; dropping them
-/// here would remove web research from the Bits backend outright rather than relocating it. For the
-/// same reason `research_agent` must NOT be advertised: delegating it would open a Research scope
-/// this backend cannot run, and the host's capability notice would come back to the orchestrator
-/// looking exactly like research findings. The prompt variant paired with this set is
-/// [`WebResearchCapability::Inline`](super::assistant::WebResearchCapability).
+/// Tools advertised to the rig/Bits platform loop. The root receives the same sealed
+/// `research_agent` fallback as every other backend; this host executes it in a fresh local
+/// public-only model context. Raw search/open/archive schemas never enter the root context.
 fn platform_loop_tool_specs(memory_enabled: bool) -> Vec<PlatformToolSpec> {
     global_assistant_tool_specs(memory_enabled)
+}
+
+const MAX_SEALED_RESEARCH_ROUNDS: usize = 6;
+
+/// Run public research in a context that can see only the immutable source request and public-web
+/// tools. This is the rig/Bits equivalent of the frontend-managed Research specialist. The root
+/// model cannot supply arguments, history, recalled memory, attachments, or app inventory to this
+/// loop, so local-app discovery cannot be encoded into an outbound query.
+async fn run_sealed_research_agent(
+    completion_client: &(dyn CompletionClientDyn + Send + Sync),
+    model_name: &str,
+    source_user_prompt: &str,
+) -> Result<(String, LLMUsageStats)> {
+    let research_date = format!(
+        "Current UTC date: {}.",
+        chrono::Utc::now().format("%Y-%m-%d")
+    );
+    let research_prompt = crate::copilot::prompts::research_system_prompt(&research_date);
+    let agent = completion_client
+        .agent(model_name)
+        .preamble(&research_prompt)
+        .build();
+    let tools: Vec<_> = public_web_tool_specs()
         .into_iter()
-        .filter(|spec| spec.name != RESEARCH_AGENT_TOOL)
-        .chain(public_web_tool_specs())
-        .collect()
+        .map(|spec| spec.to_tool_definition())
+        .collect();
+    // This sealed child gets a fresh authorization view even when the parent has already called a
+    // local research app. It still receives only the immutable source request, never the parent's
+    // app result, so local-first fallback remains possible without reopening the root context.
+    let web_session = WebResearchSession::new(source_user_prompt);
+    let mut history = Vec::new();
+    let mut current_prompt = rig::message::Message::User {
+        content: OneOrMany::one(UserContent::text(source_user_prompt.to_string())),
+    };
+    let mut research_stats = LLMUsageStats::default();
+
+    for iteration in 0..=MAX_SEALED_RESEARCH_ROUNDS {
+        let tools_for_round = if iteration < MAX_SEALED_RESEARCH_ROUNDS {
+            tools.clone()
+        } else {
+            Vec::new()
+        };
+        let request = agent
+            .completion(current_prompt.clone(), history.clone())
+            .await
+            .map_err(|error| flow_like_types::anyhow!("Sealed research completion error: {error}"))?
+            .tools(tools_for_round);
+        let mut stream = request
+            .stream()
+            .await
+            .map_err(|error| flow_like_types::anyhow!("Sealed research stream error: {error}"))?;
+        let mut response_contents = Vec::new();
+        let mut round_text = String::new();
+        while let Some(item) = stream.next().await {
+            match item.map_err(|error| {
+                flow_like_types::anyhow!("Sealed research stream error: {error}")
+            })? {
+                StreamedAssistantContent::Text(text) => {
+                    round_text.push_str(&text.text);
+                    response_contents.push(AssistantContent::Text(text));
+                }
+                StreamedAssistantContent::ToolCall { tool_call, .. } => {
+                    response_contents.push(AssistantContent::ToolCall(tool_call));
+                }
+                StreamedAssistantContent::Final(response) => {
+                    if let Some(usage) = response.token_usage() {
+                        research_stats.accumulate(&Usage::from_rig(usage), Some(model_name));
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        let tool_calls: Vec<_> = response_contents
+            .iter()
+            .filter_map(|content| match content {
+                AssistantContent::ToolCall(call) => Some(call.clone()),
+                _ => None,
+            })
+            .collect();
+        if tool_calls.is_empty() {
+            if round_text.trim().is_empty() {
+                return Err(flow_like_types::anyhow!(
+                    "The sealed researcher returned no synthesis"
+                ));
+            }
+            let unverified = unverified_citation_urls(&round_text, &web_session.opened_urls());
+            if !unverified.is_empty() {
+                return Err(flow_like_types::anyhow!(
+                    "The sealed researcher cited URLs it did not successfully open: {}",
+                    unverified.join(", ")
+                ));
+            }
+            return Ok((round_text, research_stats));
+        }
+        if iteration == MAX_SEALED_RESEARCH_ROUNDS {
+            return Err(flow_like_types::anyhow!(
+                "The sealed researcher exhausted its tool budget without a synthesis"
+            ));
+        }
+
+        // Preserve a valid alternating transcript: the original source request and every later
+        // tool-result prompt must precede the assistant turn that answered it. Without this, the
+        // second research round loses the user's question and later providers may reject orphaned
+        // tool calls/results.
+        history.push(current_prompt.clone());
+        history.push(rig::message::Message::Assistant {
+            id: None,
+            content: OneOrMany::many(response_contents).unwrap_or_else(|_| {
+                OneOrMany::one(AssistantContent::Text(rig::message::Text {
+                    text: String::new(),
+                    additional_params: None,
+                }))
+            }),
+        });
+
+        let mut results = Vec::with_capacity(tool_calls.len());
+        for call in tool_calls {
+            let name = call.function.name.as_str();
+            let arguments = call.function.arguments;
+            let mut value = match name {
+                INTERNET_SEARCH_TOOL => {
+                    if web_session.reserve_search_call() {
+                        run_internet_search(&arguments).await
+                    } else {
+                        json!({
+                            "status": "error",
+                            "tool": name,
+                            "code": "search_session_call_budget_exceeded",
+                            "retryable": false,
+                        })
+                    }
+                }
+                OPEN_URL_TOOL => match web_session.prepare_open_url_call(arguments) {
+                    Ok(arguments) => run_open_url_for_session(&arguments, &web_session).await,
+                    Err(output) => serde_json::from_str(&output).unwrap_or_else(
+                        |_| json!({ "status": "error", "tool": name, "error": output }),
+                    ),
+                },
+                ARCHIVE_LOOKUP_TOOL => {
+                    if web_session.reserve_archive_call() {
+                        run_archive_lookup_for_session(&arguments, &web_session).await
+                    } else {
+                        json!({
+                            "status": "error",
+                            "tool": name,
+                            "code": "archive_session_call_budget_exceeded",
+                            "retryable": false,
+                        })
+                    }
+                }
+                _ => json!({
+                    "status": "error",
+                    "tool": name,
+                    "code": "sealed_research_tool_not_allowed",
+                }),
+            };
+            web_session.register_and_decorate_tool_result(name, &mut value);
+            results.push(UserContent::ToolResult(RigToolResult {
+                id: call.id,
+                call_id: None,
+                content: OneOrMany::one(ToolResultContent::text(value.to_string())),
+            }));
+        }
+        current_prompt = rig::message::Message::User {
+            content: OneOrMany::many(results)
+                .unwrap_or_else(|_| OneOrMany::one(UserContent::text(""))),
+        };
+    }
+
+    Err(flow_like_types::anyhow!(
+        "The sealed researcher ended unexpectedly"
+    ))
 }
 
 fn is_public_web_tool(name: &str) -> bool {
@@ -1152,6 +1388,22 @@ fn is_public_web_tool(name: &str) -> bool {
         name,
         INTERNET_SEARCH_TOOL | OPEN_URL_TOOL | ARCHIVE_LOOKUP_TOOL
     )
+}
+
+/// Root-context tools whose results can contain private/user-controlled data. App inventory is a
+/// routing exception only because the root has no raw web tools and the sealed researcher accepts
+/// no model text. Its metadata therefore cannot cross the outbound boundary.
+fn platform_tool_enters_private_context(name: &str) -> bool {
+    !is_public_web_tool(name) && !matches!(name, "list_apps" | RESEARCH_AGENT_TOOL)
+}
+
+fn complete_app_inventory_result(output: &str) -> bool {
+    let Ok(value) = serde_json::from_str::<Value>(output) else {
+        return false;
+    };
+    value.get("status").and_then(Value::as_str) == Some("ok")
+        && value.get("complete").and_then(Value::as_bool) == Some(true)
+        && value.get("truncated").and_then(Value::as_bool) != Some(true)
 }
 
 /// Dispatch a tool call: memory and safe public-page reads run locally; everything else goes to the
@@ -1662,19 +1914,51 @@ fn search_query_contains_likely_secret(query: &str) -> bool {
 mod tests {
     use super::*;
 
-    /// This loop researches the web itself. Advertising the delegating specialist as well makes the
-    /// model hand every web question to a Research scope this backend cannot start.
+    /// Raw public-web schemas must stay out of the root context. The sealed no-argument fallback
+    /// runs an isolated local research loop instead.
     #[test]
-    fn platform_loop_holds_web_tools_and_hides_the_research_specialist() {
+    fn platform_loop_exposes_only_the_sealed_research_fallback() {
         let names: Vec<&str> = platform_loop_tool_specs(true)
             .iter()
             .map(|spec| spec.name)
             .collect();
-        assert!(!names.contains(&RESEARCH_AGENT_TOOL));
-        assert!(names.contains(&INTERNET_SEARCH_TOOL));
-        assert!(names.contains(&OPEN_URL_TOOL));
-        assert!(names.contains(&ARCHIVE_LOOKUP_TOOL));
+        assert!(names.contains(&RESEARCH_AGENT_TOOL));
+        assert!(!names.contains(&INTERNET_SEARCH_TOOL));
+        assert!(!names.contains(&OPEN_URL_TOOL));
+        assert!(!names.contains(&ARCHIVE_LOOKUP_TOOL));
         assert!(names.contains(&MEMORY_SEARCH_TOOL));
+    }
+
+    #[test]
+    fn public_fallback_requires_a_complete_app_inventory() {
+        assert!(complete_app_inventory_result(
+            &json!({ "status": "ok", "complete": true, "apps": [] }).to_string()
+        ));
+        assert!(!complete_app_inventory_result(
+            &json!({ "status": "ok", "complete": false, "apps": [] }).to_string()
+        ));
+        assert!(!complete_app_inventory_result(
+            &json!({ "status": "ok", "apps": [] }).to_string()
+        ));
+        assert!(!complete_app_inventory_result(
+            &json!({ "status": "ok", "truncated": true, "apps": [] }).to_string()
+        ));
+        assert!(!complete_app_inventory_result("not json"));
+    }
+
+    #[test]
+    fn sealed_research_and_private_tools_are_detected_as_separate_waves() {
+        assert!(!platform_tool_enters_private_context("list_apps"));
+        assert!(!platform_tool_enters_private_context(RESEARCH_AGENT_TOOL));
+        for name in [
+            "describe_app_interface",
+            "call_app_chat",
+            "call_app_event",
+            "data_studio_agent",
+            MEMORY_SEARCH_TOOL,
+        ] {
+            assert!(platform_tool_enters_private_context(name), "{name}");
+        }
     }
 
     #[test]
@@ -1690,6 +1974,21 @@ mod tests {
                 "https://z.example/source".to_string(),
             ]),
             "- https://a.example/source\n- https://z.example/source"
+        );
+    }
+
+    #[test]
+    fn sealed_research_rejects_urls_outside_the_opened_allowlist() {
+        let opened = vec!["https://example.com/opened".to_string()];
+        assert!(
+            unverified_citation_urls("Use [this](https://example.com/opened).", &opened).is_empty()
+        );
+        assert_eq!(
+            unverified_citation_urls(
+                "Unsupported [claim](https://example.com/search-only).",
+                &opened
+            ),
+            vec!["https://example.com/search-only".to_string()]
         );
     }
 
@@ -1816,6 +2115,32 @@ mod tests {
         assert!(platform_tool_serialization_lane("list_apps", &list_args).is_none());
         assert!(
             platform_tool_serialization_lane("describe_app_interface", &describe_args).is_none()
+        );
+    }
+
+    #[test]
+    fn app_runtime_lanes_parallelize_apps_but_serialize_each_app() {
+        let app_a_chat = json!({ "app_id": "app-a", "message": "one" });
+        let app_a_event = json!({ "app_id": "app-a", "event_id": "event" });
+        let app_b_chat = json!({ "app_id": "app-b", "message": "two" });
+        let unresolved_chat = json!({ "message": "unknown" });
+        let unresolved_event = json!({ "event_id": "event" });
+
+        assert_eq!(
+            platform_tool_serialization_lane("call_app_chat", &app_a_chat),
+            platform_tool_serialization_lane("call_app_event", &app_a_event)
+        );
+        assert_ne!(
+            platform_tool_serialization_lane("call_app_chat", &app_a_chat),
+            platform_tool_serialization_lane("call_app_chat", &app_b_chat)
+        );
+        assert_eq!(
+            platform_tool_serialization_lane("call_app_chat", &unresolved_chat),
+            Some("app-runtime:*".to_string())
+        );
+        assert_eq!(
+            platform_tool_serialization_lane("call_app_chat", &unresolved_chat),
+            platform_tool_serialization_lane("call_app_event", &unresolved_event)
         );
     }
 

--- a/packages/core/src/flow/copilot/public_web.rs
+++ b/packages/core/src/flow/copilot/public_web.rs
@@ -328,7 +328,7 @@ fn reserve_capped_call(counter: &AtomicUsize, limit: usize) -> bool {
         .is_ok()
 }
 
-fn public_urls_in_user_text(text: &str) -> Vec<String> {
+pub(crate) fn public_urls_in_user_text(text: &str) -> Vec<String> {
     let mut urls = Vec::new();
     let mut offset = 0usize;
     while offset < text.len() {

--- a/packages/core/src/flow/copilot/tool_spec.rs
+++ b/packages/core/src/flow/copilot/tool_spec.rs
@@ -21,8 +21,9 @@ pub const OPEN_URL_TOOL: &str = "open_url";
 pub const ARCHIVE_LOOKUP_TOOL: &str = "archive_lookup";
 pub const MEMORY_STORE_TOOL: &str = "_memory_store";
 pub const MEMORY_SEARCH_TOOL: &str = "_memory_search";
-/// Delegating web-research tool. Only backends that can host the nested `Research` scope may
-/// advertise it; the rig/Bits loop holds [`public_web_tool_specs`] directly instead.
+/// Sealed public-web fallback. Tool-driven backends delegate it to the nested `Research` scope;
+/// the rig/Bits loop runs an equivalent isolated researcher locally. It deliberately accepts no
+/// model-authored text: the host binds it to the immutable top-level user request.
 pub const RESEARCH_AGENT_TOOL: &str = "research_agent";
 
 /// The externally observable effect of a platform tool call. This is deliberately independent of
@@ -360,11 +361,25 @@ fn flowpilot_widget_message(args: &Value) -> String {
 
 fn call_app_chat_message(args: &Value) -> String {
     let app_id = spec_arg_str(args, "app_id", "appId");
-    if app_id.is_empty() {
+    let mut message = if app_id.is_empty() {
         "FlowPilot wants to message an app's chat.".to_string()
     } else {
         format!("FlowPilot wants to message the chat of app '{app_id}'.")
+    };
+    let files: Vec<&str> = args
+        .get("forward_files")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .filter(|name| !name.trim().is_empty())
+        .collect();
+    if files.is_empty() {
+        message.push_str(" No attachments will be forwarded.");
+    } else {
+        message.push_str(&format!(" Forward attachments: {}.", files.join(", ")));
     }
+    message
 }
 
 fn graph_overlay_message(args: &Value) -> String {
@@ -680,10 +695,15 @@ pub fn global_assistant_tool_specs(memory_enabled: bool) -> Vec<PlatformToolSpec
         PlatformToolSpec {
             name: "list_apps",
             description: r#"List the apps visible in the user's CURRENT profile, with the callable interfaces each
-one exposes. Every event carries a `kind` that tells you which tool consumes it: "chat" →
-`open_app_chat`/`call_app_chat`, "page" → `open_app_page` (embed the app's UI inline), "headless"
-(simple/REST/MCP/…) → `call_app_event`. Use this before acting on any app. Only apps in the current
-profile are returned."#,
+one exposes. Every callable event carries its Event `id`, `kind`, and one exact `consumer_tool`:
+"chat" → `call_app_chat` (`open_app_chat` when the user should take over), "page" →
+`open_app_page` (embed the app's UI inline), "headless"
+(simple/REST/MCP/…) → `call_app_event`. A page may also expose `page_id` and `route`; neither is its
+Event `id`, so never pass them as `event_id`. An `unavailable` event has no consumer and must not be
+called. Use this before acting on any app. Only apps in the current profile are returned.
+`complete: false`, truncation, or an app's `events_status: "error"` means the
+inventory cannot prove that no suitable local interface exists; do not use public-web fallback from
+that partial result."#,
             schema: || json!({ "type": "object", "properties": {} }),
             approval: ToolApprovalSpec::None,
             timeout_secs: 120,
@@ -734,13 +754,14 @@ information displayed in that page; read the returned images before answering. C
 `screenshot_count` and `screenshot_complete`, and never claim to have read content that was not
 captured. Works ONLY for events with kind "page" in `list_apps` — NOT for "chat" events (use
 `open_app_chat`/`call_app_chat`) or "headless" events (use `call_app_event`). Non-destructive UI
-change."#,
+change. Pass the page Event's `id` as `event_id`, never its `page_id`. A structured failure supersedes
+older inventory: do not guess another Event or route; relist at most once only when `relist_required`."#,
             schema: || {
                 json!({
                     "type": "object",
                     "properties": {
                         "app_id": { "type": "string", "description": "App id (from list_apps)." },
-                        "event_id": { "type": "string", "description": "Page event id (kind \"page\" in list_apps). Optional; defaults to the app's first page-capable event." }
+                        "event_id": { "type": "string", "description": "Exact Event id (`events[].id`, kind \"page\") from list_apps; never `page_id`/`default_page_id`. Optional; defaults to the app's first page-capable event." }
                     },
                     "required": ["app_id"]
                 })
@@ -827,65 +848,11 @@ approval dialog with a "don't ask again this session" option before it runs."#,
         },
         PlatformToolSpec {
             name: "flowpilot_board",
-            description: r#"The single entry point for ANYTHING about a specific board or workflow LOGIC — building it, explaining it, editing it, or debugging it. Delegates to the board FlowPilot, the only specialist allowed to author FlowScript or change board nodes, connections, entry events, and layers. Page/widget/component DESIGN is not board work and goes to flowpilot_widget.
+            description: r#"The board/workflow specialist and only tool allowed to explain or change FlowScript, nodes, connections, layers, and Event entry nodes. UI belongs to `flowpilot_widget`; app data belongs to `data_studio_agent`.
 
-Two modes (set `mode`):
-- mode="explain" (read-only): answer the user's question about the board — "explain this workflow", "what does this do", "why is this failing". Nothing is modified and no approval is asked. Relay the returned answer to the user.
-- mode="edit" (default): build or modify the board's WORKFLOW LOGIC (add/connect/configure nodes and events). This is NOT for UI — pages, widgets and components go to flowpilot_widget. If the app has no board yet, one is created automatically — never ask the user to create a board manually. Give a complete, self-contained instruction (trigger/event, the processing steps, and where results go). The specialist prepares and validates the edit first; approval is requested only before the retained edit is applied.
+Use `mode="explain"` for a read-only board question. Use `mode="edit"` (default) with one complete acceptance contract for one board; it creates the app's first board when needed. Send independent boards together, but never overlap edits to the same or unresolved board target.
 
-For edit mode, the complete user-requested behavior is the acceptance contract. Do not replace a
-failed/timeout full build with a reduced smoke test.
-
-ONE BOARD PER CALL, ALL BOARDS AT ONCE. Send each board's FULL scope in ONE call: never decompose a
-single board's work into a sequence of partial calls, because the specialist plans and segments a
-large build internally and the host drives those segments for you. But when the work spans SEVERAL
-independent boards — separate triggers, separate entry events, no shared execution path — emit one
-call per board in the SAME turn. They run concurrently and the turn finishes in the time of the
-slowest board instead of their sum. Sequencing independent boards is pure waste.
-
-Never overlap mutations of the SAME board: two edit calls naming one board_id, or two calls that
-both omit board_id in an app whose target would resolve to the same board, must not be in flight
-together. That is the only ordering constraint. A timeout or transport drop is an unknown outcome,
-not proof that the board is empty; inspect the same board after the request is terminal, then retry
-the full scope with diagnostics if necessary.
-
-A result may report `segments_applied` and `segments_remaining`: that is a genuine partial build, not
-a failure. Say plainly which parts are on the board and which are missing, and continue from it with
-the same acceptance contract rather than restarting the whole request.
-
-A result with `no_recoverable_candidate` and source/check/commit counters all zero is zero progress.
-Retry it at most once, and only with a material strategy change: require a scope plan that splits the
-build into smaller segments so the first source write lands quickly, after one bounded,
-highest-leverage declaration batch and at most six ancillary pre-draft inspection calls.
-Rewording or shortening the same instruction is not a material strategy change. If the equivalent
-zero-progress result repeats, report it honestly and do not launch a third equivalent board call.
-
-When the user's request includes both UI and behavior, building AND applying the workflow board is
-MANDATORY before the turn ends — a page without its board is not a deliverable. Never spend the
-remaining turn narrating that a board call is "still running": wait for its terminal result, and
-when that result is a failure or timeout, continue the pipeline in the same turn with the retained
-draft and its diagnostics instead of only reporting status.
-
-The delegated board specialist owns the FlowScript draft and its edit/validate/repair loop. The
-platform caller must not turn a validation problem into a new implementation request such as a
-"minimal diagnostic", empty Event, one-node log/notify test, or ask_user choice to downgrade the
-workflow. If any result reports `retained_candidate`, `retained_flowscript`, or a retained draft,
-that document remains the active recovery workspace even if the persisted board is still empty.
-Retained drafts are bound to THIS conversation plus the ORIGINAL user request: a follow-up
-repair call resumes them only within the same conversation, never from a different one. Include
-that original user request text verbatim in the instruction, name the retained draft_id and its
-expected_revision, and direct the specialist to repair that draft in place — same draft_id, same
-revision chain, never "start a new draft" or a from-scratch rewrite. The single exception is a
-`FLOWSCRIPT_BASE_REVISION_CONFLICT` result: the board moved underneath the draft and every
-operation on it will fail forever, so the specialist must restart with a fresh draft_id from the
-current board while keeping the same acceptance contract. Retry on the SAME app/board
-with the original acceptance contract and observed diagnostics, and explicitly instruct the
-specialist to repair and queue the retained production candidate. Only an
-explicit NEW end-user request may discard or reduce it.
-
-When a board is already open (see CURRENTLY OPEN BOARD in your context), pass its app_id/board_id and route the user's board question here directly — do NOT ask which app or board, and do NOT answer board questions yourself.
-
-SCOPE: it reads/edits board/page CONTENTS only. It cannot create apps (use create_app), rename apps, or change app metadata/settings — do not put such requests in the instruction."#,
+Edit results identify the exact app/board, summary, persisted `event_nodes`, progress counters, retained-draft diagnostics, and any `segments_remaining`/`manual_steps`. A timeout is an unknown outcome. Resume a retained draft on the same conversation/request and revision; preserve full scope. Only `FLOWSCRIPT_BASE_REVISION_CONFLICT` permits a fresh draft. Report partial/manual work rather than claiming completion."#,
             schema: || {
                 json!({
                     "type": "object",
@@ -915,13 +882,11 @@ SCOPE: it reads/edits board/page CONTENTS only. It cannot create apps (use creat
         },
         PlatformToolSpec {
             name: "flowpilot_widget",
-            description: r#"The UI specialist — design and build interfaces (A2UI). Two modes:
-- mode="edit": change an EXISTING page or widget. With the builder open on the target, generated components are staged for the user's review. With no builder open, pass app_id plus page_id (or route/page_name) and the saved page is rewritten directly — applied immediately, with no review card, so always name the page you changed when you report back. Ambient open-builder state is used only in this mode.
-- mode="create": create a NEW page from scratch in an app (pass app_id). Supplying app_id/page_id/board_id/page_name/route defaults to create mode even when another builder is open, so say mode="edit" explicitly to change a page that already exists. A page is board-scoped, so a board is created automatically if the app has none.
-	It builds the page AND any reusable widgets it needs — repeated or dynamic elements like list/grid cards, project or save-state rows, email-list items — in ONE call, then navigates the user to the page builder. A simple one-off layout (e.g. a dashboard with a chart and a table) needs no widget. Give a complete instruction for layout, content, and interaction affordances. When the user specified exact reusable-widget names, pass them in widget_names so the persisted entities keep those names even if the UI renderer omits an inline label. Side-effecting; asks for approval.
-SCOPE: UI only — pages, widgets, components. This specialist has no FlowScript or board-mutation authority and cannot build nodes, connections, entry events, or data wiring. A page may require an empty board record as its owner; that metadata scaffold is NOT workflow logic and is never proof that the board was built. Any requested behavior must be delegated separately to flowpilot_board. Never include FlowScript in this instruction and never treat this tool's success as satisfying board work.
+            description: r#"The UI specialist for A2UI pages, widgets, and components. It has no FlowScript, node, Event-entry, or data authority.
 
-RUN IT ALONGSIDE THE BOARD. You do NOT have to wait for this result before calling flowpilot_board. Every identifier the board needs to point at is one YOU choose, not one this tool invents: pass `board_id`, `page_id`, `route`, `widget_names` and the element/action ids you named in the instruction, then send those same strings to flowpilot_board in the SAME turn. When the board does not exist yet, call flowpilot_board with that exact board_id plus create_new_board=true. Both specialists bind to the contract you declared, so generation runs concurrently and persistence is safely coordinated. Only fall back to sequencing — widget first, then board — when you did not fix the ids up front."#,
+Use `mode="create"` for a new persisted page and `mode="edit"` for an existing page/open builder. Give the complete layout, content, interaction affordances, exact reusable-widget names, and caller-chosen page/route/element/action IDs. A created page may need a board record as its owner; that scaffold is not workflow logic.
+
+When IDs are fixed, pass the same board/page/UI contract to this tool and `flowpilot_board` in one wave. The result states whether UI was persisted or staged for user review; staged is not applied."#,
             schema: || {
                 json!({
                     "type": "object",
@@ -1010,10 +975,10 @@ don't blindly forward everything — but when unsure whether a file is relevant,
                         "forward_files": {
                             "type": "array",
                             "items": { "type": "string" },
-                            "description": "Exact names (from the FILES ATTACHED THIS TURN context) of the user's attached files to hand to this app. Omit to forward all attached files; pass an empty array to forward none. Pick the files whose type/content fit this app; when unsure, include the file."
+                            "description": "Exact names (from FILES ATTACHED THIS TURN) to hand to this app. Pass [] for none. Omission also forwards none, but always set this explicitly so forwarding is reviewable."
                         }
                     },
-                    "required": ["app_id", "message"]
+                    "required": ["app_id", "message", "forward_files"]
                 })
             },
             approval: ToolApprovalSpec::Execute {
@@ -1124,15 +1089,9 @@ Omit event_id to create; pass it to update. Side-effecting; asks for approval."#
         },
         PlatformToolSpec {
             name: "data_studio_agent",
-            description: r#"The single entry point for ANYTHING about an app's DATA — its databases/tables, ontologies (graph overlays), objects, graph queries, analytics, and ontology actions. Delegates to the Data Studio specialist, a data agent with full access to the app's graph/data tools.
+            description: r#"The data specialist for creating, inspecting, updating, querying, or dropping app databases/tables; SQL and Cypher; ontologies/overlays; graph queries/elements; analytics; ontology actions; and data visualizations. It does not edit workflow boards or UI.
 
-Use this for: setting up or updating databases/tables, DELETING/DROPPING a table (permanent, approval-gated, and it also prunes ontology references), creating/editing ontologies and overlays, writing/optimizing Cypher or SQL queries, running analytics/subgraph/paths/neighbors, adding graph nodes/edges, visualizing data as charts, and listing/reading/EXECUTING ontology actions on objects.
-
-Give a complete, self-contained instruction of what the user wants to know or change about the data. If a Data Studio page is currently open (see your context), its app and overlay are the default target — pass them here so the specialist starts there; it can still reach OTHER apps' data when asked. The specialist reports back transparently: the queries it ran, a step log, links, and inline charts — relay its answer (including any chart/query blocks) to the user verbatim.
-
-The specialist inspects with read-only tools freely; mutating operations (create/update/drop tables or overlays, add nodes/edges, execute actions) ask the user for approval individually. Dropping a table destroys its rows and schema irreversibly — route such a request here, name the exact table, and relay the reported cascade (pruned ontologies, saved queries left dangling) back to the user. SCOPE: data only — it does NOT edit workflow boards (use flowpilot_board) or UI (use flowpilot_widget).
-
-Data setup is NEVER a prerequisite for building a board. If this returns pending/failed table or index setup — unavailable on the deployment, refused, or approval declined — dispatch flowpilot_board anyway: LanceDB tables are created by the workflow's first write, and for embedding tables that first write derives a better schema (the model's exact vector width) than an explicit create can guess. Report the pending setup to the user; do not retry it in a loop and do not abandon the build over it."#,
+Give one complete question/change with the exact app and optional overlay from context. It returns its answer plus material query/action/chart evidence. Read-only inspection needs no approval; nested destructive/mutating operations ask separately and report their effects. If optional data setup is unavailable or declined during a larger build, disclose it but continue independent board work; do not retry in a loop."#,
             schema: || {
                 json!({
                     "type": "object",
@@ -1152,15 +1111,9 @@ Data setup is NEVER a prerequisite for building a board. If this returns pending
         },
         PlatformToolSpec {
             name: "project_scout",
-            description: r#"Research PRIOR ART before building from scratch. Delegates to the Scout specialist, a read-only researcher that searches the user's own apps, the public app store and the template catalog, inspects the candidates, and returns a foundation plan.
+            description: r#"Read-only prior-art research for a new BUILD. It searches owned apps, the public store, and templates, then returns a foundation plan; it never creates, forks, acquires, or edits anything.
 
-Call this BEFORE creating a new app or authoring a new workflow. Skip it only for a small edit to a board that already exists, or when the user already named the foundation to use. Do not skip it because the task sounds simple — rebuilding an app the user already owns is waste.
-
-The scout MUTATES NOTHING. It returns a plan; you execute it. The plan has a `base` (fork / acquire / template / new), a list of `parts` drawn from possibly DIFFERENT sources (a FlowScript fragment from one app, a template for another board, a data shape from a third), a `data` and `events` section, `changes` the user must make themselves, `blockers`, and an ordered `plan` of tool calls.
-
-Executing it: run the base step first; `fork_app` returns a `board_id_map` you must use to retarget every part's `target.board_ref` (those name boards in the SOURCE app, and a fork allocates new ids); then dispatch each part to the specialist matching its `source.kind` — `flowscript_fragment`/`board`/`event_config`/`template` to `flowpilot_board`, `data_schema` to `data_studio_agent` — passing the part's `locator` through so that specialist fetches the referenced source itself. Parts on different boards can go out together; parts on one board must be sequenced. Report `changes` and `blockers` to the user at the end.
-
-For a request spanning several distinct functional areas, call this SEVERAL times in one turn with DISJOINT `focus` values so the plans compose."#,
+Call before a from-scratch app/workflow, except for a small existing-target edit or a user-selected foundation. The result describes `base`, reusable `parts` with locators/dependencies, data/events, required user `changes`, `blockers`, and an ordered plan. The orchestrator executes that plan using the BUILD contract. Use disjoint `focus` values for genuinely independent scouts."#,
             schema: || {
                 json!({
                     "type": "object",
@@ -1181,26 +1134,22 @@ For a request spanning several distinct functional areas, call this SEVERAL time
         },
         PlatformToolSpec {
             name: RESEARCH_AGENT_TOOL,
-            description: r#"Research the PUBLIC WEB. Delegates to the Research specialist, a read-only researcher holding the only public-web tools in the system: search, page reading, and Internet Archive lookup.
+            description: r#"Run FlowPilot's sealed PUBLIC-WEB fallback for the current top-level user request.
 
-You cannot browse yourself — this tool is how any question about current external facts, documentation, prices, news, standards or third-party products gets answered. Use it whenever the answer is not already in the user's apps and not something you reliably know.
+Use only after `list_apps` found no suitable local app/interface, or no useful, nonredundant local
+research candidate produced a usable public answer. This tool accepts no question or context
+arguments: the host gives an isolated read-only researcher the immutable user request and date. It
+receives no root history, memory, attachments, app inventory/results, or model-authored arguments;
+from a mixed source request it extracts only safe public factual subquestions and never searches for
+secrets, credentials, or private identifiers. It returns cited findings plus evidence gaps.
 
-Give it the question in full, plus any constraints that matter (a date range, a jurisdiction, which sources to trust, what the user already tried). It returns a synthesis with inline markdown links to the exact pages it verified, a list of the URLs actually opened, and an explicit statement of what it could NOT establish. Relay its citations as-is — never invent, alter or re-title a link.
-
-Run several in ONE turn for genuinely separate questions; give each a distinct `question` so their findings compose. They share one research budget for the turn, so splitting one question into many near-duplicate calls buys nothing and spends the allowance faster.
-
-TWO ORDERING RULES:
-- Research BEFORE touching private data. Once you have read app databases, storage, files or memory this turn, the public-web phase closes and further research is refused — that boundary stops private data being laundered into an outbound query, and delegating does not bypass it. If a task needs both, research first, then read the app.
-- Never paste private app data, secrets, file contents or user credentials into the `question`. Describe what you need in neutral terms instead."#,
+It cannot use a local app's output as research context. If the next public query must be derived
+from private output, request a new explicit sanitized public-only turn instead."#,
             schema: || {
                 json!({
                     "type": "object",
-                    "properties": {
-                        "question": { "type": "string", "description": "The research question, in full. Include constraints that matter: dates, jurisdiction, which sources count as authoritative, and what the user already ruled out." },
-                        "context": { "type": "string", "description": "Non-private background that helps the researcher judge relevance. NEVER include app data, secrets, file contents or credentials." },
-                        "recency": { "type": "string", "description": "How current the evidence must be, e.g. \"last 30 days\", \"as of 2026\", or a historical cutoff for archive lookups." }
-                    },
-                    "required": ["question"]
+                    "properties": {},
+                    "additionalProperties": false
                 })
             },
             approval: ToolApprovalSpec::None,
@@ -1334,8 +1283,8 @@ pub fn find_global_tool_spec(name: &str) -> Option<PlatformToolSpec> {
 /// researcher has no app, database, storage or memory tools; the orchestrator has no outbound
 /// network. Provenance and spend are shared through the turn's `WebResearchSession`.
 ///
-/// The rig/Bits orchestrator still runs its own inline web loop (`platform.rs`) because that backend
-/// cannot host a nested tool-driven scope — see `research_agent`'s description.
+/// The rig/Bits orchestrator executes the same sealed fallback in a fresh local research loop; raw
+/// public-web schemas still never enter its root context.
 pub fn public_web_tool_specs() -> Vec<PlatformToolSpec> {
     vec![
         PlatformToolSpec {
@@ -1894,52 +1843,21 @@ mod tests {
         let spec = find_global_tool_spec("flowpilot_board").expect("flowpilot_board spec");
         assert!(
             spec.description
-                .contains("complete user-requested behavior")
+                .contains("one complete acceptance contract")
         );
-        assert!(spec.description.contains("reduced smoke test"));
-        assert!(spec.description.contains("Never overlap mutations"));
+        assert!(spec.description.contains("never overlap edits"));
         assert!(spec.description.contains("unknown outcome"));
+        assert!(spec.description.contains("retained draft"));
+        assert!(spec.description.contains("same conversation/request"));
         assert!(
             spec.description
-                .contains("source/check/commit counters all zero")
-        );
-        assert!(spec.description.contains("Retry it at most once"));
-        assert!(spec.description.contains("Rewording or shortening"));
-        assert!(spec.description.contains("at most six"));
-        assert!(
-            spec.description
-                .contains("do not launch a third equivalent")
+                .contains("`FLOWSCRIPT_BASE_REVISION_CONFLICT`")
         );
         assert!(
             spec.description
-                .contains("specialist owns the FlowScript draft")
+                .contains("`segments_remaining`/`manual_steps`")
         );
-        assert!(spec.description.contains("retained_flowscript"));
-        assert!(spec.description.contains("active recovery workspace"));
-        assert!(spec.description.contains("minimal diagnostic"));
-        assert!(spec.description.contains("explicit NEW end-user request"));
-        assert!(
-            spec.description
-                .contains("original user request text verbatim")
-        );
-        assert!(
-            spec.description
-                .contains("only within the same conversation")
-        );
-        assert!(
-            spec.description
-                .contains("retained draft_id and its\nexpected_revision")
-        );
-        assert!(spec.description.contains("never \"start a new draft\""));
-        assert!(
-            spec.description
-                .contains("applying the workflow board is\nMANDATORY before the turn ends")
-        );
-        assert!(spec.description.contains("still running"));
-        assert!(
-            spec.description
-                .contains("continue the pipeline in the same turn with the retained\ndraft")
-        );
+        assert!(spec.description.len() < 2_000);
         // A board build earns wall clock by proving progress, so this bound only has to outlive the
         // longest run it can earn. Every other dispatch bound on the path derives from the same
         // constant; see the desktop test that asserts the child CLI's MCP timeout tracks it.
@@ -2059,38 +1977,24 @@ mod tests {
         assert!(
             board
                 .description
-                .contains("only specialist allowed to author FlowScript")
+                .contains("only tool allowed to explain or change FlowScript")
         );
         assert!(
             board
                 .description
-                .contains("Page/widget/component DESIGN is not board work")
+                .contains("UI belongs to `flowpilot_widget`")
         );
 
         let widget = find_global_tool_spec("flowpilot_widget").expect("flowpilot_widget spec");
+        assert!(widget.description.contains("no FlowScript"));
         assert!(
             widget
                 .description
-                .contains("no FlowScript or board-mutation authority")
-        );
-        assert!(
-            widget
-                .description
-                .contains("metadata scaffold is NOT workflow logic")
-        );
-        assert!(
-            widget
-                .description
-                .contains("delegated separately to flowpilot_board")
-        );
-        assert!(
-            widget
-                .description
-                .contains("never treat this tool's success as satisfying board work")
+                .contains("scaffold is not workflow logic")
         );
         assert!(widget.description.contains("mode=\"create\""));
-        assert!(widget.description.contains("exact board_id"));
-        assert!(widget.description.contains("pass them in widget_names"));
+        assert!(widget.description.contains("same board/page/UI contract"));
+        assert!(widget.description.len() < 2_000);
         let widget_schema = (widget.schema)();
         assert_eq!(
             widget_schema["properties"]["widget_names"]["items"]["type"],
@@ -2116,6 +2020,108 @@ mod tests {
                 .expect("create_new_board description")
                 .contains("exact caller-chosen id")
         );
+    }
+
+    #[test]
+    fn app_page_tools_keep_event_and_page_identifiers_distinct() {
+        let inventory = find_global_tool_spec("list_apps").expect("list_apps spec");
+        assert!(
+            inventory
+                .description
+                .contains("Every callable event carries its Event `id`")
+        );
+        assert!(
+            inventory
+                .description
+                .contains("never pass them as `event_id`")
+        );
+
+        let open_page = find_global_tool_spec("open_app_page").expect("open_app_page spec");
+        assert!(open_page.description.contains("structured failure supersedes"));
+        assert!(open_page.description.contains("older inventory"));
+        assert!(open_page.description.contains("relist at most once"));
+        let open_page_schema = (open_page.schema)();
+        let event_id = open_page_schema["properties"]["event_id"]["description"]
+            .as_str()
+            .expect("event_id description");
+        assert!(event_id.contains("Exact Event id"));
+        assert!(event_id.contains("never `page_id`/`default_page_id`"));
+    }
+
+    #[test]
+    fn global_specialist_descriptions_stay_concise_and_schemas_stay_strict() {
+        for name in [
+            "flowpilot_board",
+            "flowpilot_widget",
+            "data_studio_agent",
+            "project_scout",
+            RESEARCH_AGENT_TOOL,
+        ] {
+            let spec = find_global_tool_spec(name).expect("global specialist spec");
+            assert!(
+                spec.description.len() < 2_000,
+                "{name} description exceeds the reviewed 2 KB model-facing budget"
+            );
+        }
+
+        let research = find_global_tool_spec(RESEARCH_AGENT_TOOL).unwrap();
+        let research_schema = (research.schema)();
+        assert_eq!(research_schema["properties"], json!({}));
+        assert_eq!(research_schema["additionalProperties"], json!(false));
+        assert!(research_schema.get("required").is_none());
+
+        let chat = find_global_tool_spec("call_app_chat").unwrap();
+        assert!(
+            (chat.schema)()["required"]
+                .as_array()
+                .unwrap()
+                .contains(&json!("forward_files"))
+        );
+        let approval = resolve_tool_approval(
+            &chat,
+            &json!({
+                "app_id": "knowledge",
+                "message": "summarize",
+                "forward_files": ["brief.pdf"]
+            }),
+        );
+        assert!(approval.description.contains("brief.pdf"));
+    }
+
+    #[test]
+    fn global_tool_descriptions_stay_within_model_facing_budget() {
+        let specs = global_assistant_tool_specs(false);
+        let total: usize = specs.iter().map(|spec| spec.description.len()).sum();
+        assert!(
+            total <= 15_000,
+            "global tool descriptions grew beyond the reviewed 15 KB budget: {total} bytes"
+        );
+        for spec in specs {
+            assert!(
+                spec.description.len() <= 2_000,
+                "{} description exceeds the 2 KB per-tool budget",
+                spec.name
+            );
+        }
+    }
+
+    #[test]
+    fn eager_global_tool_payload_stays_within_reviewed_budget() {
+        for (memory_enabled, budget) in [(false, 32_000usize), (true, 34_000usize)] {
+            let specs = global_assistant_tool_specs(memory_enabled);
+            let total: usize = specs
+                .iter()
+                .map(|spec| {
+                    spec.name.len()
+                        + spec.description.len()
+                        + serde_json::to_string(&(spec.schema)()).unwrap().len()
+                })
+                .sum();
+            assert!(
+                total <= budget,
+                "eager global tool payload grew beyond {budget} bytes (memory={memory_enabled}): {total}"
+            );
+        }
     }
 
     #[test]

--- a/packages/core/src/flow/copilot/tools.rs
+++ b/packages/core/src/flow/copilot/tools.rs
@@ -2076,9 +2076,13 @@ impl Tool for GetCurrentFlowScriptTool {
 
 Use this once before starting a new retained draft for an existing board. The returned document is
 the source you must edit and submit in full to `write_flowscript`; preserve all `//@n:<id>` anchors
-on statements you keep. After a write/check diagnostic, do NOT read the unchanged live board again:
-continue from the retained source and revision with patch_flowscript/check_flowscript/
-commit_flowscript."#
+and every `@cache` decorator on functions you keep. Cache settings use
+`@cache({ namespace: "...", ttlSeconds: 3600, scope: "user" })`; bare `@cache` defaults to the
+`global` namespace, a 300-second lifetime, and app scope. Use `ttlSeconds: 0` for no expiry.
+If existing context reports `ttl_seconds: null`, it is a permanent cache; preserve it as
+explicit `ttlSeconds: 0` rather than applying the new omission default.
+After a write/check diagnostic, do NOT read the unchanged live board again: continue from the
+retained source and revision with patch_flowscript/check_flowscript/commit_flowscript."#
                 .to_string(),
             parameters: json!({
                 "type": "object",
@@ -3315,6 +3319,12 @@ and catalog declarations, then produces minimal changes:
   resolvable FlowScript references/nested calls.
 - A new unanchored `function name(...) { ... }` declaration → creates a Function layer, places
   body nodes inside it, creates boundary pins from params/returns, and wires `return` values.
+- `@cache({ namespace: "...", ttlSeconds: 3600, scope: "user" })` immediately above a function
+  configures its result cache; bare `@cache` uses the `global` namespace, a 300-second lifetime,
+  and app scope. Set `ttlSeconds: 0` explicitly for a permanent entry. A hit skips the entire
+  function body and its side effects, so cache only input-determined functions.
+- Existing context may report `ttl_seconds: null` for a permanent cache. Preserve that as
+  explicit `ttlSeconds: 0`; omission on newly authored cache settings means 300 seconds.
 
 RULES:
 - PRESERVE every `//@n:<id>` anchor comment on statements you keep, exactly as given.
@@ -3483,7 +3493,7 @@ impl Tool for WriteFlowScriptTool {
     async fn definition(&self, _prompt: String) -> ToolDefinition {
         ToolDefinition {
             name: Self::NAME.to_string(),
-            description: "Start a retained code-first FlowScript draft. Write the complete source document; the host binds it to the immutable user request, parses it into internal BoardAst, returns structured source diagnostics, and preserves the exact text for inline preview and later patches. When a retained draft already exists for this same request (a follow-up repair run), do NOT start a new draft: reuse the SAME draft_id and exact expected_revision and repair it in place. Function returns accept node outputs, params, literals, and mutable `let` bindings (one return value per declared return pin). A `let` reassigned across if/for promotes to a board variable with its initializer preserved; never reassign a `const` inside a branch arm — declare it with `let`. Catalog-related diagnostics automatically include exact live signatures or bounded candidates in fix.catalog_declarations and structural context in fix.companion_declarations; use those before another lookup. Defaults to additive scope. Use replace mode only for an intentional complete-board document."
+            description: "Start a retained code-first FlowScript draft. Write the complete source document; the host binds it to the immutable user request, parses it into internal BoardAst, returns structured source diagnostics, and preserves the exact text for inline preview and later patches. When a retained draft already exists for this same request (a follow-up repair run), do NOT start a new draft: reuse the SAME draft_id and exact expected_revision and repair it in place. Preserve existing function cache decorators. To cache an input-determined function, place `@cache({ namespace: \"...\", ttlSeconds: 3600, scope: \"user\" })` immediately above it; bare `@cache` defaults to the `global` namespace, 300 seconds, and app scope, while `ttlSeconds: 0` is permanent. A cache hit skips the entire body and all side effects. Function returns accept node outputs, params, literals, and mutable `let` bindings (one return value per declared return pin). A `let` reassigned across if/for promotes to a board variable with its initializer preserved; never reassign a `const` inside a branch arm — declare it with `let`. Catalog-related diagnostics automatically include exact live signatures or bounded candidates in fix.catalog_declarations and structural context in fix.companion_declarations; use those before another lookup. Defaults to additive scope. Use replace mode only for an intentional complete-board document."
                 .to_string(),
             parameters: serde_json::to_value(schema_for!(WriteFlowScriptArgs))
                 .unwrap_or_else(|_| json!({ "type": "object" })),
@@ -3515,7 +3525,7 @@ impl Tool for PatchFlowScriptTool {
     async fn definition(&self, _prompt: String) -> ToolDefinition {
         ToolDefinition {
             name: Self::NAME.to_string(),
-            description: "Patch one exact, uniquely occurring text range in a retained FlowScript draft using revision compare-and-swap. This is the way to resume a retained draft in a follow-up repair run: keep its SAME draft_id and exact expected_revision instead of rewriting from scratch. The full updated source and structured diagnostics are returned inline. Function returns accept node outputs, params, literals, and mutable `let` bindings; a `let` reassigned across if/for promotes to a board variable — never reassign a `const` inside a branch arm. Catalog-related diagnostics automatically include repair signatures in fix.catalog_declarations and structural context in fix.companion_declarations; use those before another lookup. Ambiguous, stale, replayed, or scope-collapsing patches do not mutate the draft."
+            description: "Patch one exact, uniquely occurring text range in a retained FlowScript draft using revision compare-and-swap. This is the way to resume a retained draft in a follow-up repair run: keep its SAME draft_id and exact expected_revision instead of rewriting from scratch. The full updated source and structured diagnostics are returned inline. Preserve an existing function `@cache` decorator during unrelated repairs; the canonical configured form is `@cache({ namespace: \"...\", ttlSeconds: 3600, scope: \"user\" })`. Bare `@cache` defaults to the `global` namespace, 300 seconds, and app scope; `ttlSeconds: 0` is permanent. A cache hit skips the body and its side effects. Function returns accept node outputs, params, literals, and mutable `let` bindings; a `let` reassigned across if/for promotes to a board variable — never reassign a `const` inside a branch arm. Catalog-related diagnostics automatically include repair signatures in fix.catalog_declarations and structural context in fix.companion_declarations; use those before another lookup. Ambiguous, stale, replayed, or scope-collapsing patches do not mutate the draft."
                 .to_string(),
             parameters: serde_json::to_value(schema_for!(PatchFlowScriptArgs))
                 .unwrap_or_else(|_| json!({ "type": "object" })),
@@ -3630,14 +3640,30 @@ pub fn build_list_board_nodes_output(graph_context: &GraphContext) -> String {
         lines.push(format!("\nLayers ({}):", graph_context.layers.len()));
         for layer in &graph_context.layers {
             let parent = layer.parent_id.as_deref().unwrap_or("root");
+            let cache = layer.cache.as_ref().map_or_else(String::new, |cache| {
+                let ttl = cache
+                    .ttl_seconds
+                    .filter(|seconds| *seconds > 0)
+                    .map(|seconds| format!("{seconds}s"))
+                    .unwrap_or_else(|| "no-expiry".to_string());
+                format!(
+                    " | cache:{} namespace:{:?} ttl:{} scope:{}",
+                    if cache.enabled { "on" } else { "off" },
+                    cache.namespace,
+                    ttl,
+                    cache.scope,
+                )
+            });
             lines.push(format!(
-                "- {} | {} | parent:{} | nodes:{} | pos:({},{})",
+                "- {} | {} | type:{} | parent:{} | nodes:{} | pos:({},{}){}",
                 layer.id,
                 layer.name,
+                layer.layer_type,
                 parent,
                 layer.node_ids.len(),
                 layer.position.0,
                 layer.position.1,
+                cache,
             ));
         }
     }
@@ -3979,6 +4005,125 @@ mod tests {
                 })
                 .collect()
         }
+    }
+
+    #[tokio::test]
+    async fn active_flowscript_tools_document_function_cache_decorators() {
+        let board = Arc::new(Board::new_detached(
+            Some("cache-tool-docs".to_string()),
+            flow_like_storage::Path::default(),
+        ));
+        let provider: Arc<dyn CatalogProvider> = Arc::new(BatchDispatchProvider::default());
+        let store = Arc::new(FlowIrDraftStore::new());
+        let acceptance_binding =
+            store.bind_request_acceptance_contract(&board.id, "cache calculatePricing");
+
+        let current_description = GetCurrentFlowScriptTool {
+            board: board.clone(),
+        }
+        .definition(String::new())
+        .await
+        .description;
+        let write_description = WriteFlowScriptTool {
+            board: board.clone(),
+            provider: provider.clone(),
+            store: store.clone(),
+            acceptance_binding: acceptance_binding.clone(),
+        }
+        .definition(String::new())
+        .await
+        .description;
+        let patch_description = PatchFlowScriptTool {
+            board,
+            provider,
+            store,
+            acceptance_binding,
+        }
+        .definition(String::new())
+        .await
+        .description;
+
+        for description in [
+            current_description.as_str(),
+            write_description.as_str(),
+            patch_description.as_str(),
+        ] {
+            assert!(description.contains("@cache"));
+            assert!(description.contains("namespace"));
+            assert!(description.contains("ttlSeconds"));
+            assert!(description.contains("scope"));
+            assert!(description.contains("global"));
+            assert!(description.contains("300"));
+            assert!(description.contains("ttlSeconds: 0"));
+        }
+        assert!(current_description.contains("ttl_seconds: null"));
+        assert!(write_description.contains("skips the entire body and all side effects"));
+    }
+
+    #[test]
+    fn board_listing_exposes_default_function_cache_settings() {
+        use super::super::context::{LayerCacheContext, LayerContext};
+
+        let graph = GraphContext {
+            nodes: vec![],
+            edges: vec![],
+            layers: vec![LayerContext {
+                id: "pricing-layer".to_string(),
+                name: "calculatePricing".to_string(),
+                layer_type: "Function".to_string(),
+                parent_id: None,
+                node_ids: vec![],
+                position: (10, 20),
+                inputs: vec![],
+                outputs: vec![],
+                cache: Some(LayerCacheContext {
+                    enabled: true,
+                    namespace: "global".to_string(),
+                    ttl_seconds: Some(300),
+                    scope: "app".to_string(),
+                }),
+            }],
+            variables: vec![],
+            selected_nodes: vec![],
+        };
+
+        let listing = build_list_board_nodes_output(&graph);
+        assert!(listing.contains("cache:on"));
+        assert!(listing.contains("namespace:\"global\""));
+        assert!(listing.contains("ttl:300s"));
+        assert!(listing.contains("scope:app"));
+    }
+
+    #[test]
+    fn board_listing_reports_zero_cache_ttl_as_no_expiry() {
+        use super::super::context::{LayerCacheContext, LayerContext};
+
+        let graph = GraphContext {
+            nodes: vec![],
+            edges: vec![],
+            layers: vec![LayerContext {
+                id: "pricing-layer".to_string(),
+                name: "calculatePricing".to_string(),
+                layer_type: "Function".to_string(),
+                parent_id: None,
+                node_ids: vec![],
+                position: (10, 20),
+                inputs: vec![],
+                outputs: vec![],
+                cache: Some(LayerCacheContext {
+                    enabled: true,
+                    namespace: "pricing".to_string(),
+                    ttl_seconds: Some(0),
+                    scope: "app".to_string(),
+                }),
+            }],
+            variables: vec![],
+            selected_nodes: vec![],
+        };
+
+        let listing = build_list_board_nodes_output(&graph);
+        assert!(listing.contains("ttl:no-expiry"));
+        assert!(!listing.contains("ttl:0s"));
     }
 
     #[test]

--- a/packages/core/src/flow/copilot/typed_ir_parse.rs
+++ b/packages/core/src/flow/copilot/typed_ir_parse.rs
@@ -137,5 +137,13 @@ mod tests {
             payload["canonical_example"]["type_object"]["data_type"],
             "string"
         );
+        assert_eq!(
+            payload["canonical_example"]["function_cache"]["namespace"],
+            "global"
+        );
+        assert_eq!(
+            payload["canonical_example"]["function_cache"]["ttl_seconds"],
+            300
+        );
     }
 }

--- a/packages/core/src/flow/copilot/types.rs
+++ b/packages/core/src/flow/copilot/types.rs
@@ -462,6 +462,20 @@ pub enum BoardCommand {
         /// Parent layer ID. If None, creates at root or current layer.
         #[serde(default)]
         target_layer: Option<String>,
+        /// Optional result-cache configuration. FlowScript function declarations populate this
+        /// when creating a cached Function layer.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cache: Option<crate::flow::board::LayerCache>,
+        #[serde(default)]
+        summary: Option<String>,
+    },
+    /// Replace (or remove) the result-cache configuration on an existing layer. `None` removes
+    /// caching; an active [`LayerCache`](crate::flow::board::LayerCache) enables it.
+    UpdateLayerCache {
+        layer_id: String,
+        /// `null` removes cache metadata; kept in serialized commands so removal is explicit.
+        #[serde(default)]
+        cache: Option<crate::flow::board::LayerCache>,
         #[serde(default)]
         summary: Option<String>,
     },
@@ -470,4 +484,35 @@ pub enum BoardCommand {
         #[serde(default)]
         summary: Option<String>,
     },
+}
+
+#[cfg(test)]
+mod cache_command_tests {
+    use super::BoardCommand;
+
+    #[test]
+    fn update_layer_cache_removal_serializes_as_explicit_null_and_round_trips() {
+        let command = BoardCommand::UpdateLayerCache {
+            layer_id: "cached-function".to_string(),
+            cache: None,
+            summary: Some("Disable function cache".to_string()),
+        };
+
+        let value = serde_json::to_value(&command).expect("serialize cache removal command");
+        assert_eq!(value["command_type"], "UpdateLayerCache");
+        assert_eq!(value["layer_id"], "cached-function");
+        assert!(value.get("cache").is_some());
+        assert!(value["cache"].is_null());
+
+        let decoded: BoardCommand =
+            serde_json::from_value(value).expect("deserialize cache removal command");
+        assert!(matches!(
+            decoded,
+            BoardCommand::UpdateLayerCache {
+                layer_id,
+                cache: None,
+                ..
+            } if layer_id == "cached-function"
+        ));
+    }
 }

--- a/packages/core/src/flow/copilot/validation.rs
+++ b/packages/core/src/flow/copilot/validation.rs
@@ -117,6 +117,7 @@ pub fn validate_model_facing_emit_commands_scope(args: &EmitCommandsArgs) -> Emi
                     BoardCommand::CreateVariable { .. } => "CreateVariable",
                     BoardCommand::UpdateVariable { .. } => "UpdateVariable",
                     BoardCommand::RemoveVariable { .. } => "DeleteVariable",
+                    BoardCommand::UpdateLayerCache { .. } => "UpdateLayerCache",
                 };
 
                 Some(issue(
@@ -191,6 +192,12 @@ pub async fn validate_emit_commands(
     let mut known_layer_refs: HashSet<String> = graph_context
         .layers
         .iter()
+        .flat_map(|layer| [layer.id.clone(), layer.name.clone()])
+        .collect();
+    let mut function_layer_refs: HashSet<String> = graph_context
+        .layers
+        .iter()
+        .filter(|layer| layer.layer_type.eq_ignore_ascii_case("function"))
         .flat_map(|layer| [layer.id.clone(), layer.name.clone()])
         .collect();
     let known_variables: HashSet<String> = graph_context
@@ -723,6 +730,7 @@ pub async fn validate_emit_commands(
                 pins,
                 position,
                 target_layer,
+                cache,
                 summary,
                 ..
             } => {
@@ -760,6 +768,19 @@ pub async fn validate_emit_commands(
                 }
                 validate_target_layer(index, target_layer, &known_layer_refs, &mut errors);
                 validate_placeholder_pins(index, pins.as_deref(), &mut errors);
+                if cache.is_some()
+                    && !matches!(layer_type.as_deref(), Some("Function") | Some("function"))
+                {
+                    errors.push(issue(
+                        "error",
+                        "cache-requires-function-layer",
+                        Some(index),
+                        format!(
+                            "CreateLayer '{}' can only configure cache when layer_type is Function",
+                            name
+                        ),
+                    ));
+                }
 
                 let key = ref_id
                     .clone()
@@ -776,7 +797,10 @@ pub async fn validate_emit_commands(
                     known_layer_refs.insert(key.clone());
                     known_layer_refs.insert(name.clone());
                     layer_display.insert(key.clone(), name.clone());
-                    if matches!(layer_type.as_deref(), Some("Function")) {
+                    if matches!(layer_type.as_deref(), Some(kind) if kind.eq_ignore_ascii_case("function"))
+                    {
+                        function_layer_refs.insert(key.clone());
+                        function_layer_refs.insert(name.clone());
                         entities_to_check.insert(key);
                     }
                 }
@@ -788,6 +812,33 @@ pub async fn validate_emit_commands(
                         "unknown-layer",
                         Some(index),
                         format!("Cannot remove unknown layer '{}'", layer_id),
+                    ));
+                }
+            }
+            BoardCommand::UpdateLayerCache {
+                layer_id, summary, ..
+            } => {
+                if !known_layer_refs.contains(layer_id) {
+                    errors.push(issue(
+                        "error",
+                        "unknown-layer",
+                        Some(index),
+                        format!("Cannot update cache on unknown layer '{}'", layer_id),
+                    ));
+                } else if !function_layer_refs.contains(layer_id) {
+                    errors.push(issue(
+                        "error",
+                        "cache-requires-function-layer",
+                        Some(index),
+                        format!("Cannot update cache on non-Function layer '{}'", layer_id),
+                    ));
+                }
+                if summary.as_deref().unwrap_or_default().trim().is_empty() {
+                    warnings.push(issue(
+                        "warning",
+                        "missing-summary",
+                        Some(index),
+                        format!("UpdateLayerCache '{}' is missing a summary field", layer_id),
                     ));
                 }
             }
@@ -1499,6 +1550,93 @@ fn issue(
 mod tests {
     use super::*;
 
+    struct EmptyCatalogProvider;
+
+    #[flow_like_types::async_trait]
+    impl CatalogProvider for EmptyCatalogProvider {
+        async fn search(&self, _query: &str) -> Vec<super::super::types::NodeMetadata> {
+            Vec::new()
+        }
+
+        async fn search_by_pin_type(
+            &self,
+            _pin_type: &str,
+            _is_input: bool,
+        ) -> Vec<super::super::types::NodeMetadata> {
+            Vec::new()
+        }
+
+        async fn filter_by_category(
+            &self,
+            _category_prefix: &str,
+        ) -> Vec<super::super::types::NodeMetadata> {
+            Vec::new()
+        }
+
+        async fn get_node_metadata(
+            &self,
+            _node_type: &str,
+        ) -> Option<super::super::types::NodeMetadata> {
+            None
+        }
+
+        async fn get_all_nodes(&self) -> Vec<String> {
+            Vec::new()
+        }
+    }
+
+    fn layer_context(
+        id: &str,
+        name: &str,
+        layer_type: &str,
+    ) -> super::super::context::LayerContext {
+        super::super::context::LayerContext {
+            id: id.to_string(),
+            name: name.to_string(),
+            layer_type: layer_type.to_string(),
+            parent_id: None,
+            node_ids: Vec::new(),
+            position: (0, 0),
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+            cache: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn cache_update_preflight_requires_a_function_layer() {
+        let context = GraphContext {
+            nodes: Vec::new(),
+            edges: Vec::new(),
+            layers: vec![
+                layer_context("function-layer", "Lookup", "Function"),
+                layer_context("group-layer", "Group", "Collapsed"),
+            ],
+            variables: Vec::new(),
+            selected_nodes: Vec::new(),
+        };
+        let commands = |layer_id: &str| EmitCommandsArgs {
+            commands: vec![BoardCommand::UpdateLayerCache {
+                layer_id: layer_id.to_string(),
+                cache: None,
+                summary: Some("Disable cache".to_string()),
+            }],
+            explanation: "Update function caching".to_string(),
+        };
+
+        let valid =
+            validate_emit_commands(&commands("function-layer"), &context, &EmptyCatalogProvider)
+                .await;
+        assert!(valid.errors.is_empty(), "{:?}", valid.errors);
+
+        let invalid =
+            validate_emit_commands(&commands("group-layer"), &context, &EmptyCatalogProvider).await;
+        assert!(invalid.errors.iter().any(|issue| {
+            issue.code == "cache-requires-function-layer"
+                && issue.message.contains("non-Function layer")
+        }));
+    }
+
     #[test]
     fn model_facing_emit_scope_requires_flowscript_for_executable_commands() {
         let args = EmitCommandsArgs {
@@ -1583,6 +1721,7 @@ mod tests {
                 position: None,
                 color: None,
                 target_layer: None,
+                cache: None,
                 summary: Some("Create helper".to_string()),
             }],
             explanation: "Create function structure".to_string(),

--- a/packages/core/src/flow/execution.rs
+++ b/packages/core/src/flow/execution.rs
@@ -1870,12 +1870,33 @@ impl InternalRun {
             .push_node_log(node_id, operation_id, message, LogLevel::Error);
     }
 
+    /// Records a best-effort operation warning after the originating node context has
+    /// finished. Unlike an error returned from a completion callback, this does not fail
+    /// the run.
+    pub async fn log_node_warning(
+        &self,
+        node_id: &str,
+        operation_id: Option<String>,
+        message: &str,
+    ) {
+        if LogLevel::Warn >= self.log_level {
+            self.run
+                .lock()
+                .await
+                .push_node_log(node_id, operation_id, message, LogLevel::Warn);
+        }
+    }
+
     /// Runs every completion callback and reports whether any failed.
     ///
-    /// Callbacks are cloned out of the registry before awaiting them so a
-    /// callback cannot deadlock by interacting with the registry itself.
+    /// Callbacks belong to one execution. Drain them before awaiting so a
+    /// callback cannot deadlock by interacting with the registry itself and
+    /// forked runs do not retain already-completed hooks.
     async fn trigger_completion_callbacks(&self) -> bool {
-        let callbacks = self.completion_callbacks.read().await.clone();
+        let callbacks = {
+            let mut callbacks = self.completion_callbacks.write().await;
+            std::mem::take(&mut *callbacks)
+        };
         let mut failed = false;
         for callback in callbacks {
             if let Err(err) = callback(self).await {
@@ -2266,6 +2287,10 @@ mod tests {
         run.execute(state).await;
 
         assert!(matches!(run.get_status().await, RunStatus::Failed));
+        assert!(
+            run.completion_callbacks.read().await.is_empty(),
+            "completion callbacks must not leak into a forked execution"
+        );
         let traces = run.get_traces().await;
         assert_eq!(traces.len(), 1);
         assert_eq!(traces[0].node_id.as_ref(), "writer-node");

--- a/packages/ui/components/chat-history/chat-history-list.test.tsx
+++ b/packages/ui/components/chat-history/chat-history-list.test.tsx
@@ -1,0 +1,155 @@
+import { afterAll, describe, expect, mock, test } from "bun:test";
+import { Window } from "happy-dom";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import type { IHistoryEntry } from "./chat-history-types";
+
+// The `lib` barrel imports back into components, so a direct unit import of the list re-enters this
+// module graph. Stub the one helper the component actually uses.
+mock.module("../../lib/utils", () => ({
+	cn: (...classes: unknown[]) => classes.filter(Boolean).join(" "),
+}));
+
+afterAll(() => mock.restore());
+
+const NOW = Date.now();
+
+const ENTRIES: IHistoryEntry[] = [
+	{ id: "a", title: "Deploy the pipeline", updatedAt: NOW - 1000 },
+	{ id: "b", title: "Quarterly cost report", updatedAt: NOW - 3 * 86_400_000 },
+	{
+		id: "c",
+		title: "Pinned onboarding notes",
+		updatedAt: NOW - 400 * 86_400_000,
+		pinnedAt: NOW - 5000,
+	},
+];
+
+async function renderList(
+	props: Partial<
+		Parameters<typeof import("./chat-history-list").ChatHistoryList>[0]
+	> = {},
+) {
+	const window = new Window();
+	// happy-dom's Window does not carry the error constructors its own selector parser reaches for,
+	// so querying inside this harness throws unless they are patched in.
+	Object.assign(window, { SyntaxError, TypeError, Error });
+	Object.assign(globalThis, {
+		document: window.document,
+		HTMLElement: window.HTMLElement,
+		HTMLInputElement: window.HTMLInputElement,
+		Node: window.Node,
+		Event: window.Event,
+		navigator: window.navigator,
+		requestAnimationFrame: window.requestAnimationFrame.bind(window),
+		cancelAnimationFrame: window.cancelAnimationFrame.bind(window),
+		getComputedStyle: window.getComputedStyle.bind(window),
+		window,
+	});
+	Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
+	const { ChatHistoryList } = await import("./chat-history-list");
+	const container = window.document.createElement("div");
+	window.document.body.append(container);
+	const root = createRoot(container);
+
+	await act(async () => {
+		root.render(
+			<ChatHistoryList entries={ENTRIES} onSelect={() => {}} {...props} />,
+		);
+	});
+
+	const typeSearch = async (value: string) => {
+		const input = container.getElementsByTagName("input")[0];
+		if (!input) throw new Error("search input not rendered");
+		// React's synthetic `input` → `onChange` bridge does not fire under a bare happy-dom Window,
+		// so invoke the handler React actually mounted on the node. Same code path the real
+		// keystroke takes, minus the event plumbing.
+		const propsKey = Object.keys(input).find((key) =>
+			key.startsWith("__reactProps$"),
+		);
+		const onChange = propsKey
+			? (
+					input as unknown as Record<
+						string,
+						{ onChange?: (e: unknown) => void }
+					>
+				)[propsKey]?.onChange
+			: undefined;
+		if (!onChange) throw new Error("search input has no React onChange");
+
+		await act(async () => {
+			onChange({ target: { value } });
+		});
+		// The query is debounced before it reaches the index.
+		await act(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 260));
+		});
+	};
+
+	const cleanup = async () => {
+		await act(async () => root.unmount());
+		window.close();
+	};
+
+	return { container, typeSearch, cleanup };
+}
+
+describe("ChatHistoryList", () => {
+	test("groups pinned conversations first, out of their date bucket", async () => {
+		const { container, cleanup } = await renderList();
+		const headings = [...container.querySelectorAll("h3")].map(
+			(h) => h.textContent?.replace(/\d+$/, "").trim() ?? "",
+		);
+
+		expect(headings[0]).toBe("Pinned");
+		expect(headings).toContain("Today");
+		// The pinned entry is 400 days old but must not also appear under "Older".
+		expect(headings).not.toContain("Older");
+		expect(container.querySelectorAll("li").length).toBe(3);
+
+		await cleanup();
+	});
+
+	test("shows the no-match empty state when a search returns nothing", async () => {
+		const { container, typeSearch, cleanup } = await renderList();
+		await typeSearch("zzzzqqq");
+
+		expect(container.querySelectorAll("li").length).toBe(0);
+		// Regression: an always-present "Results" group made this state unreachable, leaving the
+		// user staring at a bare "RESULTS 0" header with no way out.
+		expect(container.textContent).toContain("No matches");
+		expect(container.textContent).toContain("Clear search");
+
+		await cleanup();
+	});
+
+	test("ranks matches and drops non-matching conversations", async () => {
+		const { container, typeSearch, cleanup } = await renderList();
+		await typeSearch("cost");
+
+		const titles = [...container.querySelectorAll("li")].map(
+			(row) => row.textContent ?? "",
+		);
+		expect(titles.length).toBe(1);
+		expect(titles[0]).toContain("Quarterly cost report");
+
+		await cleanup();
+	});
+
+	test("reports search activity so callers can defer loading message bodies", async () => {
+		const seen: boolean[] = [];
+		const { typeSearch, cleanup } = await renderList({
+			onSearchActiveChange: (active) => seen.push(active),
+		});
+
+		expect(seen).toEqual([false]);
+		await typeSearch("de");
+		expect(seen.at(-1)).toBe(true);
+
+		// Unmounting mid-search must release it, or the caller keeps a live Dexie subscription for
+		// the rest of the session.
+		await cleanup();
+		expect(seen.at(-1)).toBe(false);
+	});
+});

--- a/packages/ui/components/chat-history/chat-history-list.tsx
+++ b/packages/ui/components/chat-history/chat-history-list.tsx
@@ -1,0 +1,252 @@
+"use client";
+
+import {
+	MessageSquareIcon,
+	PinIcon,
+	SearchIcon,
+	SquarePenIcon,
+	XIcon,
+} from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { cn } from "../../lib/utils";
+import { Button } from "../ui/button";
+import { Input } from "../ui/input";
+import { Skeleton } from "../ui/skeleton";
+import { ChatHistoryRow } from "./chat-history-row";
+import type { IChatHistoryListProps } from "./chat-history-types";
+import { groupHistoryByDate } from "./group-history";
+import { useHistorySearch } from "./use-history-search";
+
+function HistorySkeleton() {
+	return (
+		<div className="space-y-1 p-1.5" aria-hidden>
+			{[0, 1, 2, 3].map((row) => (
+				<div key={row} className="flex items-center gap-2.5 px-2.5 py-2">
+					<Skeleton className="size-7 shrink-0 rounded-md" />
+					<div className="flex-1 space-y-1.5">
+						<Skeleton
+							className="h-3.5 rounded"
+							style={{ width: `${70 - row * 8}%` }}
+						/>
+						<Skeleton className="h-2.5 w-16 rounded" />
+					</div>
+				</div>
+			))}
+		</div>
+	);
+}
+
+/**
+ * Presentational conversation history: search, pinned + date sections, and per-row pin / rename /
+ * delete. Deliberately owns no data access — every surface (global chat, per-app chat, FlowPilot)
+ * normalizes its own store into `IHistoryEntry[]` and passes the mutations it supports.
+ */
+export function ChatHistoryList({
+	entries,
+	activeId,
+	onSelect,
+	onNew,
+	onTogglePin,
+	onRename,
+	onDelete,
+	searchPlaceholder = "Search conversations…",
+	density = "compact",
+	header,
+	emptyTitle = "No conversations yet",
+	emptyDescription = "Start a chat and it will show up here.",
+	onSearchActiveChange,
+	onRenamingChange,
+	className,
+}: Readonly<IChatHistoryListProps>) {
+	const [query, setQuery] = useState("");
+	const [renamingId, setRenamingId] = useState<string | null>(null);
+	const comfortable = density === "comfortable";
+	const { results, appliedQuery, bodySearchEnabled } = useHistorySearch(
+		entries,
+		query,
+	);
+
+	// Held in refs so an inline callback at the call site cannot turn these into per-render churn.
+	const notifySearch = useRef(onSearchActiveChange);
+	notifySearch.current = onSearchActiveChange;
+	const notifyRenaming = useRef(onRenamingChange);
+	notifyRenaming.current = onRenamingChange;
+
+	// Message bodies are only worth loading once the user is actually searching. Callers subscribe
+	// here so they can keep that (potentially large) Dexie read out of the idle render.
+	useEffect(() => {
+		notifySearch.current?.(bodySearchEnabled);
+	}, [bodySearchEnabled]);
+
+	useEffect(() => {
+		notifyRenaming.current?.(renamingId !== null);
+	}, [renamingId]);
+
+	// Reset both on unmount: the list is unmounted by its host (a Popover/Sheet closing) while the
+	// host itself stays mounted, so a flag left latched here would keep a Dexie subscription — and
+	// the host's Escape guard — alive for the rest of the session.
+	useEffect(
+		() => () => {
+			notifySearch.current?.(false);
+			notifyRenaming.current?.(false);
+		},
+		[],
+	);
+
+	const groups = useMemo(
+		// Search results are relevance-ranked, so date sections would scatter the best match down
+		// the list. While searching, show one flat ranked list instead — and no group at all when
+		// nothing matched, so the caller-visible empty state is what renders.
+		() =>
+			appliedQuery
+				? results.length > 0
+					? [{ key: "results", label: "Results", entries: results }]
+					: []
+				: groupHistoryByDate(results),
+		[appliedQuery, results],
+	);
+
+	const handleSelect = useCallback(
+		(id: string) => {
+			setQuery("");
+			setRenamingId(null);
+			return onSelect(id);
+		},
+		[onSelect],
+	);
+
+	const loading = entries === undefined;
+	// Keyed off "has any history at all", never off the result count — hiding the field as soon as
+	// a query narrows the list would trap the user with no way to edit what they typed.
+	const showSearch = loading || (entries?.length ?? 0) > 0;
+
+	return (
+		<div className={cn("flex min-h-0 flex-col", className)}>
+			<div className="shrink-0 border-b border-border/50 p-1.5">
+				<div className="flex items-center gap-1.5">
+					{showSearch && (
+						<div className="relative min-w-0 flex-1">
+							<SearchIcon className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+							<Input
+								value={query}
+								onChange={(event) => setQuery(event.target.value)}
+								placeholder={searchPlaceholder}
+								aria-label="Search conversations"
+								// 16px on mobile is mandatory: anything smaller makes iOS Safari zoom the
+								// viewport on focus and the surface never zooms back out.
+								className={cn(
+									"rounded-lg border-border/50 bg-muted/40 pl-8 pr-8 text-[16px] md:text-sm",
+									comfortable ? "h-11" : "h-9 md:h-8",
+								)}
+							/>
+							{query && (
+								<Button
+									variant="ghost"
+									size="icon"
+									className="absolute right-1 top-1/2 size-6 -translate-y-1/2 rounded-md text-muted-foreground"
+									aria-label="Clear search"
+									onClick={() => setQuery("")}
+								>
+									<XIcon className="size-3.5" />
+								</Button>
+							)}
+						</div>
+					)}
+					{onNew && (
+						<Button
+							variant="outline"
+							size="icon"
+							onClick={onNew}
+							aria-label="New chat"
+							className={cn(
+								"shrink-0 rounded-lg",
+								comfortable ? "size-11" : "size-9 md:size-8",
+							)}
+						>
+							<SquarePenIcon className="size-3.5" />
+						</Button>
+					)}
+				</div>
+				{header && (
+					<div className="px-1 pt-1.5 text-[11px] text-muted-foreground">
+						{header}
+					</div>
+				)}
+			</div>
+
+			<div className="min-h-0 flex-1 touch-pan-y overflow-y-auto overscroll-contain">
+				{loading && <HistorySkeleton />}
+
+				{!loading && groups.length === 0 && (
+					<div className="flex flex-col items-center justify-center gap-1 px-6 py-12 text-center">
+						<span className="mb-1 grid size-10 place-items-center rounded-xl border border-border/50 bg-muted/60">
+							<MessageSquareIcon className="size-4 text-muted-foreground" />
+						</span>
+						<p className="text-sm font-medium">
+							{appliedQuery ? "No matches" : emptyTitle}
+						</p>
+						<p className="text-xs text-muted-foreground">
+							{appliedQuery
+								? `Nothing matches “${appliedQuery}”.`
+								: emptyDescription}
+						</p>
+						{appliedQuery ? (
+							<Button
+								variant="ghost"
+								size="sm"
+								className="mt-2 h-8 text-xs"
+								onClick={() => setQuery("")}
+							>
+								Clear search
+							</Button>
+						) : (
+							onNew && (
+								<Button
+									variant="outline"
+									size="sm"
+									className="mt-2 h-8 gap-1.5 text-xs"
+									onClick={onNew}
+								>
+									<SquarePenIcon className="size-3.5" />
+									New chat
+								</Button>
+							)
+						)}
+					</div>
+				)}
+
+				{!loading &&
+					groups.map((group) => (
+						<section key={group.key} className="px-1.5 pb-1 pt-2">
+							<h3 className="flex items-center gap-1.5 px-2 pb-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+								{group.pinned && <PinIcon className="size-3" />}
+								{group.label}
+								<span className="ml-auto tabular-nums opacity-70">
+									{group.entries.length}
+								</span>
+							</h3>
+							<ul className="space-y-0.5">
+								{group.entries.map((entry) => (
+									<ChatHistoryRow
+										key={entry.id}
+										entry={entry}
+										active={entry.id === activeId}
+										query={appliedQuery}
+										comfortable={comfortable}
+										renaming={renamingId === entry.id}
+										onRenamingChange={(next) =>
+											setRenamingId(next ? entry.id : null)
+										}
+										onSelect={handleSelect}
+										onTogglePin={onTogglePin}
+										onRename={onRename}
+										onDelete={onDelete}
+									/>
+								))}
+							</ul>
+						</section>
+					))}
+			</div>
+		</div>
+	);
+}

--- a/packages/ui/components/chat-history/chat-history-row.tsx
+++ b/packages/ui/components/chat-history/chat-history-row.tsx
@@ -1,0 +1,300 @@
+"use client";
+
+import {
+	CheckIcon,
+	MessageSquareIcon,
+	MoreHorizontalIcon,
+	PencilIcon,
+	PinIcon,
+	PinOffIcon,
+	Trash2Icon,
+	XIcon,
+} from "lucide-react";
+import { memo, useCallback, useEffect, useRef, useState } from "react";
+import { cn } from "../../lib/utils";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "../ui/alert-dialog";
+import { Button } from "../ui/button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "../ui/dropdown-menu";
+import { Input } from "../ui/input";
+import { RelativeTime } from "../ui/relative-time";
+import type { IHistoryEntry } from "./chat-history-types";
+import { highlightMatch } from "./highlight-match";
+
+interface ChatHistoryRowProps {
+	entry: IHistoryEntry;
+	active: boolean;
+	query: string;
+	/** Touch surfaces keep the actions visible; pointer surfaces reveal them on hover/focus. */
+	comfortable: boolean;
+	/** Rename state is owned by the list, so only one row can be in rename mode at a time. */
+	renaming: boolean;
+	onRenamingChange: (renaming: boolean) => void;
+	onSelect: (id: string) => void | Promise<void>;
+	onTogglePin?: (id: string, pinned: boolean) => void | Promise<void>;
+	onRename?: (id: string, title: string) => void | Promise<void>;
+	onDelete?: (id: string) => void | Promise<void>;
+}
+
+/**
+ * One conversation row. Memoized because the list re-renders on every keystroke in the search
+ * field, and each row formats two timestamps and runs a regex split.
+ */
+export const ChatHistoryRow = memo(function ChatHistoryRow({
+	entry,
+	active,
+	query,
+	comfortable,
+	renaming,
+	onRenamingChange,
+	onSelect,
+	onTogglePin,
+	onRename,
+	onDelete,
+}: Readonly<ChatHistoryRowProps>) {
+	const [draft, setDraft] = useState(entry.title);
+	const [confirmingDelete, setConfirmingDelete] = useState(false);
+	const inputRef = useRef<HTMLInputElement>(null);
+	const pinned = Boolean(entry.pinnedAt);
+	const Icon = entry.icon ?? MessageSquareIcon;
+
+	// Read through a ref so the seed happens only when rename opens: a title that changes underneath
+	// an open editor must not wipe what the user has typed so far.
+	const titleRef = useRef(entry.title);
+	titleRef.current = entry.title;
+
+	useEffect(() => {
+		if (!renaming) return;
+		setDraft(titleRef.current);
+		// Select-all so the common case (replace the auto-generated title) is a single keystroke.
+		requestAnimationFrame(() => inputRef.current?.select());
+	}, [renaming]);
+
+	const commitRename = useCallback(() => {
+		onRenamingChange(false);
+		const next = draft.trim();
+		if (next && next !== entry.title) void onRename?.(entry.id, next);
+	}, [draft, entry.id, entry.title, onRename, onRenamingChange]);
+
+	const handleRenameKeyDown = useCallback(
+		(event: React.KeyboardEvent<HTMLInputElement>) => {
+			if (event.key === "Enter") {
+				event.preventDefault();
+				commitRename();
+			} else if (event.key === "Escape") {
+				// The host layer's own Escape guard is what stops the surrounding Popover/Sheet from
+				// dismissing; this only ends the rename.
+				event.preventDefault();
+				onRenamingChange(false);
+			}
+		},
+		[commitRename, onRenamingChange],
+	);
+
+	if (renaming) {
+		return (
+			<li className="flex items-center gap-1 rounded-lg bg-muted/50 px-1.5 py-1">
+				<Input
+					ref={inputRef}
+					value={draft}
+					onChange={(event) => setDraft(event.target.value)}
+					onKeyDown={handleRenameKeyDown}
+					onBlur={commitRename}
+					aria-label="Conversation title"
+					className="h-9 flex-1 border-transparent bg-transparent px-1.5 text-[16px] shadow-none focus-visible:ring-1 md:h-7 md:text-sm"
+				/>
+				<Button
+					variant="ghost"
+					size="icon"
+					className="size-8 shrink-0 rounded-md md:size-7"
+					aria-label="Save title"
+					onMouseDown={(event) => event.preventDefault()}
+					onClick={commitRename}
+				>
+					<CheckIcon className="size-3.5" />
+				</Button>
+				<Button
+					variant="ghost"
+					size="icon"
+					className="size-8 shrink-0 rounded-md md:size-7"
+					aria-label="Cancel rename"
+					onMouseDown={(event) => event.preventDefault()}
+					onClick={() => onRenamingChange(false)}
+				>
+					<XIcon className="size-3.5" />
+				</Button>
+			</li>
+		);
+	}
+
+	const actionsVisible = comfortable
+		? "opacity-100"
+		: "opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 data-[state=open]:opacity-100";
+
+	return (
+		<li
+			className={cn(
+				"group relative flex items-center gap-0.5 rounded-lg pr-1 transition-colors",
+				active ? "bg-primary/10" : "hover:bg-muted/50",
+			)}
+		>
+			{active && (
+				<span
+					aria-hidden
+					className="absolute inset-y-2 left-0 w-0.5 rounded-full bg-primary"
+				/>
+			)}
+			<button
+				type="button"
+				onClick={() => void onSelect(entry.id)}
+				className={cn(
+					"flex min-w-0 flex-1 items-center gap-2.5 rounded-lg px-2.5 text-left outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
+					comfortable ? "min-h-12 py-2.5" : "py-2",
+				)}
+			>
+				<span
+					className={cn(
+						"grid size-7 shrink-0 place-items-center rounded-md",
+						active
+							? "bg-primary/20 text-primary"
+							: "bg-muted text-muted-foreground",
+					)}
+				>
+					<Icon className="size-3.5" />
+				</span>
+				<span className="flex min-w-0 flex-1 flex-col">
+					<span className="flex items-center gap-1.5">
+						<span className="truncate text-sm font-medium">
+							{highlightMatch(entry.title, query)}
+						</span>
+						{entry.streaming && (
+							<span
+								aria-label="Responding"
+								className="size-1.5 shrink-0 animate-pulse rounded-full bg-primary"
+							/>
+						)}
+					</span>
+					<span className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+						<RelativeTime value={entry.updatedAt} />
+						{entry.subtitle && (
+							<>
+								<span aria-hidden>·</span>
+								<span className="truncate">{entry.subtitle}</span>
+							</>
+						)}
+					</span>
+				</span>
+			</button>
+
+			{onTogglePin && !comfortable && (
+				<Button
+					variant="ghost"
+					size="icon"
+					className={cn(
+						"size-7 shrink-0 rounded-md text-muted-foreground hover:text-foreground",
+						// A pinned row keeps its toggle visible, or unpinning is undiscoverable.
+						pinned ? "opacity-100" : actionsVisible,
+					)}
+					aria-label={pinned ? "Unpin conversation" : "Pin conversation"}
+					onClick={() => void onTogglePin(entry.id, !pinned)}
+				>
+					{pinned ? (
+						<PinIcon className="size-3.5 fill-current text-primary" />
+					) : (
+						<PinIcon className="size-3.5" />
+					)}
+				</Button>
+			)}
+
+			{(onTogglePin || onRename || onDelete) && (
+				<DropdownMenu>
+					<DropdownMenuTrigger asChild>
+						<Button
+							variant="ghost"
+							size="icon"
+							className={cn(
+								"shrink-0 rounded-md text-muted-foreground hover:text-foreground",
+								comfortable ? "size-9" : "size-7",
+								actionsVisible,
+							)}
+							aria-label="Conversation options"
+						>
+							<MoreHorizontalIcon className="size-3.5" />
+						</Button>
+					</DropdownMenuTrigger>
+					<DropdownMenuContent align="end" className="z-[10002] w-44">
+						{onTogglePin && (
+							<DropdownMenuItem
+								onSelect={() => void onTogglePin(entry.id, !pinned)}
+							>
+								{pinned ? (
+									<PinOffIcon className="size-3.5" />
+								) : (
+									<PinIcon className="size-3.5" />
+								)}
+								{pinned ? "Unpin" : "Pin"}
+							</DropdownMenuItem>
+						)}
+						{onRename && (
+							<DropdownMenuItem onSelect={() => onRenamingChange(true)}>
+								<PencilIcon className="size-3.5" />
+								Rename
+							</DropdownMenuItem>
+						)}
+						{onDelete && (
+							<>
+								<DropdownMenuSeparator />
+								<DropdownMenuItem
+									variant="destructive"
+									onSelect={() => setConfirmingDelete(true)}
+								>
+									<Trash2Icon className="size-3.5" />
+									Delete
+								</DropdownMenuItem>
+							</>
+						)}
+					</DropdownMenuContent>
+				</DropdownMenu>
+			)}
+
+			{onDelete && (
+				<AlertDialog open={confirmingDelete} onOpenChange={setConfirmingDelete}>
+					<AlertDialogContent className="z-[10002]">
+						<AlertDialogHeader>
+							<AlertDialogTitle>Delete this conversation?</AlertDialogTitle>
+							<AlertDialogDescription>
+								“{entry.title}” and all of its messages will be removed from
+								this device. This cannot be undone.
+								{entry.streaming &&
+									" This conversation is still responding — the run will be discarded."}
+							</AlertDialogDescription>
+						</AlertDialogHeader>
+						<AlertDialogFooter>
+							<AlertDialogCancel>Cancel</AlertDialogCancel>
+							<AlertDialogAction
+								className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+								onClick={() => void onDelete(entry.id)}
+							>
+								Delete
+							</AlertDialogAction>
+						</AlertDialogFooter>
+					</AlertDialogContent>
+				</AlertDialog>
+			)}
+		</li>
+	);
+});

--- a/packages/ui/components/chat-history/chat-history-types.ts
+++ b/packages/ui/components/chat-history/chat-history-types.ts
@@ -1,0 +1,68 @@
+import type { LucideIcon } from "lucide-react";
+
+/**
+ * One conversation as the history list renders it. Every backing store — the global chat's Dexie
+ * sessions, the per-app chat sessions, FlowPilot's conversations — normalizes into this shape at
+ * its own call site, so the list itself never touches a database or knows which one it is showing.
+ */
+export interface IHistoryEntry {
+	id: string;
+	title: string;
+	/** Epoch millis. Stores that keep ISO strings convert on the way in. */
+	updatedAt: number;
+	/** Epoch millis the user pinned this; absent means unpinned. */
+	pinnedAt?: number;
+	/** Optional second-line detail, e.g. "12 messages" or a board name. */
+	subtitle?: string;
+	/** Marks a conversation with a live run: shows a pulse and guards destructive actions. */
+	streaming?: boolean;
+	/** Optional leading glyph, e.g. FlowPilot's per-mode icon. */
+	icon?: LucideIcon;
+	/** Full-text body used for search only; never rendered. */
+	searchBody?: string;
+}
+
+/** A date bucket ("Pinned", "Today", …) with the entries that fall in it. */
+export interface IHistoryGroup {
+	key: string;
+	label: string;
+	entries: IHistoryEntry[];
+	pinned?: boolean;
+}
+
+export interface IChatHistoryListProps {
+	/** `undefined` renders the loading skeleton; `[]` renders the empty state. */
+	entries: readonly IHistoryEntry[] | undefined;
+	activeId?: string;
+	onSelect: (id: string) => void | Promise<void>;
+	onNew?: () => void;
+	/**
+	 * Omitting a handler hides that affordance entirely, so a surface that cannot rename or pin
+	 * simply does not pass one — no capability flags to keep in sync.
+	 */
+	onTogglePin?: (id: string, pinned: boolean) => void | Promise<void>;
+	onRename?: (id: string, title: string) => void | Promise<void>;
+	onDelete?: (id: string) => void | Promise<void>;
+	/** Live search text is owned by the list; this only seeds the placeholder. */
+	searchPlaceholder?: string;
+	/**
+	 * `comfortable` keeps row actions permanently visible and enlarges touch targets. Callers pass
+	 * this from `useIsMobile()`; the list never queries the viewport itself.
+	 */
+	density?: "comfortable" | "compact";
+	/** Rendered above the list, e.g. a conversation count. */
+	header?: React.ReactNode;
+	emptyTitle?: string;
+	emptyDescription?: string;
+	/**
+	 * Fires when the user starts / stops searching. Callers use it to load message bodies into
+	 * `searchBody` only while they are needed, instead of on every mount.
+	 */
+	onSearchActiveChange?: (active: boolean) => void;
+	/**
+	 * Fires while a row is being renamed. Hosts that dismiss on Escape (Popover, Sheet) must guard
+	 * that dismissal, or Escape tears the whole surface down instead of cancelling the rename.
+	 */
+	onRenamingChange?: (renaming: boolean) => void;
+	className?: string;
+}

--- a/packages/ui/components/chat-history/group-history.test.ts
+++ b/packages/ui/components/chat-history/group-history.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import type { IHistoryEntry } from "./chat-history-types";
+import { groupHistoryByDate } from "./group-history";
+
+// Fixed reference clock: 2026-08-12T15:00:00 local time.
+const NOW = new Date(2026, 7, 12, 15, 0, 0).getTime();
+const DAY = 24 * 60 * 60 * 1000;
+
+function entry(
+	id: string,
+	updatedAt: number,
+	pinnedAt?: number,
+): IHistoryEntry {
+	return { id, title: id, updatedAt, pinnedAt };
+}
+
+describe("groupHistoryByDate", () => {
+	test("buckets by calendar day, not by elapsed hours", () => {
+		const groups = groupHistoryByDate(
+			[
+				entry("this-morning", new Date(2026, 7, 12, 1, 0).getTime()),
+				entry("late-yesterday", new Date(2026, 7, 11, 23, 30).getTime()),
+			],
+			NOW,
+		);
+
+		// 14h ago is still "Today" and 15.5h ago is already "Yesterday": a pure hours-since-now
+		// split would put both in the same bucket.
+		expect(groups.map((g) => g.label)).toEqual(["Today", "Yesterday"]);
+		expect(groups[0].entries.map((e) => e.id)).toEqual(["this-morning"]);
+		expect(groups[1].entries.map((e) => e.id)).toEqual(["late-yesterday"]);
+	});
+
+	test("orders sections newest-first and covers every window", () => {
+		const groups = groupHistoryByDate(
+			[
+				entry("ancient", NOW - 400 * DAY),
+				entry("month", NOW - 20 * DAY),
+				entry("week", NOW - 3 * DAY),
+				entry("yesterday", NOW - DAY),
+				entry("today", NOW - 60_000),
+			],
+			NOW,
+		);
+
+		expect(groups.map((g) => g.label)).toEqual([
+			"Today",
+			"Yesterday",
+			"Previous 7 days",
+			"Previous 30 days",
+			"Older",
+		]);
+	});
+
+	test("pinned entries lead, leave their date bucket, and sort by pin time", () => {
+		const groups = groupHistoryByDate(
+			[
+				entry("old-pin", NOW - 400 * DAY, NOW - 10 * DAY),
+				entry("today", NOW - 60_000),
+				entry("fresh-pin", NOW - 2 * DAY, NOW - 60_000),
+			],
+			NOW,
+		);
+
+		expect(groups[0].label).toBe("Pinned");
+		expect(groups[0].pinned).toBe(true);
+		expect(groups[0].entries.map((e) => e.id)).toEqual([
+			"fresh-pin",
+			"old-pin",
+		]);
+		// A pinned conversation must appear exactly once, not also under its date.
+		expect(groups.slice(1).flatMap((g) => g.entries.map((e) => e.id))).toEqual([
+			"today",
+		]);
+	});
+
+	test("empty buckets are omitted entirely", () => {
+		expect(groupHistoryByDate([], NOW)).toEqual([]);
+		expect(
+			groupHistoryByDate([entry("today", NOW - 1000)], NOW).map((g) => g.label),
+		).toEqual(["Today"]);
+	});
+});

--- a/packages/ui/components/chat-history/group-history.ts
+++ b/packages/ui/components/chat-history/group-history.ts
@@ -1,0 +1,75 @@
+import type { IHistoryEntry, IHistoryGroup } from "./chat-history-types";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Bucket conversations into pinned + calendar sections.
+ *
+ * Returns an ordered array rather than a keyed object: the render order is part of the contract
+ * (Pinned always first, then newest bucket down), and an object would leave that resting on
+ * `Object.entries` insertion order.
+ *
+ * `now` is injectable so the buckets are testable without freezing the clock.
+ */
+export function groupHistoryByDate(
+	entries: readonly IHistoryEntry[],
+	now: number = Date.now(),
+): IHistoryGroup[] {
+	const reference = new Date(now);
+	const todayStart = new Date(
+		reference.getFullYear(),
+		reference.getMonth(),
+		reference.getDate(),
+	).getTime();
+	const yesterdayStart = todayStart - DAY_MS;
+	const weekStart = todayStart - 7 * DAY_MS;
+	const monthStart = todayStart - 30 * DAY_MS;
+
+	const pinned: IHistoryEntry[] = [];
+	const buckets: Record<string, IHistoryEntry[]> = {
+		today: [],
+		yesterday: [],
+		week: [],
+		month: [],
+		older: [],
+	};
+
+	for (const entry of entries) {
+		if (entry.pinnedAt) {
+			pinned.push(entry);
+			continue;
+		}
+		const at = entry.updatedAt;
+		if (at >= todayStart) buckets.today.push(entry);
+		else if (at >= yesterdayStart) buckets.yesterday.push(entry);
+		else if (at >= weekStart) buckets.week.push(entry);
+		else if (at >= monthStart) buckets.month.push(entry);
+		else buckets.older.push(entry);
+	}
+
+	// Most recently pinned first, so a fresh pin lands where the user is looking.
+	pinned.sort((a, b) => (b.pinnedAt ?? 0) - (a.pinnedAt ?? 0));
+
+	const groups: IHistoryGroup[] = [];
+	if (pinned.length > 0)
+		groups.push({
+			key: "pinned",
+			label: "Pinned",
+			entries: pinned,
+			pinned: true,
+		});
+
+	const dated: [string, string][] = [
+		["today", "Today"],
+		["yesterday", "Yesterday"],
+		["week", "Previous 7 days"],
+		["month", "Previous 30 days"],
+		["older", "Older"],
+	];
+	for (const [key, label] of dated) {
+		const bucket = buckets[key];
+		if (bucket.length > 0) groups.push({ key, label, entries: bucket });
+	}
+
+	return groups;
+}

--- a/packages/ui/components/chat-history/highlight-match.test.tsx
+++ b/packages/ui/components/chat-history/highlight-match.test.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import type { ReactElement } from "react";
+import { highlightMatch } from "./highlight-match";
+
+/** Flatten the rendered nodes into `[plain, {mark}, plain, …]` for assertion. */
+function parts(node: React.ReactNode): string[] {
+	if (typeof node === "string") return [node];
+	if (!Array.isArray(node)) return [];
+	return node.map((part) =>
+		typeof part === "string"
+			? part
+			: `{${(part as ReactElement<{ children: string }>).props.children}}`,
+	);
+}
+
+describe("highlightMatch", () => {
+	test("marks every occurrence, not every other one", () => {
+		// The obvious implementation re-tests each part with a /g regex, whose stateful lastIndex
+		// makes it skip alternating matches. Repeated identical terms catch that.
+		expect(parts(highlightMatch("chat chat chat", "chat"))).toEqual([
+			"",
+			"{chat}",
+			" ",
+			"{chat}",
+			" ",
+			"{chat}",
+			"",
+		]);
+	});
+
+	test("matches case-insensitively and keeps the original casing", () => {
+		expect(parts(highlightMatch("Board Copilot", "board"))).toEqual([
+			"",
+			"{Board}",
+			" Copilot",
+		]);
+	});
+
+	test("highlights each term independently of the order typed", () => {
+		expect(
+			parts(highlightMatch("deploy the pipeline", "pipeline deploy")),
+		).toEqual(["", "{deploy}", " the ", "{pipeline}", ""]);
+	});
+
+	test("treats regex metacharacters as literal text", () => {
+		expect(parts(highlightMatch("cost (v2) report", "(v2)"))).toEqual([
+			"cost ",
+			"{(v2)}",
+			" report",
+		]);
+	});
+
+	test("returns the plain string when there is nothing to mark", () => {
+		expect(highlightMatch("untouched", "")).toBe("untouched");
+		expect(highlightMatch("untouched", "   ")).toBe("untouched");
+		expect(highlightMatch("untouched", "missing")).toBe("untouched");
+	});
+});

--- a/packages/ui/components/chat-history/highlight-match.tsx
+++ b/packages/ui/components/chat-history/highlight-match.tsx
@@ -1,0 +1,43 @@
+import type React from "react";
+
+const ESCAPE_PATTERN = /[.*+?^${}()|[\]\\]/g;
+
+/**
+ * Wrap every occurrence of the query's terms in `text` with a `<mark>`.
+ *
+ * The query is split on whitespace and each term matched independently, so results found by the
+ * (tokenized, prefix-matching) MiniSearch index still highlight when the user typed the words in a
+ * different order than they appear in the title.
+ *
+ * Matching is done positionally against the split result rather than by re-testing each part with
+ * a `/g` regex: `RegExp.test` advances `lastIndex` between calls, which makes the obvious
+ * implementation alternate between highlighting and skipping identical parts.
+ */
+export function highlightMatch(text: string, query: string): React.ReactNode {
+	const terms = query
+		.trim()
+		.split(/\s+/)
+		.filter(Boolean)
+		.map((term) => term.replace(ESCAPE_PATTERN, "\\$&"));
+	if (terms.length === 0) return text;
+
+	const splitter = new RegExp(`(${terms.join("|")})`, "gi");
+	const parts = text.split(splitter);
+	if (parts.length === 1) return text;
+
+	// String.split with one capture group interleaves: [text, match, text, match, …], so the odd
+	// indices are exactly the matches — no re-testing needed.
+	return parts.map((part, index) =>
+		index % 2 === 1 ? (
+			<mark
+				// biome-ignore lint/suspicious/noArrayIndexKey: split output is positional, index is the identity
+				key={index}
+				className="rounded-[3px] bg-primary/20 px-0.5 text-primary"
+			>
+				{part}
+			</mark>
+		) : (
+			part
+		),
+	);
+}

--- a/packages/ui/components/chat-history/index.ts
+++ b/packages/ui/components/chat-history/index.ts
@@ -1,0 +1,14 @@
+export { ChatHistoryList } from "./chat-history-list";
+export { ChatHistoryRow } from "./chat-history-row";
+export type {
+	IChatHistoryListProps,
+	IHistoryEntry,
+	IHistoryGroup,
+} from "./chat-history-types";
+export { groupHistoryByDate } from "./group-history";
+export { highlightMatch } from "./highlight-match";
+export {
+	buildSearchCorpus,
+	MIN_BODY_SEARCH_LENGTH,
+	useHistorySearch,
+} from "./use-history-search";

--- a/packages/ui/components/chat-history/use-history-search.test.ts
+++ b/packages/ui/components/chat-history/use-history-search.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import type { IMessage } from "../interfaces/chat-default/chat-db";
+import { buildSearchCorpus } from "./use-history-search";
+
+function message(
+	sessionId: string,
+	content: IMessage["inner"]["content"],
+	timestamp: number,
+): IMessage {
+	return {
+		id: `${sessionId}-${timestamp}`,
+		appId: "global",
+		sessionId,
+		inner: { role: "user" as IMessage["inner"]["role"], content },
+		files: [],
+		timestamp,
+	};
+}
+
+describe("buildSearchCorpus", () => {
+	test("groups messages per conversation", () => {
+		const corpus = buildSearchCorpus([
+			message("a", "deploy the pipeline", 1),
+			message("b", "unrelated", 2),
+			message("a", "then check the logs", 3),
+		]);
+
+		expect(corpus.get("a")).toBe("then check the logs · deploy the pipeline");
+		expect(corpus.get("b")).toBe("unrelated");
+	});
+
+	test("flattens structured content parts and drops non-text ones", () => {
+		const corpus = buildSearchCorpus([
+			message(
+				"a",
+				[
+					{ type: "text" as never, text: "look at" },
+					{ type: "image_url" as never, image_url: { url: "http://x" } },
+					{ type: "text" as never, text: "this chart" },
+				],
+				1,
+			),
+		]);
+
+		expect(corpus.get("a")).toBe("look at this chart");
+	});
+
+	test("keeps the newest messages and bounds the indexed text", () => {
+		const many = Array.from({ length: 60 }, (_, i) =>
+			message("a", `msg${i}`, i),
+		);
+		const corpus = buildSearchCorpus(many);
+		const text = corpus.get("a") ?? "";
+
+		expect(text.startsWith("msg59 · msg58")).toBe(true);
+		expect(text).not.toContain("msg0 ");
+		expect(text.length).toBeLessThanOrEqual(2000);
+	});
+
+	test("is safe on undefined and empty input", () => {
+		expect(buildSearchCorpus(undefined).size).toBe(0);
+		expect(buildSearchCorpus([]).size).toBe(0);
+	});
+});

--- a/packages/ui/components/chat-history/use-history-search.ts
+++ b/packages/ui/components/chat-history/use-history-search.ts
@@ -1,0 +1,102 @@
+"use client";
+
+import { useDebounce } from "@uidotdev/usehooks";
+import { useMemo } from "react";
+import { useSearch } from "../../hooks/use-search-index";
+import type { IMessage } from "../interfaces/chat-default/chat-db";
+import type { IHistoryEntry } from "./chat-history-types";
+
+/** Below this the query is treated as empty — one or two characters match nearly everything. */
+export const MIN_BODY_SEARCH_LENGTH = 2;
+
+/** Streaming rewrites the same assistant row about once a second; debounce so the index is not. */
+const SEARCH_DEBOUNCE_MS = 200;
+
+/** Bounds on the indexed corpus, so a long conversation cannot blow up the in-memory index. */
+const MAX_MESSAGES_PER_CONVERSATION = 40;
+const MAX_CHARS_PER_CONVERSATION = 2000;
+
+/** Flatten one message's content — it is either a plain string or an array of typed parts. */
+function messageText(message: IMessage): string {
+	const content = message.inner?.content;
+	if (typeof content === "string") return content;
+	if (!Array.isArray(content)) return "";
+	return content
+		.map((part) => (typeof part?.text === "string" ? part.text : ""))
+		.filter(Boolean)
+		.join(" ");
+}
+
+/**
+ * Fold a flat list of messages from many conversations into one bounded text blob per
+ * conversation, newest message first.
+ *
+ * Callers fetch those messages with a single indexed `anyOf(ids)` scan — never one query per
+ * conversation. On desktop every IndexedDB op runs through the SQLite shim at 12–26× native cost,
+ * so an N+1 here would be felt directly.
+ */
+export function buildSearchCorpus(
+	messages: readonly IMessage[] | undefined,
+): Map<string, string> {
+	const corpus = new Map<string, string>();
+	if (!messages) return corpus;
+
+	const bySession = new Map<string, IMessage[]>();
+	for (const message of messages) {
+		const bucket = bySession.get(message.sessionId);
+		if (bucket) bucket.push(message);
+		else bySession.set(message.sessionId, [message]);
+	}
+
+	for (const [sessionId, bucket] of bySession) {
+		const text = bucket
+			.sort((a, b) => b.timestamp - a.timestamp)
+			.slice(0, MAX_MESSAGES_PER_CONVERSATION)
+			.map(messageText)
+			.filter(Boolean)
+			.join(" · ")
+			.slice(0, MAX_CHARS_PER_CONVERSATION);
+		corpus.set(sessionId, text);
+	}
+
+	return corpus;
+}
+
+export interface HistorySearchResult {
+	/** Entries matching the query, or all entries when the query is empty. */
+	results: IHistoryEntry[];
+	/** The query the results actually reflect — use this to drive match highlighting. */
+	appliedQuery: string;
+	/** True once the query is long enough that message bodies should be loaded. */
+	bodySearchEnabled: boolean;
+}
+
+/**
+ * Rank history entries against a query with MiniSearch (prefix + fuzzy, titles boosted over
+ * bodies). An empty query returns the entries untouched and in order.
+ */
+export function useHistorySearch(
+	entries: readonly IHistoryEntry[] | undefined,
+	query: string,
+): HistorySearchResult {
+	const trimmed = query.trim();
+	const debounced = useDebounce(trimmed, SEARCH_DEBOUNCE_MS);
+	const bodySearchEnabled = trimmed.length >= MIN_BODY_SEARCH_LENGTH;
+
+	// `useSearchIndex` only rebuilds on the item list and field config — an `extract` closure over
+	// the corpus would be captured in a ref and silently go stale. So body text has to be part of
+	// the items themselves, which the caller does by filling `searchBody`.
+	const results = useSearch(entries, debounced, {
+		fields: ["title", "searchBody"],
+		boost: { title: 4 },
+	});
+
+	return useMemo(
+		() => ({
+			results: entries ? results : [],
+			appliedQuery: debounced,
+			bodySearchEnabled,
+		}),
+		[entries, results, debounced, bodySearchEnabled],
+	);
+}

--- a/packages/ui/components/flow/flowscript/flowscript-language.test.ts
+++ b/packages/ui/components/flow/flowscript/flowscript-language.test.ts
@@ -38,6 +38,8 @@ interface TestModel {
 
 interface TestCompletionItem {
 	label: string | { label: string };
+	insertText?: string;
+	documentation?: { value: string };
 }
 
 type CompletionCallback = (
@@ -45,8 +47,43 @@ type CompletionCallback = (
 	position: TestPosition,
 ) => { suggestions: TestCompletionItem[] };
 
-function completionLabels(text: string): string[] {
+type HoverCallback = (
+	model: TestModel & {
+		getWordAtPosition: (
+			position: TestPosition,
+		) => { word: string; startColumn: number; endColumn: number } | null;
+		getValueInRange: (range: {
+			startLineNumber: number;
+			startColumn: number;
+			endLineNumber: number;
+			endColumn: number;
+		}) => string;
+	},
+	position: TestPosition,
+) => { contents: { value: string }[] } | null;
+
+function editorPosition(text: string): TestPosition {
+	const lines = text.split("\n");
+	return {
+		lineNumber: lines.length,
+		column: (lines.at(-1) ?? "").length + 1,
+	};
+}
+
+function offsetAt(text: string, position: TestPosition): number {
+	const lines = text.split("\n");
+	return (
+		lines
+			.slice(0, position.lineNumber - 1)
+			.reduce((sum, line) => sum + line.length + 1, 0) +
+		position.column -
+		1
+	);
+}
+
+function registerTestProviders() {
 	let complete: CompletionCallback | undefined;
+	let hover: HoverCallback | undefined;
 	const disposable = { dispose: () => undefined };
 	const monaco = {
 		languages: {
@@ -69,31 +106,102 @@ function completionLabels(text: string): string[] {
 				complete = provider.provideCompletionItems;
 				return disposable;
 			},
-			registerHoverProvider: () => disposable,
+			registerHoverProvider: (
+				_languageId: string,
+				provider: { provideHover: HoverCallback },
+			) => {
+				hover = provider.provideHover;
+				return disposable;
+			},
 			registerSignatureHelpProvider: () => disposable,
 		},
 	} as unknown as Monaco;
 
 	const providers = registerFlowScriptProviders(monaco, () => catalog);
+	return {
+		complete: () => {
+			if (!complete) throw new Error("Completion provider was not registered");
+			return complete;
+		},
+		hover: () => {
+			if (!hover) throw new Error("Hover provider was not registered");
+			return hover;
+		},
+		dispose: providers.dispose,
+	};
+}
+
+function completionItems(text: string): TestCompletionItem[] {
+	const providers = registerTestProviders();
+	const position = editorPosition(text);
+	const complete = providers.complete();
 	if (!complete) throw new Error("Completion provider was not registered");
 	const result = complete(
 		{
 			getValue: () => text,
-			getOffsetAt: () => text.length,
+			getOffsetAt: (at) => offsetAt(text, at),
 			getWordUntilPosition: () => ({
 				word: "",
-				startColumn: 1,
-				endColumn: 1,
+				startColumn: position.column,
+				endColumn: position.column,
 			}),
 		},
-		{ lineNumber: 2, column: 1 },
+		position,
 	);
 	providers.dispose();
-	return result.suggestions.map((suggestion) =>
+	return result.suggestions;
+}
+
+function completionLabels(text: string): string[] {
+	return completionItems(text).map((suggestion) =>
 		typeof suggestion.label === "string"
 			? suggestion.label
 			: suggestion.label.label,
 	);
+}
+
+function hoverMarkdown(
+	text: string,
+	position: TestPosition,
+): string | undefined {
+	const providers = registerTestProviders();
+	const hover = providers.hover();
+	const lines = text.split("\n");
+	const result = hover(
+		{
+			getValue: () => text,
+			getOffsetAt: (at) => offsetAt(text, at),
+			getWordUntilPosition: () => ({
+				word: "",
+				startColumn: position.column,
+				endColumn: position.column,
+			}),
+			getWordAtPosition: (at) => {
+				const line = lines[at.lineNumber - 1] ?? "";
+				let start = Math.max(0, at.column - 1);
+				while (start > 0 && /[A-Za-z0-9_$]/.test(line[start - 1])) start--;
+				let end = Math.max(0, at.column - 1);
+				while (end < line.length && /[A-Za-z0-9_$]/.test(line[end])) end++;
+				return end > start
+					? {
+							word: line.slice(start, end),
+							startColumn: start + 1,
+							endColumn: end + 1,
+						}
+					: null;
+			},
+			getValueInRange: (range) => {
+				if (range.startLineNumber !== range.endLineNumber) return "";
+				return (lines[range.startLineNumber - 1] ?? "").slice(
+					range.startColumn - 1,
+					range.endColumn - 1,
+				);
+			},
+		},
+		position,
+	);
+	providers.dispose();
+	return result?.contents[0]?.value;
 }
 
 describe("canonical FlowScript event headers", () => {
@@ -121,5 +229,62 @@ describe("canonical FlowScript event headers", () => {
 		);
 
 		expect(labels).toContain("wikiExplorerLoad");
+	});
+});
+
+describe("FlowScript function cache editor support", () => {
+	test("offers bare and configured cache decorator snippets", () => {
+		const items = completionItems("@ca");
+		const labels = items.map((item) =>
+			typeof item.label === "string" ? item.label : item.label.label,
+		);
+
+		expect(labels).toEqual(["@cache", "@cache({ … })"]);
+		expect(items[1]?.insertText).toBe(
+			'@cache({ namespace: "${1:global}", ttlSeconds: ${2:300}, scope: "${3|app,user|}" })',
+		);
+	});
+
+	test("offers only missing cache settings inside the decorator", () => {
+		const items = completionItems('@cache({ namespace: "pricing", ');
+		const labels = items.map((item) =>
+			typeof item.label === "string" ? item.label : item.label.label,
+		);
+
+		expect(labels).toEqual(["ttlSeconds", "scope"]);
+		expect(labels).not.toContain("eventsGeneric");
+		expect(items[0]?.insertText).toBe("ttlSeconds: ${1:300}");
+	});
+
+	test("offers canonical app and user scope values", () => {
+		expect(completionLabels('@cache({ scope: "')).toEqual(['"app"', '"user"']);
+	});
+
+	test("documents cache semantics on decorator hover", () => {
+		const markdown = hoverMarkdown("@cache", { lineNumber: 1, column: 3 });
+
+		expect(markdown).toContain("skips the entire function body");
+		expect(markdown).toContain('`"global"` namespace');
+		expect(markdown).toContain("300-second lifetime");
+		expect(markdown).toContain("`ttlSeconds: 0`");
+	});
+
+	test("does not lint the cache decorator as an unknown function", () => {
+		const text = `@cache({ namespace: "pricing" })
+function calculatePricing(): void {
+}`;
+		const { markers } = computeFlowScriptDiagnostics(
+			diagnosticMonaco,
+			text,
+			catalog,
+		);
+
+		expect(markers).toHaveLength(0);
+	});
+
+	test("keeps catalog completions available outside cache settings", () => {
+		expect(completionLabels("function calculatePricing() {\n\t")).toContain(
+			"eventsGeneric",
+		);
 	});
 });

--- a/packages/ui/components/flow/flowscript/flowscript-language.ts
+++ b/packages/ui/components/flow/flowscript/flowscript-language.ts
@@ -1123,6 +1123,82 @@ function buildCallSnippet(info: FlowScriptNodeInfo): string {
 	return `${info.identifier}({ ${params} })`;
 }
 
+const CACHE_DECORATOR_MARKDOWN = `\`\`\`flowscript
+@cache
+@cache({})
+@cache({ namespace: "pricing", ttlSeconds: 0, scope: "user" })
+\`\`\`
+
+Caches a function's outputs by its layer and inputs. A cache hit replays the outputs and skips the entire function body, including side effects.
+
+Bare \`@cache\` and \`@cache({})\` use the \`"global"\` namespace, a 300-second lifetime, and app scope. Set \`ttlSeconds: 0\` explicitly for entries that remain until invalidated. Use user scope for private or user-dependent results. The decorator only applies to \`function\` declarations.`;
+
+const CACHE_FIELD_MARKDOWN: Record<string, string> = {
+	namespace:
+		'`namespace: string` — Groups cache entries for invalidation. Defaults to `"global"`.',
+	ttlSeconds:
+		"`ttlSeconds: int` — Non-negative cache lifetime in seconds. Defaults to `300`; use `0` for no expiry.",
+	scope:
+		'`scope: "app" | "user"` — `app` shares entries across the app; `user` isolates entries by triggering user.',
+};
+
+interface CacheDecoratorContext {
+	existingKeys: string[];
+	mode: "key" | "value";
+	activeField?: string;
+}
+
+/** Detects the cursor inside the settings object of an unfinished `@cache({ ... })`. */
+function analyzeCacheDecoratorContext(
+	maskedBefore: string,
+): CacheDecoratorContext | null {
+	const head = /@cache\s*\(\s*\{/g;
+	let match: RegExpExecArray | null = null;
+	for (
+		let candidate = head.exec(maskedBefore);
+		candidate;
+		candidate = head.exec(maskedBefore)
+	) {
+		match = candidate;
+	}
+	if (!match) return null;
+
+	const body = maskedBefore.slice(match.index + match[0].length);
+	const existingKeys: string[] = [];
+	let depth = 0;
+	let segment = "";
+	const flush = () => {
+		const field = /^\s*([A-Za-z_$][\w$]*)\s*:/.exec(segment);
+		if (field) existingKeys.push(field[1]);
+	};
+
+	for (const ch of body) {
+		if (ch === "{" || ch === "[" || ch === "(") {
+			depth++;
+		} else if (ch === "}" || ch === "]" || ch === ")") {
+			if (depth === 0) return null;
+			depth--;
+		}
+		if (depth === 0 && ch === ",") {
+			flush();
+			segment = "";
+		} else {
+			segment += ch;
+		}
+	}
+
+	const active = /^\s*([A-Za-z_$][\w$]*)\s*:([\s\S]*)$/.exec(segment);
+	if (active) {
+		existingKeys.push(active[1]);
+		return {
+			existingKeys,
+			mode: "value",
+			activeField: active[1],
+		};
+	}
+	return { existingKeys, mode: "key" };
+}
+
 /**
  * Registers completion, hover and signature-help providers for FlowScript, all backed by the
  * live catalog. Returns a single disposable that tears every provider down.
@@ -1134,7 +1210,7 @@ export function registerFlowScriptProviders(
 	const completion = monaco.languages.registerCompletionItemProvider(
 		FLOWSCRIPT_LANGUAGE_ID,
 		{
-			triggerCharacters: [".", "{", ",", " ", ":"],
+			triggerCharacters: [".", "{", ",", " ", ":", "@"],
 			provideCompletionItems: (model, position) => {
 				const index = getFlowScriptIndex(getCatalogNodes());
 				const word = model.getWordUntilPosition(position);
@@ -1147,6 +1223,105 @@ export function registerFlowScriptProviders(
 
 				const maskedFull = maskLiterals(model.getValue());
 				const offset = model.getOffsetAt(position);
+				const maskedBefore = maskedFull.slice(0, offset);
+				const decoratorToken = /@[A-Za-z_]*$/.exec(maskedBefore);
+				if (decoratorToken) {
+					const decoratorRange = {
+						...range,
+						startColumn: position.column - decoratorToken[0].length,
+					};
+					return {
+						suggestions: [
+							{
+								label: "@cache",
+								kind: monaco.languages.CompletionItemKind.Keyword,
+								detail: "Enable function result caching with defaults",
+								documentation: { value: CACHE_DECORATOR_MARKDOWN },
+								insertText: "@cache",
+								range: decoratorRange,
+								sortText: "0_cache_bare",
+							},
+							{
+								label: "@cache({ … })",
+								kind: monaco.languages.CompletionItemKind.Keyword,
+								detail: "Configure function result caching",
+								documentation: { value: CACHE_DECORATOR_MARKDOWN },
+								insertText:
+									'@cache({ namespace: "${1:global}", ttlSeconds: ${2:300}, scope: "${3|app,user|}" })',
+								insertTextRules:
+									monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
+								range: decoratorRange,
+								sortText: "0_cache_configured",
+							},
+						],
+					};
+				}
+
+				const cacheContext = analyzeCacheDecoratorContext(maskedBefore);
+				if (cacheContext?.mode === "value") {
+					if (cacheContext.activeField !== "scope") {
+						return { suggestions: [] };
+					}
+					const quotedValue = /"[^"\n]*$/.exec(
+						model.getValue().slice(0, offset),
+					);
+					const scopeRange = quotedValue
+						? {
+								...range,
+								startColumn: position.column - quotedValue[0].length,
+							}
+						: range;
+					return {
+						suggestions: ["app", "user"].map((scope) => ({
+							label: `"${scope}"`,
+							kind: monaco.languages.CompletionItemKind.EnumMember,
+							detail:
+								scope === "app"
+									? "Shared across the app"
+									: "Isolated by triggering user",
+							insertText: `"${scope}"`,
+							range: scopeRange,
+							sortText: `0_${scope}`,
+						})),
+					};
+				}
+				if (cacheContext?.mode === "key") {
+					const present = new Set(cacheContext.existingKeys);
+					const fields = [
+						{
+							name: "namespace",
+							detail: "string (optional)",
+							insertText: 'namespace: "${1:global}"',
+						},
+						{
+							name: "ttlSeconds",
+							detail: "non-negative integer (optional)",
+							insertText: "ttlSeconds: ${1:300}",
+						},
+						{
+							name: "scope",
+							detail: '"app" | "user" (optional)',
+							insertText: 'scope: "${1|app,user|}"',
+						},
+					];
+					return {
+						suggestions: fields
+							.filter((field) => !present.has(field.name))
+							.map((field) => ({
+								label: field.name,
+								kind: monaco.languages.CompletionItemKind.Field,
+								detail: field.detail,
+								documentation: {
+									value: CACHE_FIELD_MARKDOWN[field.name],
+								},
+								insertText: field.insertText,
+								insertTextRules:
+									monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
+								range,
+								sortText: `0_${field.name}`,
+							})),
+					};
+				}
 
 				// Dot notation → offer members: a node's output pins, or a struct's schema fields
 				// (following variable bindings, explicit outputs and nested $refs).
@@ -1313,6 +1488,28 @@ export function registerFlowScriptProviders(
 				startColumn: word.startColumn,
 				endColumn: word.endColumn,
 			};
+			const value = model.getValue();
+			const wordStartOffset = model.getOffsetAt({
+				lineNumber: position.lineNumber,
+				column: word.startColumn,
+			});
+			if (
+				word.word === "cache" &&
+				value.slice(0, wordStartOffset).endsWith("@")
+			) {
+				return { range, contents: [{ value: CACHE_DECORATOR_MARKDOWN }] };
+			}
+			if (
+				CACHE_FIELD_MARKDOWN[word.word] &&
+				analyzeCacheDecoratorContext(
+					maskLiterals(value.slice(0, wordStartOffset)),
+				)
+			) {
+				return {
+					range,
+					contents: [{ value: CACHE_FIELD_MARKDOWN[word.word] }],
+				};
+			}
 
 			const info = index.byName.get(word.word);
 			if (info) {
@@ -1758,7 +1955,7 @@ export function computeFlowScriptDiagnostics(
 		const name = match[1];
 		const nameStart = match.index;
 		const prev = masked.slice(0, nameStart).trimEnd();
-		if (prev.endsWith(".")) continue; // member access, not a node call
+		if (prev.endsWith(".") || prev.endsWith("@")) continue; // member access/decorator, not a node call
 		if (KEYWORD_SET.has(name)) continue;
 
 		const info = index.byName.get(name);

--- a/packages/ui/components/flowpilot/HistoryPanel.tsx
+++ b/packages/ui/components/flowpilot/HistoryPanel.tsx
@@ -5,21 +5,22 @@ import {
 	ClockIcon,
 	LayoutGridIcon,
 	MessageSquareIcon,
-	PlusIcon,
-	TrashIcon,
 	WorkflowIcon,
 } from "lucide-react";
-import { memo, useCallback, useEffect, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
 
 import { Button } from "../ui/button";
-import { ScrollArea } from "../ui/scroll-area";
-import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
 
+import { useIsMobile } from "../../hooks/use-mobile";
 import {
 	type IFlowPilotConversation,
 	deleteConversation,
 	getRecentConversations,
+	renameConversation,
+	setConversationPinned,
 } from "../../lib/flowpilot-db";
+import { ChatHistoryList } from "../chat-history/chat-history-list";
+import type { IHistoryEntry } from "../chat-history/chat-history-types";
 import type { AgentMode } from "./types";
 
 interface HistoryPanelProps {
@@ -31,33 +32,11 @@ interface HistoryPanelProps {
 	onClose: () => void;
 }
 
-const ModeIcon = memo(function ModeIcon({
-	mode,
-}: { mode: "board" | "ui" | "both" }) {
-	switch (mode) {
-		case "board":
-			return <WorkflowIcon className="h-3 w-3" />;
-		case "ui":
-			return <LayoutGridIcon className="h-3 w-3" />;
-		default:
-			return <MessageSquareIcon className="h-3 w-3" />;
-	}
-});
-
-const formatRelativeTime = (dateString: string): string => {
-	const date = new Date(dateString);
-	const now = new Date();
-	const diffMs = now.getTime() - date.getTime();
-	const diffMins = Math.floor(diffMs / 60000);
-	const diffHours = Math.floor(diffMs / 3600000);
-	const diffDays = Math.floor(diffMs / 86400000);
-
-	if (diffMins < 1) return "Just now";
-	if (diffMins < 60) return `${diffMins}m ago`;
-	if (diffHours < 24) return `${diffHours}h ago`;
-	if (diffDays < 7) return `${diffDays}d ago`;
-	return date.toLocaleDateString();
-};
+const MODE_ICONS = {
+	board: WorkflowIcon,
+	ui: LayoutGridIcon,
+	both: MessageSquareIcon,
+} as const;
 
 export const HistoryPanel = memo(function HistoryPanel({
 	mode,
@@ -67,34 +46,77 @@ export const HistoryPanel = memo(function HistoryPanel({
 	isOpen,
 	onClose,
 }: HistoryPanelProps) {
-	const [conversations, setConversations] = useState<IFlowPilotConversation[]>(
-		[],
-	);
-	const [loading, setLoading] = useState(true);
+	const isMobile = useIsMobile();
+	const [conversations, setConversations] = useState<
+		IFlowPilotConversation[] | undefined
+	>(undefined);
 
 	const loadConversations = useCallback(async () => {
-		setLoading(true);
 		try {
-			const recent = await getRecentConversations(50, mode);
-			setConversations(recent);
+			setConversations(await getRecentConversations(50, mode));
 		} catch (error) {
 			console.error("Failed to load conversations:", error);
-		} finally {
-			setLoading(false);
+			setConversations([]);
 		}
 	}, [mode]);
 
 	useEffect(() => {
-		if (isOpen) {
-			loadConversations();
-		}
+		if (isOpen) void loadConversations();
 	}, [isOpen, loadConversations]);
 
-	const handleDelete = useCallback(async (e: React.MouseEvent, id: string) => {
-		e.stopPropagation();
+	// FlowPilot's conversation store keeps ISO strings; the shared list works in epoch millis.
+	const entries = useMemo<IHistoryEntry[] | undefined>(
+		() =>
+			conversations?.map((conversation) => ({
+				id: conversation.id,
+				title: conversation.title,
+				updatedAt: new Date(conversation.updatedAt).getTime(),
+				pinnedAt: conversation.pinnedAt
+					? new Date(conversation.pinnedAt).getTime()
+					: undefined,
+				subtitle: `${conversation.messageCount} message${
+					conversation.messageCount === 1 ? "" : "s"
+				}`,
+				icon: MODE_ICONS[conversation.mode] ?? MessageSquareIcon,
+			})),
+		[conversations],
+	);
+
+	const handleSelect = useCallback(
+		(id: string) => {
+			const conversation = conversations?.find((entry) => entry.id === id);
+			if (!conversation) return;
+			onSelectConversation(conversation);
+			onClose();
+		},
+		[conversations, onSelectConversation, onClose],
+	);
+
+	const handleNew = useCallback(() => {
+		onNewConversation();
+		onClose();
+	}, [onNewConversation, onClose]);
+
+	const handleTogglePin = useCallback(
+		async (id: string, pinned: boolean) => {
+			await setConversationPinned(id, pinned);
+			await loadConversations();
+		},
+		[loadConversations],
+	);
+
+	const handleRename = useCallback(
+		async (id: string, title: string) => {
+			await renameConversation(id, title);
+			await loadConversations();
+		},
+		[loadConversations],
+	);
+
+	const handleDelete = useCallback(async (id: string) => {
 		try {
 			await deleteConversation(id);
-			setConversations((prev) => prev.filter((c) => c.id !== id));
+			setConversations((prev) => prev?.filter((c) => c.id !== id));
 		} catch (error) {
 			console.error("Failed to delete conversation:", error);
 		}
@@ -108,120 +130,35 @@ export const HistoryPanel = memo(function HistoryPanel({
 				initial={{ opacity: 0, x: -10 }}
 				animate={{ opacity: 1, x: 0 }}
 				exit={{ opacity: 0, x: -10 }}
-				className="absolute inset-0 z-10 bg-background/95 backdrop-blur-sm flex flex-col"
+				className="absolute inset-0 z-10 flex flex-col bg-background/95 backdrop-blur-sm"
 			>
-				{/* Header */}
-				<div className="flex items-center justify-between px-3 py-2 border-b shrink-0">
+				<div className="flex shrink-0 items-center justify-between border-b px-3 py-2">
 					<div className="flex items-center gap-2">
 						<ClockIcon className="h-4 w-4 text-muted-foreground" />
 						<span className="text-sm font-medium">History</span>
 					</div>
-					<div className="flex items-center gap-1">
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<Button
-									size="sm"
-									variant="ghost"
-									className="h-7 w-7 p-0"
-									onClick={() => {
-										onNewConversation();
-										onClose();
-									}}
-								>
-									<PlusIcon className="h-4 w-4" />
-								</Button>
-							</TooltipTrigger>
-							<TooltipContent>New conversation</TooltipContent>
-						</Tooltip>
-						<Button
-							size="sm"
-							variant="ghost"
-							className="h-7 px-2 text-xs"
-							onClick={onClose}
-						>
-							Close
-						</Button>
-					</div>
+					<Button
+						size="sm"
+						variant="ghost"
+						className="h-7 px-2 text-xs"
+						onClick={onClose}
+					>
+						Close
+					</Button>
 				</div>
 
-				{/* Conversations list */}
-				<ScrollArea className="flex-1">
-					<div className="p-2 space-y-1">
-						{loading ? (
-							<div className="flex items-center justify-center py-8">
-								<div className="animate-pulse text-xs text-muted-foreground">
-									Loading...
-								</div>
-							</div>
-						) : conversations.length === 0 ? (
-							<div className="flex flex-col items-center justify-center py-8 text-center">
-								<MessageSquareIcon className="h-8 w-8 text-muted-foreground/50 mb-2" />
-								<p className="text-xs text-muted-foreground">
-									No conversations yet
-								</p>
-								<p className="text-[10px] text-muted-foreground/70 mt-1">
-									Start a new chat to see it here
-								</p>
-							</div>
-						) : (
-							conversations.map((conversation) => (
-								<motion.button
-									key={conversation.id}
-									initial={{ opacity: 0, y: 5 }}
-									animate={{ opacity: 1, y: 0 }}
-									onClick={() => {
-										onSelectConversation(conversation);
-										onClose();
-									}}
-									className={`w-full text-left p-2 rounded-lg transition-colors group ${
-										conversation.id === currentConversationId
-											? "bg-primary/10 border border-primary/20"
-											: "hover:bg-muted/50 border border-transparent"
-									}`}
-								>
-									<div className="flex items-start gap-2">
-										<div
-											className={`p-1 rounded shrink-0 ${
-												conversation.id === currentConversationId
-													? "bg-primary/20 text-primary"
-													: "bg-muted text-muted-foreground"
-											}`}
-										>
-											<ModeIcon mode={conversation.mode} />
-										</div>
-										<div className="flex-1 min-w-0">
-											<div className="flex items-center justify-between gap-2">
-												<span className="text-xs font-medium truncate">
-													{conversation.title}
-												</span>
-												<Button
-													size="sm"
-													variant="ghost"
-													className="h-5 w-5 p-0 opacity-0 group-hover:opacity-100 transition-opacity shrink-0"
-													onClick={(e) => handleDelete(e, conversation.id)}
-												>
-													<TrashIcon className="h-3 w-3 text-muted-foreground hover:text-destructive" />
-												</Button>
-											</div>
-											<div className="flex items-center gap-2 mt-0.5">
-												<span className="text-[10px] text-muted-foreground">
-													{conversation.messageCount} message
-													{conversation.messageCount !== 1 ? "s" : ""}
-												</span>
-												<span className="text-[10px] text-muted-foreground/70">
-													•
-												</span>
-												<span className="text-[10px] text-muted-foreground/70">
-													{formatRelativeTime(conversation.updatedAt)}
-												</span>
-											</div>
-										</div>
-									</div>
-								</motion.button>
-							))
-						)}
-					</div>
-				</ScrollArea>
+				<ChatHistoryList
+					className="min-h-0 flex-1"
+					entries={entries}
+					activeId={currentConversationId}
+					onSelect={handleSelect}
+					onNew={handleNew}
+					onTogglePin={handleTogglePin}
+					onRename={handleRename}
+					onDelete={handleDelete}
+					density={isMobile ? "comfortable" : "compact"}
+					emptyDescription="Start a new chat to see it here."
+				/>
 			</motion.div>
 		</AnimatePresence>
 	);

--- a/packages/ui/components/flowpilot/history-budget.ts
+++ b/packages/ui/components/flowpilot/history-budget.ts
@@ -51,6 +51,8 @@ function summarizeAcceptedWork(messages: CopilotMessage[]): string[] {
 					return "Added workflow comment";
 				case "CreateLayer":
 					return `Created layer ${command.name}`;
+				case "UpdateLayerCache":
+					return `${command.cache?.enabled ? "Configured" : "Disabled"} function cache for ${command.layer_id}`;
 				case "RemoveNode":
 					return `Removed node ${command.node_id}`;
 				default:

--- a/packages/ui/components/flowpilot/utils.tsx
+++ b/packages/ui/components/flowpilot/utils.tsx
@@ -40,6 +40,7 @@ export function getCommandIcon(cmd: BoardCommand, size = "w-4 h-4") {
 		case "DeleteComment":
 			return <MessageSquareIcon className={size} />;
 		case "CreateLayer":
+		case "UpdateLayerCache":
 		case "AddNodesToLayer":
 		case "RemoveNodesFromLayer":
 			return <SquarePenIcon className={size} />;
@@ -63,6 +64,10 @@ export function getCommandSummary(cmd: BoardCommand): string {
 			return `Set ${cmd.pin_id}`;
 		case "MoveNode":
 			return "Move node";
+		case "UpdateLayerCache":
+			return cmd.cache?.enabled
+				? "Configure function cache"
+				: "Disable function cache";
 		default:
 			return cmd.command_type.replace(/([A-Z])/g, " $1").trim();
 	}

--- a/packages/ui/components/global-chat/app-event-interface.test.ts
+++ b/packages/ui/components/global-chat/app-event-interface.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, test } from "bun:test";
+import {
+	activePageEventCandidates,
+	classifyAppEventInterface,
+	consumerToolForEventKind,
+	resolveOpenAppPageEvent,
+	resolveOpenAppPageRequest,
+} from "./app-event-interface";
+
+const event = (
+	overrides: Partial<{
+		id: string;
+		name: string;
+		event_type: string;
+		active: boolean;
+		default_page_id: string | null;
+		route: string | null;
+	}> = {},
+) => ({
+	id: "event-1",
+	name: "Briefing",
+	event_type: "page",
+	active: true,
+	default_page_id: "page-1",
+	route: "/briefing",
+	...overrides,
+});
+
+describe("FlowPilot app interface classification", () => {
+	test("uses one page invariant for inventory and exact opening", () => {
+		const listed = event();
+		expect(classifyAppEventInterface(listed)).toBe("page");
+		expect(activePageEventCandidates([listed])).toEqual([
+			{
+				event_id: "event-1",
+				name: "Briefing",
+				page_id: "page-1",
+				route: "/briefing",
+			},
+		]);
+		expect(resolveOpenAppPageEvent([listed], listed.id)).toEqual({
+			ok: true,
+			event: listed,
+		});
+	});
+
+	test("does not treat a page discriminator without a real target as embeddable", () => {
+		for (const defaultPageId of [null, "", "   ", " page-1 "]) {
+			const broken = event({ default_page_id: defaultPageId });
+			expect(classifyAppEventInterface(broken)).toBe("unavailable");
+			expect(resolveOpenAppPageEvent([broken], broken.id)).toEqual({
+				ok: false,
+				code: "page_target_missing",
+				actual_kind: "unavailable",
+				relist_required: true,
+			});
+		}
+	});
+
+	test("returns one exact callable consumer and none for malformed pages", () => {
+		expect(consumerToolForEventKind("chat")).toBe("call_app_chat");
+		expect(consumerToolForEventKind("page")).toBe("open_app_page");
+		expect(consumerToolForEventKind("headless")).toBe("call_app_event");
+		expect(consumerToolForEventKind("unavailable")).toBeUndefined();
+	});
+
+	test("chat takes precedence over stale page metadata", () => {
+		const chat = event({ event_type: "simple_chat" });
+		expect(classifyAppEventInterface(chat)).toBe("chat");
+		expect(resolveOpenAppPageEvent([chat], chat.id)).toEqual({
+			ok: false,
+			code: "event_interface_changed",
+			actual_kind: "chat",
+			relist_required: true,
+		});
+	});
+
+	test("separates inactive, changed, missing, and no-page outcomes", () => {
+		expect(
+			resolveOpenAppPageEvent([event({ active: false })], "event-1"),
+		).toEqual({
+			ok: false,
+			code: "event_inactive",
+			actual_kind: "page",
+			relist_required: true,
+		});
+		expect(
+			resolveOpenAppPageEvent(
+				[event({ event_type: "quick_action", default_page_id: null })],
+				"event-1",
+			),
+		).toEqual({
+			ok: false,
+			code: "event_interface_changed",
+			actual_kind: "headless",
+			relist_required: true,
+		});
+		expect(resolveOpenAppPageEvent([event()], "missing")).toEqual({
+			ok: false,
+			code: "event_not_found",
+			relist_required: true,
+		});
+		expect(resolveOpenAppPageEvent([], undefined)).toEqual({
+			ok: false,
+			code: "no_page_event",
+			relist_required: false,
+		});
+	});
+
+	test("canonicalizes a page id only when it maps to exactly one active page event", () => {
+		const page = event();
+		expect(resolveOpenAppPageEvent([page], "page-1")).toEqual({
+			ok: true,
+			event: page,
+			canonicalized_from: "page_id",
+		});
+		expect(
+			resolveOpenAppPageEvent(
+				[page, event({ id: "event-2", name: "Duplicate" })],
+				"page-1",
+			),
+		).toEqual({
+			ok: false,
+			code: "event_not_found",
+			relist_required: true,
+		});
+	});
+
+	test("keeps an exact refreshed capability authoritative over a conflicting bulk snapshot", async () => {
+		const exact = event({
+			event_type: "quick_action",
+			default_page_id: null,
+		});
+		const staleBulkCopy = event();
+		const sibling = event({
+			id: "event-2",
+			name: "Overview",
+			default_page_id: "page-2",
+		});
+		const lookup = await resolveOpenAppPageRequest(
+			exact.id,
+			async () => exact,
+			async () => [staleBulkCopy, sibling],
+		);
+		expect(lookup).toEqual({
+			status: "resolved",
+			resolution: {
+				ok: false,
+				code: "event_interface_changed",
+				actual_kind: "headless",
+				relist_required: true,
+			},
+			candidate_events: [sibling],
+		});
+	});
+
+	test("distinguishes an unavailable inventory from an authoritative not-found result", async () => {
+		const unavailable = await resolveOpenAppPageRequest(
+			"missing",
+			async () => {
+				throw new Error("lookup unavailable");
+			},
+			async () => {
+				throw new Error("inventory unavailable");
+			},
+		);
+		expect(unavailable).toEqual({ status: "inventory_unavailable" });
+
+		const notFound = await resolveOpenAppPageRequest(
+			"missing",
+			async () => {
+				throw new Error("not found");
+			},
+			async () => [event()],
+		);
+		expect(notFound).toEqual({
+			status: "resolved",
+			resolution: {
+				ok: false,
+				code: "event_not_found",
+				relist_required: true,
+			},
+			candidate_events: [event()],
+		});
+	});
+});

--- a/packages/ui/components/global-chat/app-event-interface.ts
+++ b/packages/ui/components/global-chat/app-event-interface.ts
@@ -1,0 +1,241 @@
+import { isChatEventType } from "../../lib/event-config";
+
+export type EventInterfaceKind = "chat" | "page" | "headless" | "unavailable";
+
+export type EventConsumerTool =
+	| "call_app_chat"
+	| "open_app_page"
+	| "call_app_event";
+
+export interface AppEventInterfaceRecord {
+	id: string;
+	name?: string | null;
+	event_type: string;
+	active: boolean;
+	default_page_id?: string | null;
+	route?: string | null;
+}
+
+export interface PageEventCandidate {
+	event_id: string;
+	name: string;
+	page_id: string;
+	route?: string;
+}
+
+export type OpenAppPageResolution<T extends AppEventInterfaceRecord> =
+	| {
+			ok: true;
+			event: T;
+			canonicalized_from?: "page_id";
+	  }
+	| {
+			ok: false;
+			code:
+				| "event_not_found"
+				| "event_inactive"
+				| "event_interface_changed"
+				| "page_target_missing"
+				| "no_page_event";
+			actual_kind?: EventInterfaceKind;
+			relist_required: boolean;
+	  };
+
+export type OpenAppPageLookup<T extends AppEventInterfaceRecord> =
+	| {
+			status: "resolved";
+			resolution: OpenAppPageResolution<T>;
+			candidate_events: T[];
+	  }
+	| { status: "inventory_unavailable" };
+
+function nonEmpty(value: string | null | undefined): string | undefined {
+	const trimmed = value?.trim();
+	return trimmed ? trimmed : undefined;
+}
+
+function canonicalPageId(value: string | null | undefined): string | undefined {
+	const trimmed = nonEmpty(value);
+	return trimmed && trimmed === value ? trimmed : undefined;
+}
+
+/** One shared definition for inventory routing and actual interface execution. */
+export function classifyAppEventInterface(
+	event: Pick<AppEventInterfaceRecord, "event_type" | "default_page_id">,
+): EventInterfaceKind {
+	if (isChatEventType(event.event_type)) return "chat";
+	if (canonicalPageId(event.default_page_id)) return "page";
+	if (
+		event.event_type.trim().toLowerCase() === "page" ||
+		nonEmpty(event.default_page_id)
+	) {
+		return "unavailable";
+	}
+	return "headless";
+}
+
+export function consumerToolForEventKind(
+	kind: EventInterfaceKind,
+): EventConsumerTool | undefined {
+	switch (kind) {
+		case "chat":
+			return "call_app_chat";
+		case "page":
+			return "open_app_page";
+		case "headless":
+			return "call_app_event";
+		case "unavailable":
+			return undefined;
+	}
+}
+
+export function activePageEventCandidates<T extends AppEventInterfaceRecord>(
+	events: readonly T[],
+): PageEventCandidate[] {
+	return events.flatMap((event) => {
+		const pageId = canonicalPageId(event.default_page_id);
+		if (
+			!event.active ||
+			!pageId ||
+			classifyAppEventInterface(event) !== "page"
+		) {
+			return [];
+		}
+		const route = nonEmpty(event.route);
+		return [
+			{
+				event_id: event.id,
+				name: nonEmpty(event.name) ?? event.id,
+				page_id: pageId,
+				...(route ? { route } : {}),
+			},
+		];
+	});
+}
+
+/**
+ * Resolve an exact page Event without guessing a sibling. A common event_id/page_id mix-up can be
+ * repaired in-place only when the supplied page id maps uniquely to one active page Event.
+ */
+export function resolveOpenAppPageEvent<T extends AppEventInterfaceRecord>(
+	events: readonly T[],
+	requestedEventId?: string,
+): OpenAppPageResolution<T> {
+	const requested = nonEmpty(requestedEventId);
+	if (!requested) {
+		const first = events.find(
+			(event) => event.active && classifyAppEventInterface(event) === "page",
+		);
+		return first
+			? { ok: true, event: first }
+			: { ok: false, code: "no_page_event", relist_required: false };
+	}
+
+	const exact = events.find((event) => event.id === requested);
+	if (!exact) {
+		const pageIdMatches = events.filter(
+			(event) =>
+				event.active &&
+				classifyAppEventInterface(event) === "page" &&
+				nonEmpty(event.default_page_id) === requested,
+		);
+		if (pageIdMatches.length === 1) {
+			const matchedEvent = pageIdMatches[0];
+			if (!matchedEvent) {
+				return {
+					ok: false,
+					code: "event_not_found",
+					relist_required: true,
+				};
+			}
+			return {
+				ok: true,
+				event: matchedEvent,
+				canonicalized_from: "page_id",
+			};
+		}
+		return {
+			ok: false,
+			code: "event_not_found",
+			relist_required: true,
+		};
+	}
+
+	if (!exact.active) {
+		return {
+			ok: false,
+			code: "event_inactive",
+			actual_kind: classifyAppEventInterface(exact),
+			relist_required: true,
+		};
+	}
+
+	const actualKind = classifyAppEventInterface(exact);
+	if (actualKind !== "page") {
+		return {
+			ok: false,
+			code:
+				actualKind === "unavailable"
+					? "page_target_missing"
+					: "event_interface_changed",
+			actual_kind: actualKind,
+			relist_required: true,
+		};
+	}
+
+	return { ok: true, event: exact };
+}
+
+/**
+ * Resolve one open request against injected Event readers. An exact read is authoritative for an
+ * explicit Event id; a later bulk snapshot may supply alternatives but cannot contradict that
+ * target. Bulk discovery is authoritative only when the exact lookup failed or no id was supplied.
+ */
+export async function resolveOpenAppPageRequest<
+	T extends AppEventInterfaceRecord,
+>(
+	requestedEventId: string | undefined,
+	readExact: (eventId: string) => Promise<T>,
+	readAll: () => Promise<T[]>,
+): Promise<OpenAppPageLookup<T>> {
+	const requested = nonEmpty(requestedEventId);
+	if (requested) {
+		try {
+			const exact = await readExact(requested);
+			const resolution = resolveOpenAppPageEvent([exact], requested);
+			if (resolution.ok) {
+				return { status: "resolved", resolution, candidate_events: [] };
+			}
+			const candidateEvents = await readAll().catch(() => []);
+			return {
+				status: "resolved",
+				resolution,
+				candidate_events: candidateEvents.filter(
+					(candidate) => candidate.id !== exact.id,
+				),
+			};
+		} catch {
+			try {
+				const candidateEvents = await readAll();
+				return {
+					status: "resolved",
+					resolution: resolveOpenAppPageEvent(candidateEvents, requested),
+					candidate_events: candidateEvents,
+				};
+			} catch {
+				return { status: "inventory_unavailable" };
+			}
+		}
+	}
+
+	try {
+		const candidateEvents = await readAll();
+		return {
+			status: "resolved",
+			resolution: resolveOpenAppPageEvent(candidateEvents),
+			candidate_events: candidateEvents,
+		};
+	} catch {
+		return { status: "inventory_unavailable" };
+	}
+}

--- a/packages/ui/components/global-chat/global-chat-body.tsx
+++ b/packages/ui/components/global-chat/global-chat-body.tsx
@@ -683,6 +683,7 @@ export function GlobalChatBody({ variant = "page" }: GlobalChatBodyProps) {
 				responseMessage,
 				agentSelection: turnSelection,
 				label: trimmed,
+				sourceAttachments: [...attachments],
 				inputPreview: {
 					prompt: trimmed,
 					attachments: allFiles.map((file) => ({
@@ -1326,7 +1327,7 @@ export function GlobalChatBody({ variant = "page" }: GlobalChatBodyProps) {
 						</Button>
 					)}
 				</div>
-				<GlobalChatHistory />
+				<GlobalChatHistory className="ml-auto" />
 			</header>
 
 			<div

--- a/packages/ui/components/global-chat/global-chat-history.tsx
+++ b/packages/ui/components/global-chat/global-chat-history.tsx
@@ -1,42 +1,54 @@
 "use client";
 
 import { useLiveQuery } from "dexie-react-hooks";
-import { HistoryIcon, SquarePenIcon, Trash2Icon } from "lucide-react";
-import { useCallback, useState } from "react";
-import {
-	Button,
-	Popover,
-	PopoverContent,
-	PopoverTrigger,
-	Tooltip,
-	TooltipContent,
-	TooltipTrigger,
-} from "../../index";
+import { HistoryIcon, SquarePenIcon } from "lucide-react";
+import { useCallback, useMemo, useState } from "react";
+import { useIsMobile } from "../../hooks/use-mobile";
+import { cn } from "../../lib/utils";
 import {
 	GLOBAL_CHAT_APP_ID,
 	globalChatDb,
 } from "../../state/global-chat/global-chat-db";
 import { useGlobalChatStore } from "../../state/global-chat/global-chat-store";
-import { restoreGlobalChatConversation } from "../../state/global-chat/global-chat-stream";
+import {
+	deleteGlobalChatConversation,
+	renameGlobalChatSession,
+	restoreGlobalChatConversation,
+	setGlobalChatSessionPinned,
+} from "../../state/global-chat/global-chat-stream";
+import { ChatHistoryList } from "../chat-history/chat-history-list";
+import type { IHistoryEntry } from "../chat-history/chat-history-types";
+import { buildSearchCorpus } from "../chat-history/use-history-search";
+import { Button } from "../ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
+import {
+	Sheet,
+	SheetContent,
+	SheetHeader,
+	SheetTitle,
+	SheetTrigger,
+} from "../ui/sheet";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
 
-function relativeTime(timestamp: number): string {
-	const delta = Date.now() - timestamp;
-	const minutes = Math.floor(delta / 60_000);
-	if (minutes < 1) return "just now";
-	if (minutes < 60) return `${minutes}m ago`;
-	const hours = Math.floor(minutes / 60);
-	if (hours < 24) return `${hours}h ago`;
-	const days = Math.floor(hours / 24);
-	if (days < 7) return `${days}d ago`;
-	return new Date(timestamp).toLocaleDateString();
+/** Recency window for unpinned conversations. Pinned rows are fetched separately and never cut. */
+const RECENT_LIMIT = 200;
+
+interface GlobalChatHistoryProps {
+	className?: string;
 }
 
 /**
- * Global chat history: a New-chat action plus a popover listing persisted conversations
- * (from the GlobalChat Dexie DB) with resume and delete.
+ * Global chat history: a New-chat action plus a searchable, pinnable conversation list.
+ *
+ * The list renders in a Popover on pointer devices and a bottom Sheet on touch, since a 320px
+ * popover anchored to a header button is unusable with a thumb.
  */
-export function GlobalChatHistory() {
+export function GlobalChatHistory({
+	className,
+}: Readonly<GlobalChatHistoryProps>) {
 	const [open, setOpen] = useState(false);
+	const isMobile = useIsMobile();
+
 	// Switching chats no longer blocks on a live turn: runs are keyed by run id and keep streaming
 	// (and finalizing into IndexedDB) in whatever conversation they belong to, reappearing in place
 	// when the user comes back.
@@ -44,39 +56,135 @@ export function GlobalChatHistory() {
 		(s) => s.activeConversationId,
 	);
 	const newConversation = useGlobalChatStore((s) => s.newConversation);
+	// A comma-joined key, not the `runs` record: `runs` gets a fresh identity on every streamed
+	// chunk, which would re-derive `entries` and rebuild the whole MiniSearch index per token.
+	// This string only changes when a conversation actually starts or finishes a run.
+	const streamingKey = useGlobalChatStore((s) =>
+		Array.from(new Set(Object.values(s.runs).map((run) => run.conversationId)))
+			.sort()
+			.join(","),
+	);
 
-	const sessions = useLiveQuery(
+	// Two queries rather than one: a single `limit()` would be applied before the appId filter (so
+	// migrated board/ui rows eat slots) and would drop pinned-but-old conversations entirely.
+	const pinnedSessions = useLiveQuery(
+		() => globalChatDb.sessions.where("pinnedAt").above(0).toArray(),
+		[],
+	);
+	const recentSessions = useLiveQuery(
 		() =>
-			globalChatDb.sessions.orderBy("updatedAt").reverse().limit(50).toArray(),
+			globalChatDb.sessions
+				.orderBy("updatedAt")
+				.reverse()
+				.filter((session) => session.appId === GLOBAL_CHAT_APP_ID)
+				.limit(RECENT_LIMIT)
+				.toArray(),
 		[],
 	);
 
+	const sessions = useMemo(() => {
+		if (!pinnedSessions || !recentSessions) return undefined;
+		const pinned = pinnedSessions.filter(
+			(session) => session.appId === GLOBAL_CHAT_APP_ID,
+		);
+		const pinnedIds = new Set(pinned.map((session) => session.id));
+		return [
+			...pinned,
+			...recentSessions.filter((session) => !pinnedIds.has(session.id)),
+		];
+	}, [pinnedSessions, recentSessions]);
+
+	const sessionIds = useMemo(
+		() => (sessions ?? []).map((session) => session.id),
+		[sessions],
+	);
+	const sessionIdKey = sessionIds.join(",");
+
+	// One indexed range scan over every listed conversation, not one query per row — on desktop each
+	// IndexedDB op goes through the SQLite shim, so an N+1 here would be felt directly. Gated on the
+	// user actually searching, so merely opening the panel never pulls every message it has.
+	const [searching, setSearching] = useState(false);
+	const [renaming, setRenaming] = useState(false);
+	const messages = useLiveQuery(
+		() =>
+			searching && sessionIds.length > 0
+				? globalChatDb.messages.where("sessionId").anyOf(sessionIds).toArray()
+				: [],
+		[searching, sessionIdKey],
+	);
+
+	const streamingIds = useMemo(
+		() => new Set(streamingKey ? streamingKey.split(",") : []),
+		[streamingKey],
+	);
+
+	const entries = useMemo<IHistoryEntry[] | undefined>(() => {
+		if (!sessions) return undefined;
+		const corpus = buildSearchCorpus(messages);
+		return sessions.map((session) => ({
+			id: session.id,
+			title: session.summarization || "Untitled conversation",
+			updatedAt: session.updatedAt,
+			pinnedAt: session.pinnedAt,
+			streaming: streamingIds.has(session.id),
+			searchBody: corpus.get(session.id) ?? "",
+		}));
+	}, [sessions, messages, streamingIds]);
+
 	// Shared restore path: settles stale mid-stream checkpoints (no eternal spinners) and
 	// re-attaches runs of this conversation that are still streaming in Rust.
-	const handleResume = useCallback(async (sessionId: string) => {
+	const handleSelect = useCallback(async (sessionId: string) => {
 		await restoreGlobalChatConversation(sessionId);
 		setOpen(false);
 	}, []);
 
-	const handleDelete = useCallback(
-		async (sessionId: string) => {
-			await globalChatDb.messages.where("sessionId").equals(sessionId).delete();
-			await globalChatDb.sessions.delete(sessionId);
-			if (sessionId === useGlobalChatStore.getState().activeConversationId) {
-				newConversation();
-			}
-		},
-		[newConversation],
+	const handleNew = useCallback(() => {
+		newConversation();
+		setOpen(false);
+	}, [newConversation]);
+
+	const list = (
+		<ChatHistoryList
+			entries={entries}
+			activeId={activeConversationId}
+			onSelect={handleSelect}
+			onNew={handleNew}
+			onTogglePin={setGlobalChatSessionPinned}
+			onRename={renameGlobalChatSession}
+			onDelete={deleteGlobalChatConversation}
+			density={isMobile ? "comfortable" : "compact"}
+			onSearchActiveChange={setSearching}
+			onRenamingChange={setRenaming}
+			emptyDescription="Ask FlowPilot something and the conversation shows up here."
+			className={isMobile ? "h-full" : "max-h-[min(70vh,480px)]"}
+		/>
+	);
+
+	// Radix dismisses on Escape from a document capture listener, which fires before the rename
+	// input's own handler — without this the key would tear down the whole surface mid-rename.
+	const guardEscape = (event: KeyboardEvent) => {
+		if (renaming) event.preventDefault();
+	};
+
+	const trigger = (
+		<Button
+			variant="ghost"
+			size="icon"
+			className="h-9 w-9 rounded-lg md:h-8 md:w-8"
+			aria-label="Chat history"
+		>
+			<HistoryIcon className="size-4" />
+		</Button>
 	);
 
 	return (
-		<div className="flex items-center gap-0.5 ml-auto shrink-0">
+		<div className={cn("flex shrink-0 items-center gap-0.5", className)}>
 			<Tooltip>
 				<TooltipTrigger asChild>
 					<Button
 						variant="ghost"
 						size="icon"
-						className="h-9 w-9 md:h-8 md:w-8 rounded-lg"
+						className="h-9 w-9 rounded-lg md:h-8 md:w-8"
 						aria-label="New chat"
 						onClick={newConversation}
 					>
@@ -88,71 +196,44 @@ export function GlobalChatHistory() {
 				</TooltipContent>
 			</Tooltip>
 
-			<Popover open={open} onOpenChange={setOpen}>
-				<Tooltip>
-					<TooltipTrigger asChild>
-						<PopoverTrigger asChild>
-							<Button
-								variant="ghost"
-								size="icon"
-								className="h-9 w-9 md:h-8 md:w-8 rounded-lg"
-								aria-label="Chat history"
-							>
-								<HistoryIcon className="size-4" />
-							</Button>
-						</PopoverTrigger>
-					</TooltipTrigger>
-					<TooltipContent side="bottom" className="text-xs">
-						History
-					</TooltipContent>
-				</Tooltip>
-				<PopoverContent align="end" className="w-80 p-1.5 z-[10000]">
-					<p className="px-2 py-1.5 text-xs font-medium text-muted-foreground">
-						Conversations
-					</p>
-					<div className="max-h-80 overflow-y-auto">
-						{(sessions?.filter((s) => s.appId === GLOBAL_CHAT_APP_ID) ?? [])
-							.length === 0 && (
-							<p className="px-2 py-6 text-center text-sm text-muted-foreground">
-								No conversations yet.
-							</p>
-						)}
-						{sessions
-							?.filter((session) => session.appId === GLOBAL_CHAT_APP_ID)
-							.map((session) => {
-								const active = session.id === activeConversationId;
-								return (
-									<div
-										key={session.id}
-										className={`group flex items-center gap-1 rounded-lg ${active ? "bg-primary/10" : "hover:bg-muted/60"}`}
-									>
-										<button
-											type="button"
-											className="flex-1 min-w-0 px-2 py-2 text-left"
-											onClick={() => void handleResume(session.id)}
-										>
-											<span className="block text-sm truncate">
-												{session.summarization || "Untitled conversation"}
-											</span>
-											<span className="block text-[11px] text-muted-foreground">
-												{relativeTime(session.updatedAt)}
-											</span>
-										</button>
-										<Button
-											variant="ghost"
-											size="icon"
-											className="h-7 w-7 mr-1 rounded-md opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-destructive shrink-0"
-											aria-label="Delete conversation"
-											onClick={() => void handleDelete(session.id)}
-										>
-											<Trash2Icon className="size-3.5" />
-										</Button>
-									</div>
-								);
-							})}
-					</div>
-				</PopoverContent>
-			</Popover>
+			{isMobile ? (
+				<Sheet open={open} onOpenChange={setOpen}>
+					<SheetTrigger asChild>{trigger}</SheetTrigger>
+					{/* The docked chat overlay sits at z-9999, so the Sheet and its backdrop have to
+					    be raised explicitly or they render behind it. */}
+					<SheetContent
+						side="bottom"
+						overlayClassName="z-[10000]"
+						onEscapeKeyDown={guardEscape}
+						className="z-[10001] flex h-[85dvh] max-h-[85dvh] flex-col overflow-hidden rounded-t-2xl p-0"
+					>
+						<SheetHeader className="shrink-0 px-4 pb-0 pt-4">
+							<SheetTitle className="text-base">Conversations</SheetTitle>
+						</SheetHeader>
+						{/* SheetContent wraps children in a flex column; without min-h-0 this never scrolls. */}
+						<div className="flex min-h-0 flex-1 flex-col">{list}</div>
+					</SheetContent>
+				</Sheet>
+			) : (
+				<Popover open={open} onOpenChange={setOpen}>
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<PopoverTrigger asChild>{trigger}</PopoverTrigger>
+						</TooltipTrigger>
+						<TooltipContent side="bottom" className="text-xs">
+							History
+						</TooltipContent>
+					</Tooltip>
+					<PopoverContent
+						align="end"
+						sideOffset={8}
+						onEscapeKeyDown={guardEscape}
+						className="z-[10000] w-[380px] max-w-[calc(100vw-2rem)] overflow-hidden p-0 shadow-floating"
+					>
+						{list}
+					</PopoverContent>
+				</Popover>
+			)}
 		</div>
 	);
 }

--- a/packages/ui/components/global-chat/global-tool-bridge.tsx
+++ b/packages/ui/components/global-chat/global-tool-bridge.tsx
@@ -135,6 +135,12 @@ import type {
 import type { IAttachment, IMessage } from "../interfaces/chat-default/chat-db";
 import { processChatEvents } from "../interfaces/chat-default/event-processor";
 import {
+	activePageEventCandidates,
+	classifyAppEventInterface,
+	consumerToolForEventKind,
+	resolveOpenAppPageRequest,
+} from "./app-event-interface";
+import {
 	pageEventPersistenceReset,
 	resolveAppEventTarget,
 	resolveAppEventType,
@@ -328,6 +334,19 @@ function sourceUserPrompt(request: FrontendToolRequest): string | undefined {
 }
 
 /**
+ * Public research must be bound to the prompt captured by the owning host request. Unlike other
+ * delegated specialists, it may never infer a source from mutable global chat state: concurrent
+ * runs or later user turns could otherwise change the outbound research brief.
+ */
+function sealedSourceUserPrompt(
+	request: FrontendToolRequest,
+): string | undefined {
+	const owned =
+		request.context?.sourceUserPrompt ?? request.context?.source_user_prompt;
+	return owned?.trim() ? owned.trim() : undefined;
+}
+
+/**
  * Conversation id that scopes a delegated run's retained-draft identity. Prefer the id carried by
  * the owning request; fall back to the active conversation (the same source `sourceUserPrompt`
  * falls back to) so nested and follow-up repair runs of one conversation share identity while
@@ -465,18 +484,6 @@ function parseAsk(args: Record<string, unknown>): GlobalToolAsk {
 	};
 }
 
-type EventInterfaceKind = "chat" | "page" | "headless";
-
-/** How an event is consumed: inline chat, embeddable UI page, or headless execution. */
-function classifyEvent(event: {
-	event_type: string;
-	default_page_id?: string | null;
-}): EventInterfaceKind {
-	if (isChatEventType(event.event_type)) return "chat";
-	if (event.default_page_id) return "page";
-	return "headless";
-}
-
 /**
  * The chat run a tool call belongs to.
  *
@@ -514,6 +521,30 @@ export interface RunScope {
 	): void;
 	/** The provider/model/effort pinned by this run, for nested specialists. */
 	turnSelection(): GlobalChatAgentSelection;
+}
+
+interface SolveRoutingState {
+	appInventoryComplete: boolean;
+	sealedResearchUsed: boolean;
+}
+
+// Routing state is host-owned, not model-authored: public fallback is unavailable until a
+// complete local inventory has actually returned, and is one-shot afterwards. Keep it bounded so
+// abandoned run ids cannot accumulate for the lifetime of the desktop process.
+const solveRoutingStateByRun = new Map<string, SolveRoutingState>();
+const MAX_SOLVE_ROUTING_STATES = 256;
+
+function setSolveRoutingState(
+	runId: string | undefined,
+	state: SolveRoutingState,
+) {
+	if (!runId) return;
+	solveRoutingStateByRun.set(runId, state);
+	while (solveRoutingStateByRun.size > MAX_SOLVE_ROUTING_STATES) {
+		const oldest = solveRoutingStateByRun.keys().next().value;
+		if (typeof oldest !== "string") break;
+		solveRoutingStateByRun.delete(oldest);
+	}
 }
 
 function createRunScope(runId: string | undefined): RunScope {
@@ -2024,34 +2055,60 @@ export function GlobalToolBridge() {
 								name: string;
 								description: string;
 								event_type: string;
-								kind: EventInterfaceKind;
+								kind: ReturnType<typeof classifyAppEventInterface>;
+								consumer_tool?: string;
+								interface_error?: "page_target_missing";
+								page_id?: string;
+								route?: string;
 							}> = [];
+							let eventsStatus: "ok" | "error" = "ok";
 							try {
 								const appEvents = await backend.eventState.getEvents(app.id);
 								events = appEvents
 									.filter((event) => event.active)
-									.map((event) => ({
-										id: event.id,
-										name: event.name,
-										description: event.description,
-										event_type: event.event_type,
-										// Tells the agent which tool consumes this interface: open_app_chat /
-										// call_app_chat ("chat"), open_app_page ("page"), call_app_event ("headless").
-										kind: classifyEvent(event),
-									}));
+									.map((event) => {
+										const kind = classifyAppEventInterface(event);
+										const consumerTool = consumerToolForEventKind(kind);
+										const pageId = event.default_page_id?.trim();
+										const route = event.route?.trim();
+										return {
+											id: event.id,
+											name: event.name,
+											description: event.description,
+											event_type: event.event_type,
+											// The consumer and identifiers are explicit so event_id is never confused
+											// with the page record that the Event happens to render.
+											kind,
+											...(consumerTool ? { consumer_tool: consumerTool } : {}),
+											...(kind === "unavailable"
+												? { interface_error: "page_target_missing" as const }
+												: {}),
+											...(kind === "page" && pageId ? { page_id: pageId } : {}),
+											...(route ? { route } : {}),
+										};
+									});
 							} catch {
-								// ignore apps whose events cannot be listed
+								// An unreadable event inventory is not evidence that this app has no
+								// suitable interface. Surface it so the orchestrator cannot turn a
+								// partial catalog into a false "nothing found" web fallback.
+								eventsStatus = "error";
 							}
 							return {
 								app_id: app.id,
 								name: meta?.name ?? app.id,
 								description: meta?.description ?? "",
 								events,
+								events_status: eventsStatus,
 							};
 						}),
 					);
+					const eventInventoryComplete = detailed.every(
+						(app) => app.events_status === "ok",
+					);
+					const inventoryComplete = !truncated && eventInventoryComplete;
 					return {
 						status: "ok",
+						complete: inventoryComplete,
 						total: visible.length,
 						returned: detailed.length,
 						...(truncated
@@ -2106,6 +2163,8 @@ export function GlobalToolBridge() {
 					if (serialized.length > 12_000) {
 						config = { truncated: true, preview: serialized.slice(0, 12_000) };
 					}
+					const kind = classifyAppEventInterface(event);
+					const consumerTool = consumerToolForEventKind(kind);
 					return {
 						status: "ok",
 						event: {
@@ -2113,6 +2172,13 @@ export function GlobalToolBridge() {
 							name: event.name,
 							description: event.description,
 							event_type: event.event_type,
+							kind,
+							...(consumerTool ? { consumer_tool: consumerTool } : {}),
+							...(kind === "unavailable"
+								? { interface_error: "page_target_missing" }
+								: {}),
+							default_page_id: event.default_page_id ?? null,
+							route: event.route ?? null,
 							active: event.active,
 							inputs: event.inputs ?? [],
 						},
@@ -2335,19 +2401,64 @@ export function GlobalToolBridge() {
 						};
 					const eventId =
 						argString(args, "event_id") || argString(args, "eventId");
-					const events = await backend.eventState.getEvents(appId);
-					const isPageEvent = (event: (typeof events)[number]) =>
-						event.active && classifyEvent(event) === "page";
-					const pageEvent = eventId
-						? events.find((event) => event.id === eventId && isPageEvent(event))
-						: events.find(isPageEvent);
-					if (!pageEvent)
+					const inventoryUnavailable = (target?: string) => ({
+						status: "error",
+						code: "event_inventory_unavailable",
+						retryable: false,
+						same_call_retryable: false,
+						relist_required: true,
+						inventory_stale: true,
+						available_page_events: [],
+						message: `Could not refresh app '${appId}' Event metadata${target ? ` to verify Event '${target}'` : ""}, so page availability cannot be established. Do not guess an Event id or route; refresh list_apps once if the goal still requires this interface.`,
+					});
+					// Exact ids use the freshness-reconciled single-Event read. The injected
+					// resolver keeps it authoritative even if a later bulk snapshot drifts.
+					const lookup = await resolveOpenAppPageRequest(
+						eventId,
+						(targetEventId) =>
+							backend.eventState.getEvent(appId, targetEventId),
+						() => backend.eventState.getEvents(appId, true),
+					);
+					if (lookup.status === "inventory_unavailable") {
+						return inventoryUnavailable(eventId);
+					}
+					const resolution = lookup.resolution;
+					const candidateEvents = lookup.candidate_events;
+
+					if (!resolution.ok) {
+						const availablePageEvents =
+							activePageEventCandidates(candidateEvents);
+						const correctConsumer = resolution.actual_kind
+							? consumerToolForEventKind(resolution.actual_kind)
+							: undefined;
+						const message = (() => {
+							switch (resolution.code) {
+								case "event_not_found":
+									return `Event '${eventId}' no longer exists in app '${appId}', or the supplied id is neither an Event id nor a uniquely mapped page id.`;
+								case "event_inactive":
+									return `Event '${eventId}' is currently inactive and cannot be opened.`;
+								case "event_interface_changed":
+									return `Event '${eventId}' is currently '${resolution.actual_kind}', not an embeddable page. Its current interface state supersedes the earlier inventory.`;
+								case "page_target_missing":
+									return `Event '${eventId}' is marked as a page but has no persisted page target, so it cannot be embedded.`;
+								case "no_page_event":
+									return `App '${appId}' currently has no active embeddable page Event.`;
+							}
+						})();
 						return {
 							status: "error",
-							message: eventId
-								? `Event '${eventId}' in app '${appId}' is not an embeddable UI page. Use call_app_event for headless events or open_app_chat for chats.`
-								: `App '${appId}' has no embeddable UI page event.`,
+							code: resolution.code,
+							retryable: false,
+							same_call_retryable: false,
+							relist_required: resolution.relist_required,
+							inventory_stale: resolution.relist_required,
+							actual_kind: resolution.actual_kind,
+							correct_consumer_tool: correctConsumer,
+							available_page_events: availablePageEvents,
+							message: `${message} Do not guess another Event id or route, and do not use navigate_view as a substitute for embedding or page evidence.${resolution.relist_required ? " Refresh list_apps once if the original goal still requires this interface." : ""}`,
 						};
+					}
+					const pageEvent = resolution.event;
 					useGlobalChatStore.getState().addInlineAppPage({
 						appId,
 						eventId: pageEvent.id,
@@ -2417,6 +2528,14 @@ export function GlobalToolBridge() {
 						snapshot.complete && screenshotCount === snapshot.images.length;
 					return {
 						status: "ok",
+						event_id: pageEvent.id,
+						page_id: pageEvent.default_page_id,
+						...(resolution.canonicalized_from
+							? {
+									canonicalized_from: resolution.canonicalized_from,
+									requested_event_id: eventId,
+								}
+							: {}),
 						message:
 							screenshotCount > 0
 								? `Embedded the page '${pageEvent.name}' inline and attached ${screenshotCount} visual capture${screenshotCount === 1 ? "" : "s"} of its rendered content for inspection.`
@@ -3191,23 +3310,43 @@ export function GlobalToolBridge() {
 					}
 				}
 				case "research_agent": {
-					const question = argString(args, "question");
-					if (!question)
+					// This boundary is deliberately sealed. The root model has already seen local app
+					// metadata (and may have recalled memory), so accepting a model-authored question or
+					// context here would let it encode private text into an outbound query. Bind the
+					// researcher only to the immutable top-level user request carried by the host.
+					const routingState = scope.runId
+						? solveRoutingStateByRun.get(scope.runId)
+						: undefined;
+					if (!routingState?.appInventoryComplete)
 						return {
 							status: "error",
-							message: "research_agent requires a question.",
+							code: "local_app_discovery_required",
+							message:
+								"A complete list_apps result is required before sealed public research.",
 						};
-					const researchContext = argString(args, "context");
-					const recency = argString(args, "recency");
+					if (routingState.sealedResearchUsed)
+						return {
+							status: "error",
+							code: "sealed_research_already_used",
+							message:
+								"The sealed public researcher is one-shot for this run; synthesize its findings and disclose remaining gaps.",
+						};
 
-					const briefParts = [`Research question: ${question}`];
-					if (researchContext)
-						briefParts.push(`Background: ${researchContext}`);
-					if (recency) briefParts.push(`Recency requirement: ${recency}`);
-					const instruction = briefParts.join("\n");
+					const owningUserPrompt = sealedSourceUserPrompt(request);
+					if (!owningUserPrompt)
+						return {
+							status: "error",
+							code: "sealed_research_source_missing",
+							message:
+								"The immutable top-level user request is unavailable; sealed public research was not started.",
+						};
+					setSolveRoutingState(scope.runId, {
+						...routingState,
+						sealedResearchUsed: true,
+					});
+					const instruction = owningUserPrompt;
 
 					const turnSelection = scope.turnSelection();
-					const owningUserPrompt = sourceUserPrompt(request);
 					const owningConversationId = conversationScopeId(request);
 					const rawSpecialistPrompt = composeDelegatedRawUserPrompt(
 						owningUserPrompt,
@@ -3268,8 +3407,7 @@ export function GlobalToolBridge() {
 								provider: normalizeAIProvider(turnSelection.provider),
 								model_id: modelId,
 								reasoning_effort: turnSelection.reasoningEffort || undefined,
-								recency: recency || undefined,
-								question,
+								sealed_to_source_request: true,
 							},
 							summary: "Delegated web research started.",
 						}),
@@ -3299,10 +3437,12 @@ export function GlobalToolBridge() {
 							{
 								parentRequestId: request.requestId,
 								conversationId: owningConversationId,
-								runId: scope.runId,
-								// The researcher joins the turn's shared WebResearchSession, which is
-								// keyed on this prompt: parallel researchers then share one citation
-								// ledger and one search budget instead of each getting a fresh one.
+								// Use a sealed child authorization view. It is fresh even when a local
+								// research app already ran, but remains bound to the immutable source
+								// request and cannot receive that app's result.
+								runId: scope.runId
+									? `${scope.runId}:sealed-research`
+									: undefined,
 								sourceUserPrompt: owningUserPrompt,
 							},
 							nestedRunRequestId,
@@ -3312,7 +3452,7 @@ export function GlobalToolBridge() {
 						flushSubRun();
 						return {
 							status: "ok",
-							question,
+							sealed_to_source_request: true,
 							findings: response.message,
 						};
 					} catch (error) {
@@ -6068,22 +6208,19 @@ Completion contract: build complete helper logic first and add the Event entry l
 
 					// Hand the user's attached files to the app chat. The assistant selects which files
 					// via `forward_files` (exact names from the FILES ATTACHED THIS TURN manifest):
-					// omitted → forward all (safe default so a needed file is never silently dropped);
-					// an explicit list forwards only the named files; [] forwards none.
-					const currentTurnFiles = (() => {
-						const msgs = useGlobalChatStore.getState().messages;
-						for (let i = msgs.length - 1; i >= 0; i--) {
-							if (msgs[i]?.inner.role === IRole.User)
-								return msgs[i].files ?? [];
-						}
-						return [];
-					})();
+					// an explicit list forwards only the named files; omitted or [] forwards none.
+					// This fail-closed default prevents an underspecified tool call from disclosing every
+					// attachment to a local app.
+					const currentTurnFiles = scope.runId
+						? (useGlobalChatStore.getState().runs[scope.runId]
+								?.sourceAttachments ?? [])
+						: [];
 					const requestedFileNames = Array.isArray(args.forward_files)
 						? (args.forward_files as unknown[])
 								.filter((value): value is string => typeof value === "string")
 								.map((value) => value.trim().toLowerCase())
 								.filter((value) => value.length > 0)
-						: undefined;
+						: [];
 					const attachmentLabels = (file: IAttachment): string[] => {
 						const raw =
 							typeof file === "string"
@@ -6099,14 +6236,33 @@ Completion contract: build complete helper logic first and add the Event entry l
 						});
 						return withBasenames.map((value) => value.toLowerCase());
 					};
-					const forwardedAttachments =
-						requestedFileNames === undefined
-							? currentTurnFiles
-							: currentTurnFiles.filter((file) =>
-									attachmentLabels(file).some((label) =>
-										requestedFileNames.includes(label),
-									),
-								);
+					const forwardedAttachments: IAttachment[] = [];
+					const selectedIndexes = new Set<number>();
+					for (const requestedName of new Set(requestedFileNames)) {
+						const matches = currentTurnFiles
+							.map((file, index) => ({ file, index }))
+							.filter(({ file }) =>
+								attachmentLabels(file).includes(requestedName),
+							);
+						if (matches.length !== 1) {
+							return {
+								status: "error",
+								code:
+									matches.length === 0
+										? "forward_file_not_found"
+										: "forward_file_name_ambiguous",
+								message:
+									matches.length === 0
+										? `Attachment '${requestedName}' does not belong to this tool call's user turn.`
+										: `Attachment name '${requestedName}' matches more than one file in this user turn. Ask the user to rename or reattach the intended file; no file was forwarded.`,
+							};
+						}
+						const [{ file, index }] = matches;
+						if (!selectedIndexes.has(index)) {
+							selectedIndexes.add(index);
+							forwardedAttachments.push(file);
+						}
+					}
 
 					// Invoke the app's chat event through the SAME pipeline the simple chat uses
 					// (executeEvent + processChatEvents), so it runs with full app-chat behavior.
@@ -6568,6 +6724,25 @@ Completion contract: build complete helper logic first and add the Event entry l
 			if (timeoutId !== undefined) clearTimeout(timeoutId);
 
 			response = { ...response, requestId: request.requestId };
+			if (
+				request.toolName === "list_apps" &&
+				!requestExecutionFenceRef.current.isInvalidated(executionLease) &&
+				response.approved &&
+				!response.error
+			) {
+				const inventory =
+					response.result && typeof response.result === "object"
+						? (response.result as Record<string, unknown>)
+						: undefined;
+				const previousRoutingState = scope.runId
+					? solveRoutingStateByRun.get(scope.runId)
+					: undefined;
+				setSolveRoutingState(scope.runId, {
+					appInventoryComplete:
+						inventory?.status === "ok" && inventory?.complete === true,
+					sealedResearchUsed: previousRoutingState?.sealedResearchUsed ?? false,
+				});
+			}
 			boardRecoveryScopeByRequestRef.current.delete(request.requestId);
 			const resultRecord =
 				response.result && typeof response.result === "object"

--- a/packages/ui/components/index.ts
+++ b/packages/ui/components/index.ts
@@ -24,6 +24,7 @@ export * from "./learn/index";
 export * from "./library/index";
 export * from "./layout/index";
 export * from "./animated-icons/index";
+export * from "./chat-history/index";
 export {
 	FlowPilotBubbleOrb,
 	type FlowPilotBubbleOrbProps,

--- a/packages/ui/components/interfaces/chat-default/chat-db.ts
+++ b/packages/ui/components/interfaces/chat-default/chat-db.ts
@@ -168,6 +168,11 @@ export interface ISession {
 	summarization: string;
 	createdAt: number;
 	updatedAt: number;
+	/**
+	 * Epoch millis the user pinned this conversation; absent means unpinned. A timestamp rather
+	 * than a boolean because booleans are not valid IndexedDB keys.
+	 */
+	pinnedAt?: number;
 }
 
 export interface ILocalChatState {
@@ -195,6 +200,13 @@ const chatDb = new Dexie("Chat-History") as Dexie & {
 // Schema declaration:
 chatDb.version(3).stores({
 	sessions: "id, appId, updatedAt, [updatedAt+appId]",
+	messages: "id, sessionId",
+	localStage: "sessionId, appId, eventId, [sessionId+eventId], timestamp",
+	globalState: "appId, eventId, [appId+eventId]",
+});
+
+chatDb.version(4).stores({
+	sessions: "id, appId, updatedAt, [updatedAt+appId], pinnedAt",
 	messages: "id, sessionId",
 	localStage: "sessionId, appId, eventId, [sessionId+eventId], timestamp",
 	globalState: "appId, eventId, [appId+eventId]",

--- a/packages/ui/components/interfaces/chat-default/history.tsx
+++ b/packages/ui/components/interfaces/chat-default/history.tsx
@@ -2,16 +2,11 @@
 
 import { createId } from "@paralleldrive/cuid2";
 import { useLiveQuery } from "dexie-react-hooks";
-import {
-	CalendarIcon,
-	MessageCircleIcon,
-	SearchIcon,
-	SquarePenIcon,
-	TrashIcon,
-} from "lucide-react";
-import { type RefObject, useCallback, useState } from "react";
-import { useSearch } from "../../../hooks/use-search-index";
-import { Badge, Button, Input } from "../../ui";
+import { type RefObject, useCallback, useMemo, useState } from "react";
+import { useIsMobile } from "../../../hooks/use-mobile";
+import { ChatHistoryList } from "../../chat-history/chat-history-list";
+import type { IHistoryEntry } from "../../chat-history/chat-history-types";
+import { buildSearchCorpus } from "../../chat-history/use-history-search";
 import type { ISidebarActions } from "../interfaces";
 import { chatDb } from "./chat-db";
 
@@ -28,7 +23,7 @@ export function ChatHistory({
 	onSessionChange,
 	sidebarRef,
 }: Readonly<IChatHistory>) {
-	const [searchQuery, setSearchQuery] = useState("");
+	const isMobile = useIsMobile();
 
 	const sessions = useLiveQuery(
 		() =>
@@ -40,241 +35,98 @@ export function ChatHistory({
 		[appId],
 	);
 
-	const matchedSessions = useSearch(sessions, searchQuery, {
-		fields: ["summarization"],
-	});
-	const filteredSessions = sessions ? matchedSessions : undefined;
+	const sessionIds = useMemo(
+		() => (sessions ?? []).map((session) => session.id),
+		[sessions],
+	);
+	const sessionIdKey = sessionIds.join(",");
 
-	const handleNewChat = useCallback(() => {
-		const newSessionId = createId();
-		onSessionChange(newSessionId);
-		if (sidebarRef?.current?.isMobile()) {
-			sidebarRef?.current?.toggleOpen();
-		}
-	}, [onSessionChange]);
-
-	const handleSessionSelect = useCallback(
-		(selectedSessionId: string) => {
-			onSessionChange(selectedSessionId);
-			if (sidebarRef?.current?.isMobile()) {
-				sidebarRef?.current?.toggleOpen();
-			}
-		},
-		[onSessionChange],
+	// One indexed range scan across every listed conversation rather than a query per row, and only
+	// once the user is actually searching — this sidebar is mounted for the whole session, so an
+	// unconditional read would pull the app's entire message history on every mount.
+	const [searching, setSearching] = useState(false);
+	const messages = useLiveQuery(
+		() =>
+			searching && sessionIds.length > 0
+				? chatDb.messages.where("sessionId").anyOf(sessionIds).toArray()
+				: [],
+		[searching, sessionIdKey],
 	);
 
-	const handleDeleteSession = useCallback(
-		async (sessionIdToDelete: string, e: React.MouseEvent) => {
-			e.stopPropagation();
-			await chatDb.messages
-				.where("sessionId")
-				.equals(sessionIdToDelete)
-				.delete();
-			await chatDb.sessions.delete(sessionIdToDelete);
-			await chatDb.localStage
-				.where("sessionId")
-				.equals(sessionIdToDelete)
-				.delete();
+	const entries = useMemo<IHistoryEntry[] | undefined>(() => {
+		if (!sessions) return undefined;
+		const corpus = buildSearchCorpus(messages);
+		return sessions.map((session) => ({
+			id: session.id,
+			title: session.summarization || "New conversation",
+			updatedAt: session.updatedAt,
+			pinnedAt: session.pinnedAt,
+			searchBody: corpus.get(session.id) ?? "",
+		}));
+	}, [sessions, messages]);
 
-			if (sessionIdToDelete === sessionId) {
-				handleNewChat();
-			}
+	const closeMobileSidebar = useCallback(() => {
+		if (sidebarRef?.current?.isMobile()) sidebarRef.current.toggleOpen();
+	}, [sidebarRef]);
+
+	const handleNewChat = useCallback(() => {
+		onSessionChange(createId());
+		closeMobileSidebar();
+	}, [onSessionChange, closeMobileSidebar]);
+
+	const handleSelect = useCallback(
+		(selectedSessionId: string) => {
+			onSessionChange(selectedSessionId);
+			closeMobileSidebar();
+		},
+		[onSessionChange, closeMobileSidebar],
+	);
+
+	const handleTogglePin = useCallback(
+		// A partial update, never a whole-row put: pinning must not bump `updatedAt` or the
+		// conversation jumps into the "Today" group just for being pinned.
+		async (id: string, pinned: boolean) => {
+			await chatDb.sessions.update(id, {
+				pinnedAt: pinned ? Date.now() : undefined,
+			});
+		},
+		[],
+	);
+
+	const handleRename = useCallback(async (id: string, title: string) => {
+		const next = title.trim().slice(0, 80);
+		if (!next) return;
+		await chatDb.sessions.update(id, { summarization: next });
+	}, []);
+
+	const handleDelete = useCallback(
+		async (idToDelete: string) => {
+			await chatDb.messages.where("sessionId").equals(idToDelete).delete();
+			await chatDb.sessions.delete(idToDelete);
+			await chatDb.localStage.where("sessionId").equals(idToDelete).delete();
+			if (idToDelete === sessionId) handleNewChat();
 		},
 		[sessionId, handleNewChat],
 	);
 
-	const formatRelativeTime = (timestamp: number) => {
-		const now = Date.now();
-		const diff = now - timestamp;
-		const minutes = Math.floor(diff / (1000 * 60));
-		const hours = Math.floor(diff / (1000 * 60 * 60));
-		const days = Math.floor(diff / (1000 * 60 * 60 * 24));
-
-		if (minutes < 1) return "Just now";
-		if (minutes < 60) return `${minutes}m ago`;
-		if (hours < 24) return `${hours}h ago`;
-		if (days < 7) return `${days}d ago`;
-		return new Date(timestamp).toLocaleDateString();
-	};
-
-	const groupSessionsByDate = (sessions: typeof filteredSessions) => {
-		if (!sessions) return {};
-
-		const groups: Record<string, typeof sessions> = {};
-		const now = new Date();
-		const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-		const yesterday = new Date(today.getTime() - 24 * 60 * 60 * 1000);
-		const weekAgo = new Date(today.getTime() - 7 * 24 * 60 * 60 * 1000);
-
-		sessions.forEach((session) => {
-			const sessionDate = new Date(session.updatedAt);
-			let groupKey: string;
-
-			if (sessionDate >= today) {
-				groupKey = "Today";
-			} else if (sessionDate >= yesterday) {
-				groupKey = "Yesterday";
-			} else if (sessionDate >= weekAgo) {
-				groupKey = "This Week";
-			} else {
-				groupKey = "Older";
-			}
-
-			if (!groups[groupKey]) groups[groupKey] = [];
-			groups[groupKey].push(session);
-		});
-
-		return groups;
-	};
-
-	const sessionGroups = groupSessionsByDate(filteredSessions);
-
 	return (
-		<div className="flex flex-col h-full flex-grow overflow-hidden max-h-full">
-			<div className="relative border-b border-border/20 bg-background/95 backdrop-blur-md">
-				<div className="p-4">
-					<div className="flex items-center justify-between mb-4">
-						<div className="flex items-center gap-3">
-							<div className="p-2 rounded-lg bg-primary/10 border border-primary/15">
-								<MessageCircleIcon className="w-4 h-4 text-primary" />
-							</div>
-							<div>
-								<h2 className="text-lg font-semibold text-foreground">
-									Chat History
-								</h2>
-								<p className="text-xs text-muted-foreground">
-									{sessions?.length ?? 0} conversation
-									{sessions?.length !== 1 ? "s" : ""}
-								</p>
-							</div>
-						</div>
-						<Button
-							variant="outline"
-							size="sm"
-							onClick={handleNewChat}
-							className="h-8 w-8 p-0 border-border/30 hover:border-primary/30 hover:bg-primary/5"
-						>
-							<SquarePenIcon className="w-3.5 h-3.5" />
-						</Button>
-					</div>
-
-					<div className="relative">
-						<SearchIcon className="absolute left-3 top-1/2 transform -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground/60" />
-						<Input
-							placeholder="Search conversations..."
-							value={searchQuery}
-							onChange={(e) => setSearchQuery(e.target.value)}
-							className="pl-9 pr-3 py-2 h-8 text-sm bg-muted/30 border-border/30 focus:border-primary/40 focus:ring-2 focus:ring-primary/10 rounded-md"
-						/>
-					</div>
-				</div>
-			</div>
-
-			<div className="flex flex-col flex-1 bg-gradient-to-b from-background/50 to-background max-h-full overflow-auto">
-				<div className="p-6 space-y-8 w-full">
-					{Object.entries(sessionGroups).map(([groupName, groupSessions]) => (
-						<div key={groupName} className="space-y-4 w-full">
-							<div className="flex items-center gap-3 px-1 w-full">
-								<div className="p-1.5 rounded-md bg-muted/60 border border-border/40">
-									<CalendarIcon className="w-3.5 h-3.5 text-muted-foreground" />
-								</div>
-								<h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">
-									{groupName}
-								</h3>
-								<div className="flex-1 h-px bg-gradient-to-r from-border/50 to-transparent" />
-								<Badge
-									variant="secondary"
-									className="text-xs px-2.5 py-1 bg-muted/60 text-muted-foreground border border-border/40"
-								>
-									{groupSessions.length}
-								</Badge>
-							</div>
-
-							<div className="space-y-2">
-								{groupSessions.map((session) => (
-									<button
-										key={session.id}
-										className={`
-                                        group w-full relative rounded-lg overflow-hidden transition-all duration-200 cursor-pointer
-                                        ${
-																					session.id === sessionId
-																						? "bg-primary/8 border border-primary/20"
-																						: "hover:bg-muted/40 border border-transparent"
-																				}
-                                    `}
-										onClick={() => handleSessionSelect(session.id)}
-									>
-										<div className="px-4 py-3">
-											<div className="flex items-center justify-start gap-4">
-												<div
-													className={`
-                                                w-2 h-2 rounded-full transition-colors duration-200
-                                                ${
-																									session.id === sessionId
-																										? "bg-primary"
-																										: "bg-muted/80 group-hover:bg-primary"
-																								}
-                                            `}
-												/>
-
-												<div className="flex-1 min-w-0 w-full flex flex-col items-start">
-													<p className="text-sm font-medium text-foreground line-clamp-1 mb-1 text-start">
-														{session.summarization || "New conversation"}
-													</p>
-													<p className="text-xs text-muted-foreground">
-														{formatRelativeTime(session.updatedAt)}
-													</p>
-												</div>
-
-												<Button
-													variant="destructive"
-													size="icon"
-													className="h-7 w-7 opacity-0 group-hover:opacity-100 transition-opacity"
-													onClick={(e) => handleDeleteSession(session.id, e)}
-												>
-													<TrashIcon className="w-3.5 h-3.5" />
-												</Button>
-											</div>
-										</div>
-									</button>
-								))}
-							</div>
-						</div>
-					))}
-
-					{filteredSessions?.length === 0 && (
-						<div className="flex flex-col items-center justify-center py-20 text-center w-full">
-							<div className="relative mb-6">
-								<div className="absolute inset-0 bg-muted/30 rounded-full blur-xl" />
-								<div className="relative p-6 rounded-full bg-gradient-to-br from-muted/60 to-muted/40 border border-border/40 shadow-lg">
-									<MessageCircleIcon className="w-10 h-10 text-muted-foreground/60" />
-								</div>
-							</div>
-							<h3 className="text-lg font-bold text-foreground mb-3">
-								{searchQuery
-									? "No conversations found"
-									: "No conversations yet"}
-							</h3>
-							<p className="text-sm text-muted-foreground/80 max-w-sm leading-relaxed mb-6">
-								{searchQuery
-									? "Try adjusting your search terms to find what you're looking for"
-									: "Start a new conversation and it will appear here for easy access"}
-							</p>
-							{!searchQuery && (
-								<Button
-									variant="default"
-									size="sm"
-									onClick={handleNewChat}
-									className="gap-2 bg-primary hover:bg-primary/90 shadow-lg hover:shadow-xl transition-all duration-300 hover:scale-105"
-								>
-									<SquarePenIcon className="w-4 h-4" />
-									Start Chatting
-								</Button>
-							)}
-						</div>
-					)}
-				</div>
-			</div>
-		</div>
+		<ChatHistoryList
+			className="h-full max-h-full grow"
+			entries={entries}
+			activeId={sessionId}
+			onSelect={handleSelect}
+			onNew={handleNewChat}
+			onTogglePin={handleTogglePin}
+			onRename={handleRename}
+			onDelete={handleDelete}
+			density={isMobile ? "comfortable" : "compact"}
+			onSearchActiveChange={setSearching}
+			header={
+				entries
+					? `${entries.length} conversation${entries.length === 1 ? "" : "s"}`
+					: undefined
+			}
+			emptyDescription="Start a conversation and it will appear here."
+		/>
 	);
 }

--- a/packages/ui/hooks/use-copilot-commands.tsx
+++ b/packages/ui/hooks/use-copilot-commands.tsx
@@ -691,6 +691,15 @@ export function useCopilotCommands({
 			for (const cmd of commands) {
 				if (cmd.command_type === "CreateLayer" && isSetupLayerCommand(cmd)) {
 					const layerId = createId();
+					const layerType = layerTypeFromCommand(cmd.layer_type);
+					if (cmd.cache != null && layerType !== ILayerType.Function) {
+						recordCommandFailure(
+							cmd,
+							"layer creation",
+							`Cannot configure function cache on non-Function layer "${cmd.name}"`,
+						);
+						continue;
+					}
 					const position = cmd.position || {
 						x: baseX + (nodeIndex % 3) * 300,
 						y: baseY + Math.floor(nodeIndex / 3) * 200,
@@ -699,13 +708,14 @@ export function useCopilotCommands({
 					const layer: ILayer = {
 						id: layerId,
 						name: cmd.name,
-						type: layerTypeFromCommand(cmd.layer_type),
+						type: layerType,
 						color: cmd.color || null,
 						coordinates: [position.x, position.y, 0],
 						nodes: {},
 						variables: {},
 						comments: {},
 						pins: pinsFromDefs(cmd.pins, false),
+						cache: cmd.cache ?? null,
 						parent_id: targetLayer,
 					};
 
@@ -1311,6 +1321,15 @@ export function useCopilotCommands({
 							break;
 						}
 						const layerId = createId();
+						const layerType = layerTypeFromCommand(cmd.layer_type);
+						if (cmd.cache != null && layerType !== ILayerType.Function) {
+							recordCommandFailure(
+								cmd,
+								"layer creation",
+								`Cannot configure function cache on non-Function layer "${cmd.name}"`,
+							);
+							break;
+						}
 						const targetLayer =
 							resolveLayerId(cmd.target_layer) ?? currentLayer;
 						const nodeIds = resolveNodeIds(cmd.node_ids || []);
@@ -1319,13 +1338,14 @@ export function useCopilotCommands({
 						const layer: ILayer = {
 							id: layerId,
 							name: cmd.name,
-							type: layerTypeFromCommand(cmd.layer_type),
+							type: layerType,
 							color: cmd.color || null,
 							coordinates: [position.x, position.y, 0],
 							nodes: {},
 							variables: {},
 							comments: {},
 							pins: pinsFromDefs(cmd.pins, false),
+							cache: cmd.cache ?? null,
 							parent_id: targetLayer,
 						};
 
@@ -1344,6 +1364,41 @@ export function useCopilotCommands({
 							[cmd.ref_id, cmd.name, layerId],
 							layerAsNode(layer),
 						);
+						break;
+					}
+
+					case "UpdateLayerCache": {
+						const existingLayer = resolveLayer(cmd.layer_id);
+						if (!existingLayer) {
+							recordCommandFailure(
+								cmd,
+								"board edit",
+								`Cannot update function cache: "${cmd.layer_id}" was not found`,
+							);
+							break;
+						}
+						if (existingLayer.type !== ILayerType.Function) {
+							recordCommandFailure(
+								cmd,
+								"board edit",
+								`Cannot update function cache: "${cmd.layer_id}" is not a Function layer`,
+							);
+							break;
+						}
+
+						const updatedLayer: ILayer = {
+							...existingLayer,
+							cache: cmd.cache ?? null,
+						};
+						remainingGenericCommands.push(
+							upsertLayerCommand({
+								layer: updatedLayer,
+								node_ids: [],
+								current_layer: existingLayer.parent_id ?? null,
+								old_layer: existingLayer,
+							}),
+						);
+						latestBoardLayers[existingLayer.id] = updatedLayer;
 						break;
 					}
 

--- a/packages/ui/lib/flowpilot-db.ts
+++ b/packages/ui/lib/flowpilot-db.ts
@@ -51,6 +51,11 @@ export interface IFlowPilotConversation {
 	messageCount: number;
 	/** When the conversation was created */
 	createdAt: string;
+	/**
+	 * ISO timestamp of when the user pinned this conversation; absent means unpinned. A timestamp
+	 * rather than a boolean because booleans are not valid IndexedDB keys.
+	 */
+	pinnedAt?: string;
 	/** When the conversation was last updated */
 	updatedAt: string;
 }
@@ -65,6 +70,11 @@ const flowpilotDB = new Dexie("FlowPilotHistory") as Dexie & {
 
 flowpilotDB.version(1).stores({
 	conversations: "id, mode, boardId, appId, updatedAt",
+	messages: "id, conversationId, createdAt",
+});
+
+flowpilotDB.version(2).stores({
+	conversations: "id, mode, boardId, appId, updatedAt, pinnedAt",
 	messages: "id, conversationId, createdAt",
 });
 
@@ -113,17 +123,55 @@ export async function deleteConversation(id: string): Promise<void> {
 }
 
 /**
- * Get recent conversations, sorted by updatedAt descending
+ * Get recent conversations, sorted by updatedAt descending.
+ *
+ * Pinned conversations are fetched separately and merged in front, so a pinned-but-old
+ * conversation is never cut by the recency window.
  */
 export async function getRecentConversations(
 	limit = 20,
 	mode?: "board" | "ui" | "both",
 ): Promise<IFlowPilotConversation[]> {
-	let query = flowpilotDB.conversations.orderBy("updatedAt").reverse();
-	if (mode) {
-		query = query.filter((c) => c.mode === mode);
-	}
-	return query.limit(limit).toArray();
+	const matchesMode = (c: IFlowPilotConversation) => !mode || c.mode === mode;
+
+	const pinned = (
+		await flowpilotDB.conversations.where("pinnedAt").above("").toArray()
+	)
+		.filter(matchesMode)
+		.sort((a, b) => (b.pinnedAt ?? "").localeCompare(a.pinnedAt ?? ""));
+
+	const pinnedIds = new Set(pinned.map((c) => c.id));
+	const recent = await flowpilotDB.conversations
+		.orderBy("updatedAt")
+		.reverse()
+		.filter((c) => matchesMode(c) && !pinnedIds.has(c.id))
+		.limit(limit)
+		.toArray();
+
+	return [...pinned, ...recent];
+}
+
+/**
+ * Pin/unpin a conversation. Writes the row directly rather than going through
+ * `updateConversation`, which stamps `updatedAt` — pinning must not reorder history.
+ */
+export async function setConversationPinned(
+	id: string,
+	pinned: boolean,
+): Promise<void> {
+	await flowpilotDB.conversations.update(id, {
+		pinnedAt: pinned ? new Date().toISOString() : undefined,
+	});
+}
+
+/** Rename a conversation without touching `updatedAt`. Empty titles are ignored. */
+export async function renameConversation(
+	id: string,
+	title: string,
+): Promise<void> {
+	const next = title.trim().slice(0, 80);
+	if (!next) return;
+	await flowpilotDB.conversations.update(id, { title: next });
 }
 
 /**

--- a/packages/ui/lib/idb-cleanup.ts
+++ b/packages/ui/lib/idb-cleanup.ts
@@ -26,8 +26,15 @@ const DEFAULTS: Required<CleanupOptions> = {
 
 async function pruneOldChatMessages(maxAgeDays: number): Promise<number> {
 	const cutoff = Date.now() - maxAgeDays * DAY_MS;
+	// A pinned conversation is an explicit "keep this" from the user, so neither its messages nor
+	// its session row may be aged out — otherwise pinning quietly guarantees deletion instead.
+	const pinnedSessionIds = new Set(
+		(await chatDb.sessions.where("pinnedAt").above(0).primaryKeys()).map(
+			String,
+		),
+	);
 	const old = await chatDb.messages
-		.filter((m) => m.timestamp < cutoff)
+		.filter((m) => m.timestamp < cutoff && !pinnedSessionIds.has(m.sessionId))
 		.primaryKeys();
 	if (old.length > 0) await chatDb.messages.bulkDelete(old);
 
@@ -35,6 +42,7 @@ async function pruneOldChatMessages(maxAgeDays: number): Promise<number> {
 	const allSessions = await chatDb.sessions.toArray();
 	const orphanIds: string[] = [];
 	for (const session of allSessions) {
+		if (session.pinnedAt) continue;
 		const count = await chatDb.messages
 			.where("sessionId")
 			.equals(session.id)
@@ -49,7 +57,7 @@ async function pruneOldChatMessages(maxAgeDays: number): Promise<number> {
 async function pruneOldFlowpilotHistory(maxAgeDays: number): Promise<number> {
 	const cutoff = new Date(Date.now() - maxAgeDays * DAY_MS).toISOString();
 	const oldConversations = await flowpilotDB.conversations
-		.filter((c) => c.updatedAt < cutoff)
+		.filter((c) => c.updatedAt < cutoff && !c.pinnedAt)
 		.primaryKeys();
 
 	let deletedMessages = 0;

--- a/packages/ui/lib/schema/flow/copilot.ts
+++ b/packages/ui/lib/schema/flow/copilot.ts
@@ -1,3 +1,5 @@
+import type { ILayerCache } from "./board";
+
 /// Agent types for the multi-agent system
 export type AgentType = "Explain" | "Edit";
 
@@ -56,7 +58,6 @@ export interface PlaceholderPinDef {
 	enforce_schema?: boolean;
 }
 
-/// Commands that can be executed on the board
 export type BoardCommand =
 	| {
 			command_type: "AddNode";
@@ -191,9 +192,18 @@ export type BoardCommand =
 			color?: string;
 			node_ids?: string[];
 			pins?: PlaceholderPinDef[];
+			/** Result-cache settings for a Function layer. */
+			cache?: ILayerCache | null;
 			position?: { x: number; y: number };
 			/** Parent layer ID for nesting. If undefined, creates at current layer. */
 			target_layer?: string;
+			summary?: string;
+	  }
+	| {
+			command_type: "UpdateLayerCache";
+			layer_id: string;
+			/** New cache settings, or explicit null to remove caching. */
+			cache: ILayerCache | null;
 			summary?: string;
 	  }
 	| {

--- a/packages/ui/state/global-chat/global-chat-db.ts
+++ b/packages/ui/state/global-chat/global-chat-db.ts
@@ -15,6 +15,12 @@ export interface IGlobalChatSession extends ISession {
 	boardId?: string;
 	/** Conversation scope: platform-wide ("global"), board copilot ("board"), or UI builder ("ui"). */
 	mode?: "global" | "board" | "ui";
+	/**
+	 * Epoch millis the user pinned this conversation; absent means unpinned. A timestamp rather
+	 * than a boolean because booleans are not valid IndexedDB keys — `pinned` would index nothing —
+	 * and it gives pinned rows a stable order for free.
+	 */
+	pinnedAt?: number;
 }
 
 /**
@@ -34,6 +40,11 @@ globalChatDb.version(1).stores({
 
 globalChatDb.version(2).stores({
 	sessions: "id, updatedAt, boardId, mode",
+	messages: "id, sessionId, timestamp",
+});
+
+globalChatDb.version(3).stores({
+	sessions: "id, updatedAt, boardId, mode, pinnedAt",
 	messages: "id, sessionId, timestamp",
 });
 

--- a/packages/ui/state/global-chat/global-chat-store.test.ts
+++ b/packages/ui/state/global-chat/global-chat-store.test.ts
@@ -79,6 +79,7 @@ describe("global chat overlay dismissal", () => {
 			selection,
 			label: runId,
 			message: null,
+			sourceAttachments: [],
 		});
 	};
 

--- a/packages/ui/state/global-chat/global-chat-store.ts
+++ b/packages/ui/state/global-chat/global-chat-store.ts
@@ -201,6 +201,8 @@ export interface GlobalChatRun {
 	startedAt: number;
 	/** First line of the prompt that started the turn — labels its stop/steer controls. */
 	label: string;
+	/** Files attached to the owning user turn, snapshotted before concurrent runs can advance chat. */
+	sourceAttachments: IAttachment[];
 	selection: GlobalChatTurnSelection;
 	/** The assistant reply being streamed into. Its id always equals `runId`. */
 	message: IMessage | null;
@@ -381,7 +383,12 @@ interface GlobalChatState {
 	startRun: (
 		run: Pick<
 			GlobalChatRun,
-			"runId" | "conversationId" | "selection" | "label" | "message"
+			| "runId"
+			| "conversationId"
+			| "selection"
+			| "label"
+			| "message"
+			| "sourceAttachments"
 		>,
 	) => void;
 	/** Replace a run's streaming bubble. No-op once the run has ended, so a late chunk from a
@@ -653,7 +660,14 @@ export const useGlobalChatStore = create<GlobalChatState>((set, get) => ({
 			messages[index] = message;
 			return { messages };
 		}),
-	startRun: ({ runId, conversationId, selection, label, message }) =>
+	startRun: ({
+		runId,
+		conversationId,
+		selection,
+		label,
+		message,
+		sourceAttachments,
+	}) =>
 		set((state) => {
 			const existing = state.runs[runId];
 			if (existing) {
@@ -671,6 +685,7 @@ export const useGlobalChatStore = create<GlobalChatState>((set, get) => ({
 						conversationId,
 						selection,
 						label,
+						sourceAttachments,
 						message,
 						status: "streaming",
 						startedAt: Date.now(),

--- a/packages/ui/state/global-chat/global-chat-stream.ts
+++ b/packages/ui/state/global-chat/global-chat-stream.ts
@@ -200,7 +200,18 @@ export function makeGlobalChatMessage(
 	};
 }
 
+/**
+ * Conversations deleted in this session.
+ *
+ * Cancelling a run only *requests* teardown — the backend call returns on delivery, and the run's
+ * own `finally` still commits its partial reply afterwards. Without this guard that write lands
+ * under the sessionId that was just deleted, leaving message rows no session owns and nothing ever
+ * collects (globalChatDb is not pruned). Ids are cuid2 and never reused, so membership is final.
+ */
+const deletedConversations = new Set<string>();
+
 export async function persistGlobalChatMessage(message: IMessage) {
+	if (deletedConversations.has(message.sessionId)) return;
 	try {
 		if (FLOWPILOT_DEBUG_ENABLED) {
 			await globalChatDb.messages.put(message);
@@ -219,12 +230,17 @@ export async function persistGlobalChatSession(
 	sessionId: string,
 	title: string,
 ) {
+	if (deletedConversations.has(sessionId)) return;
 	try {
 		const existing = await globalChatDb.sessions.get(sessionId);
 		const now = Date.now();
+		// Spread the existing row: this is a whole-row put, so anything not restated here would be
+		// erased on the user's next send — `pinnedAt`, `boardId` and `mode` all live only on the row.
 		await globalChatDb.sessions.put({
+			...existing,
 			id: sessionId,
 			appId: GLOBAL_CHAT_APP_ID,
+			// Sticky: the first title wins, so a user rename survives every later send.
 			summarization: existing?.summarization || title.slice(0, 80),
 			createdAt: existing?.createdAt ?? now,
 			updatedAt: now,
@@ -232,6 +248,71 @@ export async function persistGlobalChatSession(
 	} catch {
 		// history persistence is best-effort in v1
 	}
+}
+
+/**
+ * Pin/unpin a conversation. Deliberately a partial `update` that leaves `updatedAt` alone —
+ * touching it would yank the conversation into the "Today" group just for being pinned.
+ */
+export async function setGlobalChatSessionPinned(
+	sessionId: string,
+	pinned: boolean,
+) {
+	try {
+		await globalChatDb.sessions.update(sessionId, {
+			pinnedAt: pinned ? Date.now() : undefined,
+		});
+	} catch {
+		// history mutation is best-effort
+	}
+}
+
+/** Rename a conversation. Empty titles are ignored rather than blanking the row. */
+export async function renameGlobalChatSession(
+	sessionId: string,
+	title: string,
+) {
+	const next = title.trim().slice(0, 80);
+	if (!next) return;
+	try {
+		await globalChatDb.sessions.update(sessionId, { summarization: next });
+	} catch {
+		// history mutation is best-effort
+	}
+}
+
+/**
+ * Delete a conversation and its messages. Starts a fresh conversation when the deleted one was
+ * active, so the surface is never left pointing at a session row that no longer exists.
+ *
+ * Live runs are cancelled first. Runs deliberately survive a conversation switch and keep
+ * checkpointing into IndexedDB under their own conversation id, so deleting the rows out from
+ * under one would let it re-create the session moments later — the conversation would visibly
+ * come back from the dead.
+ */
+export async function deleteGlobalChatConversation(sessionId: string) {
+	// Tombstone first: cancellation is not synchronous, so this is what actually stops a run's
+	// in-flight checkpoint or its closing write from re-creating rows behind the delete.
+	deletedConversations.add(sessionId);
+
+	const state = useGlobalChatStore.getState();
+	const liveRunIds = Object.values(state.runs)
+		.filter((run) => run.conversationId === sessionId)
+		.map((run) => run.runId);
+	await Promise.allSettled(
+		liveRunIds.map((runId) => cancelGlobalChatRun(runId)),
+	);
+
+	try {
+		await globalChatDb.messages.where("sessionId").equals(sessionId).delete();
+		await globalChatDb.sessions.delete(sessionId);
+	} catch {
+		// history mutation is best-effort
+	}
+
+	// Re-read: cancelling a run mutates the store, so the pre-cancel snapshot is stale here.
+	const current = useGlobalChatStore.getState();
+	if (current.activeConversationId === sessionId) current.newConversation();
 }
 
 interface DriveOptions {
@@ -245,6 +326,8 @@ interface DriveOptions {
 	isResume?: boolean;
 	/** Bounded/redacted user input metadata included in the persisted debug report. */
 	inputPreview?: unknown;
+	/** Exact files from the owning user turn, captured before concurrent turns can change history. */
+	sourceAttachments?: IMessage["files"];
 	/**
 	 * Transport hook. Drives the underlying run and forwards every raw FlowPilot stream chunk to
 	 * `onChunk`; resolves with the transport's result (the desktop Tauri command's return value or,
@@ -283,6 +366,7 @@ export async function driveGlobalChatStream({
 	label,
 	isResume,
 	inputPreview,
+	sourceAttachments,
 	start,
 }: DriveOptions) {
 	const store = useGlobalChatStore;
@@ -291,6 +375,22 @@ export async function driveGlobalChatStream({
 	let lastCheckpoint = 0;
 	let streamFailure: string | undefined;
 	const turnSelection = beginGlobalChatTurnSelection(runId, agentSelection);
+	const owningAttachments =
+		sourceAttachments ??
+		(() => {
+			const messages = store.getState().messages;
+			for (let index = messages.length - 1; index >= 0; index -= 1) {
+				const candidate = messages[index];
+				if (
+					candidate.sessionId === responseMessage.sessionId &&
+					candidate.inner.role === IRole.User &&
+					candidate.timestamp <= responseMessage.timestamp
+				) {
+					return [...(candidate.files ?? [])];
+				}
+			}
+			return [];
+		})();
 	// Register the run BEFORE anything streams: every per-run store write (sub-agent buffers, debug
 	// events, the bubble itself) is addressed by run id and is a no-op until the record exists.
 	store.getState().startRun({
@@ -299,6 +399,7 @@ export async function driveGlobalChatStream({
 		selection: turnSelection,
 		label: label?.trim() || "Assistant turn",
 		message: { ...responseMessage },
+		sourceAttachments: owningAttachments,
 	});
 	// Desktop control is derivable from the run id alone. The web transport replaces this with an
 	// SSE-addressed control once the server hands back its own run id.


### PR DESCRIPTION
This pull request introduces significant changes to how FlowPilot orchestrates global research and public web tool access, with a focus on security, schema loading, and improved agent behavior. The main updates include deferring the loading of tool schemas for global orchestrator surfaces, restricting direct access to raw public web tools, and improving test coverage for these behaviors. Additionally, support for function `@cache` decorators is documented.

**Global Orchestrator and Tool Access**

* The global orchestrator surface now only advertises the sealed `research_agent` tool, removing direct access to `internet_search`, `open_url`, and `archive_lookup` from the global toolset. This ensures that public web access can only occur through a controlled, auditable path. [[1]](diffhunk://#diff-dc227f0bce411fc0234743ebeba5aac70f9590640ce50726ea811d696669244dL15826-R15847) [[2]](diffhunk://#diff-dc227f0bce411fc0234743ebeba5aac70f9590640ce50726ea811d696669244dL25434-R25470)
* The orchestrator's instructions and tests have been updated to reflect its new role and the correct toolset, emphasizing strict boundaries between board logic, UI, and data. [[1]](diffhunk://#diff-dc227f0bce411fc0234743ebeba5aac70f9590640ce50726ea811d696669244dR12614-R12618) [[2]](diffhunk://#diff-dc227f0bce411fc0234743ebeba5aac70f9590640ce50726ea811d696669244dR25626-R25637)

**Tool Schema Loading and Environment Management**

* For global orchestrator invocations (those including `list_apps`, `flowpilot_board`, and `research_agent`), tool schema loading is now deferred to Claude's native ToolSearch, rather than eagerly preloading all schemas. This is enforced by omitting the `ENABLE_TOOL_SEARCH` environment variable and explicitly removing any ambient overrides. [[1]](diffhunk://#diff-dc227f0bce411fc0234743ebeba5aac70f9590640ce50726ea811d696669244dL21-R21) [[2]](diffhunk://#diff-dc227f0bce411fc0234743ebeba5aac70f9590640ce50726ea811d696669244dL13328-R13353) [[3]](diffhunk://#diff-dc227f0bce411fc0234743ebeba5aac70f9590640ce50726ea811d696669244dR13436-R13452) [[4]](diffhunk://#diff-dc227f0bce411fc0234743ebeba5aac70f9590640ce50726ea811d696669244dL13434-R13471) [[5]](diffhunk://#diff-dc227f0bce411fc0234743ebeba5aac70f9590640ce50726ea811d696669244dR13942-R13944) [[6]](diffhunk://#diff-dc227f0bce411fc0234743ebeba5aac70f9590640ce50726ea811d696669244dR26079-R26123)

**Frontend Tool and Public Web Phase Management**

* All frontend tools now explicitly close the parent session's public web phase before dispatching, ensuring that no raw web access can occur after private local work has started. This is enforced both in code and by a new test. [[1]](diffhunk://#diff-324513bbc9116b9cfb94e04ff94471a095aca6787abc4749f94442191c3e86a2R767-R770) [[2]](diffhunk://#diff-324513bbc9116b9cfb94e04ff94471a095aca6787abc4749f94442191c3e86a2R853-R869) [[3]](diffhunk://#diff-324513bbc9116b9cfb94e04ff94471a095aca6787abc4749f94442191c3e86a2L923-R937) [[4]](diffhunk://#diff-324513bbc9116b9cfb94e04ff94471a095aca6787abc4749f94442191c3e86a2R4899-R4915)

**Prompt and Documentation Updates**

* The research system prompt now includes the current UTC date for improved context.
* The changelog documents new support for function `@cache` decorators, including default and permanent caching behavior. [[1]](diffhunk://#diff-324513bbc9116b9cfb94e04ff94471a095aca6787abc4749f94442191c3e86a2R2877-R2882) [[2]](diffhunk://#diff-315a395eb90ea9b714edc9ec184538414166f359d9b2958e12ccae3fd6061376R10-R11)

These changes collectively improve FlowPilot's security posture, agent orchestration clarity, and developer experience.